### PR TITLE
[DEV-2128] Divide config height in a vertical & horizontal 

### DIFF
--- a/packages/chart/src/components/BarChart.tsx
+++ b/packages/chart/src/components/BarChart.tsx
@@ -66,7 +66,7 @@ export default function BarChart({ xScale, yScale, seriesScale, xMax, yMax, getX
     let totalHeight = barsArr.length * (barHeight + labelHeight + barSpace)
 
     if (isHorizontal) {
-      config.height = totalHeight
+      config.heights.horizontal = totalHeight
     }
 
     // return new updated bars/groupes
@@ -366,8 +366,8 @@ export default function BarChart({ xScale, yScale, seriesScale, xMax, yMax, getX
                             <foreignObject
                               id={`barGroup${barGroup.index}`}
                               key={`bar-group-bar-${barGroup.index}-${bar.index}-${bar.value}-${bar.key}`}
-                              x={config.runtime.horizontal ? 0 : (barWidth * bar.index) + offset}
-                              y={config.runtime.horizontal ? (barWidth * bar.index) : barY}
+                              x={config.runtime.horizontal ? 0 : barWidth * bar.index + offset}
+                              y={config.runtime.horizontal ? barWidth * bar.index : barY}
                               width={config.runtime.horizontal ? bar.y : barWidth}
                               height={isHorizontal && !config.isLollipopChart ? barWidth : isHorizontal && config.isLollipopChart ? lollipopBarWidth : barHeight}
                               style={{

--- a/packages/chart/src/components/EditorPanel.js
+++ b/packages/chart/src/components/EditorPanel.js
@@ -792,7 +792,7 @@ const EditorPanel = () => {
                     }
                   />
 
-                  {config.visualizationSubType !== 'horizontal' && <TextField type='number' value={config.height} fieldName='height' label='Chart Height' updateField={updateField} />}
+                  {config.orientation === 'vertical' && <TextField type='number' value={config.heights.vertical} section='heights' fieldName='vertical' label='Chart Height' updateField={updateField} />}
                 </AccordionItemPanel>
               </AccordionItem>
 
@@ -1580,7 +1580,7 @@ const EditorPanel = () => {
 
                   {config.series?.some(series => series.type === 'Bar' || series.type === 'Paired Bar') && <Select value={config.barHasBorder} fieldName='barHasBorder' label='Bar Borders' updateField={updateField} options={['true', 'false']} />}
 
-                  <CheckBox value={config.animate} fieldName="animate" label="Animate Visualization" updateField={updateField} />
+                  <CheckBox value={config.animate} fieldName='animate' label='Animate Visualization' updateField={updateField} />
 
                   {/*<CheckBox value={config.animateReplay} fieldName="animateReplay" label="Replay Animation When Filters Are Changed" updateField={updateField} />*/}
 

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -502,7 +502,7 @@ export default function LinearChart() {
                       {!config.runtime.yAxis.hideAxis && <Line from={props.axisFromPoint} to={props.axisToPoint} stroke='#333' />}
                     </Group>
                     <Group>
-                      <Text transform={`translate(${xMax / 2}, ${yMax + 20}) rotate(-${0})`} verticalAnchor='start' textAnchor={'middle'} stroke='red'>
+                      <Text transform={`translate(${xMax / 2}, ${yMax + 20}) rotate(-${0})`} verticalAnchor='start' textAnchor={'middle'} stroke='#333'>
                         {config.runtime.xAxis.label}
                       </Text>
                     </Group>

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -6,7 +6,6 @@ import { Line } from '@visx/shape'
 import { Text } from '@visx/text'
 import { scaleLinear, scalePoint, scaleBand } from '@visx/scale'
 import { AxisLeft, AxisBottom, AxisRight, AxisTop } from '@visx/axis'
-import * as d3 from 'd3-array'
 
 import BarChart from './BarChart'
 import LineChart from './LineChart'
@@ -16,7 +15,6 @@ import useIntersectionObserver from './useIntersectionObserver'
 import CoveBoxPlot from './BoxPlot'
 
 import ErrorBoundary from '@cdc/core/components/ErrorBoundary'
-import numberFromString from '@cdc/core/helpers/numberFromString'
 import '../scss/LinearChart.scss'
 import useReduceData from '../hooks/useReduceData'
 import useRightAxis from '../hooks/useRightAxis'
@@ -28,7 +26,6 @@ export default function LinearChart() {
   let [width] = dimensions
   const { minValue, maxValue, existPositiveValue, isAllLine } = useReduceData(config, data)
   const [animatedChart, setAnimatedChart] = useState<boolean>(false)
-  const [animatedChartPlayed, setAnimatedChartPlayed] = useState<boolean>(false)
 
   const triggerRef = useRef()
   const dataRef = useIntersectionObserver(triggerRef, {
@@ -55,10 +52,10 @@ export default function LinearChart() {
   if (config && config.legend && !config.legend.hide && config.legend.position !== 'bottom' && (currentViewport === 'lg' || currentViewport === 'md')) {
     width = width * 0.73
   }
-
-  const height = config.aspectRatio ? width * config.aspectRatio : config.height
+  const { horizontal: heightHorizontal } = config.heights
+  const height = config.aspectRatio ? width * config.aspectRatio : config.heights[config.orientation]
   const xMax = width - config.runtime.yAxis.size - config.yAxis.rightAxisSize
-  const yMax = height - config.runtime.xAxis.size
+  const yMax = height - (config.orientation === 'horizontal' ? 0 : config.runtime.xAxis.size)
 
   const { yScaleRight, hasRightAxis } = useRightAxis({ config, yMax, data, updateConfig })
   const { hasTopAxis } = useTopAxis(config)
@@ -142,7 +139,7 @@ export default function LinearChart() {
         range: [0, yMax]
       })
 
-      yScale.rangeRound([0, height])
+      yScale.rangeRound([0, yMax])
     } else {
       min = min < 0 ? min * 1.11 : min
 
@@ -347,7 +344,7 @@ export default function LinearChart() {
                       </Group>
                     )
                   })}
-                  {!config.yAxis.hideAxis && <Line from={props.axisFromPoint} to={config.runtime.horizontal ? { x: 0, y: Number(config.height) } : props.axisToPoint} stroke='#000' />}
+                  {!config.yAxis.hideAxis && <Line from={props.axisFromPoint} to={config.runtime.horizontal ? { x: 0, y: Number(heightHorizontal) } : props.axisToPoint} stroke='#000' />}
                   {yScale.domain()[0] < 0 && <Line from={{ x: props.axisFromPoint.x, y: yScale(0) }} to={{ x: xMax, y: yScale(0) }} stroke='#333' />}
                   <Text className='y-label' textAnchor='middle' verticalAnchor='start' transform={`translate(${-1 * config.runtime.yAxis.size}, ${axisCenter}) rotate(-90)`} fontWeight='bold' fill={config.yAxis.labelColor}>
                     {props.label}
@@ -407,7 +404,7 @@ export default function LinearChart() {
         {/* X axis */}
         {config.visualizationType !== 'Paired Bar' && config.visualizationType !== 'Spark Line' && (
           <AxisBottom
-            top={config.runtime.horizontal ? Number(config.height) : yMax}
+            top={yMax}
             left={Number(config.runtime.yAxis.size)}
             label={config.runtime.xAxis.label}
             tickFormat={tick => (config.runtime.xAxis.type === 'date' ? formatDate(tick) : config.orientation === 'horizontal' ? formatNumber(tick) : tick)}
@@ -505,7 +502,7 @@ export default function LinearChart() {
                       {!config.runtime.yAxis.hideAxis && <Line from={props.axisFromPoint} to={props.axisToPoint} stroke='#333' />}
                     </Group>
                     <Group>
-                      <Text transform={`translate(${xMax / 2}, ${config.height - yMax + 20}) rotate(-${0})`} verticalAnchor='start' textAnchor={'middle'} stroke='#333'>
+                      <Text transform={`translate(${xMax / 2}, ${yMax + 20}) rotate(-${0})`} verticalAnchor='start' textAnchor={'middle'} stroke='red'>
                         {config.runtime.xAxis.label}
                       </Text>
                     </Group>

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -44,8 +44,11 @@ export default {
   },
   barThickness: 0.35,
   barHeight: 25,
-  barSpace:20,
-  height: 300,
+  barSpace: 20,
+  heights: {
+    vertical: 300,
+    horizontal: 750
+  },
   xAxis: {
     type: 'categorical',
     hideAxis: false,


### PR DESCRIPTION
## Briefly describe your changes
Divided chart height into two parts. Vertical charts can be manually updated by user.Horizontal charts is gets updated dynamically based on bar height, bar space etc..
Fixed: When switching from horizontal charts to vertical, the vertical chart used to inherit the size(height) from horizontal.
now it doesn't inherit. each chart has own height.
## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [ ] Standalone Full Editor
- [ ] CDC Internal Checks
