### PR TITLE
Map > Fix legend circle color width and height

### DIFF
--- a/packages/map/src/scss/main.scss
+++ b/packages/map/src/scss/main.scss
@@ -170,6 +170,10 @@
     display: inline-block;
     height: 1em;
     width: 1em;
+    min-width: 1em;
+    min-height: 1em;
+    max-width: 1em;
+    max-height: 1em;
     border: rgba(0,0,0,.3) 1px solid;
   }
 


### PR DESCRIPTION
Makes legend circles on maps exactly 1em instead of stretching into ovals.