### PR TITLE
WCMSRD-12272 Applying a bottom margin to columns in small viewport.

### DIFF
--- a/packages/dashboard/src/scss/main.scss
+++ b/packages/dashboard/src/scss/main.scss
@@ -144,6 +144,7 @@
   .dashboard-col-12 {
     width: 100%;
   }
+
   @include breakpointClass(md) {
     .dashboard-row {
       flex-direction: row;
@@ -161,6 +162,12 @@
   
     .dashboard-col-4 {
       width: 33%;
+    }
+  }
+
+  @include breakpointClass(sm) {
+    .dashboard-col {
+      margin-bottom: 25px;
     }
   }
 


### PR DESCRIPTION
@danielimmke In the "small" viewport, the flexed rows and columns do not have any bottom margin. I've applied a 25px bottom margin to the columns. I know there's more than one way to do this, so feel free to adjust if you want. 