### PR TITLE
WCMSRD-12282 seriesKey not being set back to the field when changing …

### DIFF
--- a/packages/editor/src/components/ChooseTab.js
+++ b/packages/editor/src/components/ChooseTab.js
@@ -42,7 +42,6 @@ export default function ChooseTab() {
         let classNames = (config.type === type && isSubType) ? 'active' : ''
 
         let setTypes = () => {
-
             // Only take the data/data source properties from existing config. Covers case of selecting a new visualization.
             let newConfig = {
                 data: [...config.data],

--- a/packages/editor/src/components/ChooseTab.js
+++ b/packages/editor/src/components/ChooseTab.js
@@ -42,6 +42,7 @@ export default function ChooseTab() {
         let classNames = (config.type === type && isSubType) ? 'active' : ''
 
         let setTypes = () => {
+            
             // Only take the data/data source properties from existing config. Covers case of selecting a new visualization.
             let newConfig = {
                 data: [...config.data],

--- a/packages/editor/src/components/ChooseTab.js
+++ b/packages/editor/src/components/ChooseTab.js
@@ -42,7 +42,6 @@ export default function ChooseTab() {
         let classNames = (config.type === type && isSubType) ? 'active' : ''
 
         let setTypes = () => {
-            
             // Only take the data/data source properties from existing config. Covers case of selecting a new visualization.
             let newConfig = {
                 data: [...config.data],

--- a/packages/editor/src/components/DataImport.js
+++ b/packages/editor/src/components/DataImport.js
@@ -441,7 +441,7 @@ export default function DataImport() {
                     {config.dataDescription.horizontal === true && config.dataDescription.series === true && (
                       <div className="question">
                         <div className="heading-4 data-question">Which property in the dataset represents which series the row is describing?</div>
-                        <select onChange={(e) => {updateDescriptionProp('seriesKey', e.target.value)}}>
+                        <select onChange={(e) => { updateDescriptionProp('seriesKey', e.target.value) }} value={config.dataDescription.seriesKey}>
                             <option value="">Choose an option</option>
                             {Object.keys(config.data[0]).map(key => <option value={key}>{key}</option>)}
                         </select>


### PR DESCRIPTION
…tabs. Here are the instructions Bill provided for how to reproduce:

- New viz
- Import that Fig1.4 dataset
- Choose Horizontal, Yes (multiple data series), "Ages" as the property
- Choose Charts
- Configure a chart. Notice that the Data Series options are the years (2004-2019) and Ages
- Go back to the Data Import tab
- Notice you need to reselect "Ages" as the last field 
- Go back to the configuration tab (just click on the config tab after selecting "Ages"), notice that the data series now is different values

So the data definition tab has defined the data two different ways using the same choices.