### PR TITLE
WCMSRD-12236 fixing issue where changing chart type removes the "hori…

### DIFF
--- a/packages/editor/src/components/ChooseTab.js
+++ b/packages/editor/src/components/ChooseTab.js
@@ -48,6 +48,7 @@ export default function ChooseTab() {
                 data: [...config.data],
                 dataFileName: config.dataFileName,
                 dataFileSourceType: config.dataFileSourceType,
+                dataDescription: config.dataDescription,
                 newViz: true,
                 type
             }


### PR DESCRIPTION
…zontal" or "vertical" state attributes.

Added the dataDescription to the list of default fields when you changes from one chart type to another.