### PR TITLE
Update tooltips to 5.8 release

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -46,7 +46,7 @@
     "react-accessible-accordion": "^3.3.4",
     "react-spring": "^8.0.27",
     "react-table": "^7.5.0",
-    "react-tooltip": "5.8.0-beta.0",
+    "react-tooltip": "5.8",
     "use-debounce": "^6.0.1",
     "whatwg-fetch": "^3.6.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "prop-types": "^15.8.1",
     "react-accessible-accordion": "^5.0.0",
     "react-select": "^5.3.1",
-    "react-tooltip": "5.8.0-beta.0",
+    "react-tooltip": "5.8",
     "use-debounce": "^6.0.1"
   },
   "peerDependencies": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -37,7 +37,7 @@
     "react-dnd": "^14.0.2",
     "react-dnd-html5-backend": "^14.0.0",
     "react-table": "^7.5.0",
-    "react-tooltip": "5.8.0-beta.0",
+    "react-tooltip": "5.8",
     "use-debounce": "^6.0.1",
     "whatwg-fetch": "^3.6.2"
   },

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -40,7 +40,7 @@
     "react-accessible-accordion": "^3.0.1",
     "react-table": "^7.5.0",
     "react-tag-autocomplete": "^6.0.0",
-    "react-tooltip": "5.8.0-beta.0",
+    "react-tooltip": "5.8",
     "topojson-client": "^3.1.0",
     "use-debounce": "^5.2.0",
     "whatwg-fetch": "^3.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8242,10 +8242,10 @@ react-tag-autocomplete@^6.0.0:
   resolved "https://registry.yarnpkg.com/react-tag-autocomplete/-/react-tag-autocomplete-6.3.0.tgz#ce064bbab77b4daf7706be1c08413e7d0335ff4d"
   integrity sha512-MUBVUFh5eOqshUm5NM20qp7zXk8TzSiKO4GoktlFzBLIOLs356npaMKtL02bm0nFV2f1zInUrXn1fq6+i5YX0w==
 
-react-tooltip@5.8.0-beta.0:
-  version "5.8.0-beta.0"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.8.0-beta.0.tgz#5fda61befa088818621e0cd83c4ff6f9aa92b470"
-  integrity sha512-sBZFK+mPpSpt5HRHS41Kv4NxxgQjR/mAte1PGWz6x52855bqVgX0q8UgyjjibRgYFS177MkLjUo8SPOZfABeWA==
+react-tooltip@5.8:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.8.1.tgz#2b1ea9f5cb24578964a5c0a7ce9b183f5cb7dfd9"
+  integrity sha512-q30ARh/WwtcwNiZpzfYWFUmgZl6acRas/n7uhK6pXDiIWG6Xcklic0WFzHQLlvIGNeYbCY//h/RFdyBemfhZyQ==
   dependencies:
     "@floating-ui/dom" "1.1.1"
     classnames "^2.3.2"


### PR DESCRIPTION
Update dependencies for non-beta `react-tooltip` release