### PR TITLE
[wcmsrd-14492b] Add Reset in Waffle Chart Editor

### DIFF
--- a/packages/core/styles/v2/components/editor.scss
+++ b/packages/core/styles/v2/components/editor.scss
@@ -2,6 +2,8 @@
 @import "../themes/index";
 
 .cove-editor {
+
+  @import "./../base/reset";
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-areas: "panel content";


### PR DESCRIPTION
 - We moved the reset out to avoid style bleeds, but it looks like other issues moved into the editor. Adding this back temporarily just for the editor.