### PR TITLE
[DEV-2759a] Add barSpace while labels are below bar

### DIFF
--- a/packages/chart/src/components/BarChart.tsx
+++ b/packages/chart/src/components/BarChart.tsx
@@ -64,12 +64,9 @@ export default function BarChart({ xScale, yScale, seriesScale, xMax, yMax, getX
       barHeight = heights.stacked
     }
 
-    const labelHeight = isLabelBelowBar ? fontSize[config.fontSize || 'medium'] : 0
-    let barSpace = isLabelBelowBar ? barHeight / 2 : Number(config.barSpace)
+    const labelHeight = isLabelBelowBar ? fontSize[config.fontSize] * 1.2 : 0
+    let barSpace = Number(config.barSpace)
 
-    if (config.isLollipopChart && isLabelBelowBar && !isStacked) {
-      barSpace = 20 // 20 is hard coded space.
-    }
     // calculate height of container based height, space and fontSize of labels
     let totalHeight = barsArr.length * (barHeight + labelHeight + barSpace)
 

--- a/packages/chart/src/components/EditorPanel.js
+++ b/packages/chart/src/components/EditorPanel.js
@@ -1684,7 +1684,7 @@ const EditorPanel = () => {
                   )}
                   {config.orientation === 'horizontal' && !config.isLollipopChart && config.yAxis.labelPlacement !== 'On Bar' && <TextField type='number' value={config.barHeight || '25'} fieldName='barHeight' label=' Bar Thickness' updateField={updateField} min='15' />}
                   {((config.visualizationType === 'Bar' && config.orientation !== 'horizontal') || config.visualizationType === 'Combo') && <TextField value={config.barThickness} type='number' fieldName='barThickness' label='Bar Thickness' updateField={updateField} />}
-                  {config.orientation === 'horizontal' && config.yAxis.labelPlacement === 'On Date/Category Axis' && <TextField type='number' value={config.barSpace || '20'} fieldName='barSpace' label='Bar Space' updateField={updateField} min='0' />}
+                  {config.orientation === 'horizontal' && <TextField type='number' value={config.barSpace || '20'} fieldName='barSpace' label='Bar Space' updateField={updateField} min='0' />}
                   {(config.visualizationType === 'Bar' || config.visualizationType === 'Line' || config.visualizationType === 'Combo') && <CheckBox value={config.topAxis.hasLine} section='topAxis' fieldName='hasLine' label='Add Top Axis Line' updateField={updateField} />}
 
                   {config.visualizationType === 'Spark Line' && (

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -45,7 +45,7 @@ export default {
   isLegendValue: false,
   barThickness: 0.35,
   barHeight: 25,
-  barSpace: 20,
+  barSpace: 15,
   heights: {
     vertical: 300,
     horizontal: 750


### PR DESCRIPTION
## Briefly describe your changes
Added "Bar Space" feature which is on "Visual panel" to bars when labels are below bar.Previously it was only when labels are outside of bar.Bar space adds margin to each bar to increase or decrease space between bars.Works only in Horizontal (regular,stacked,lollipop) bars.

## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [x] Standalone Full Editor
- [ ] CDC Internal Checks
