### PR TITLE
[hide-vertical] Hide vertical option in Deviaton bar

### DIFF
--- a/packages/chart/index.html
+++ b/packages/chart/index.html
@@ -42,7 +42,7 @@
   
    <!-- EDGE CASES -->
   <!-- <div class="react-container" data-config="/examples/big-small-test-line.json"></div>  -->
-  <div class="react-container" data-config="/examples/big-small-test-bar.json"></div> 
+  <!-- <div class="react-container" data-config="/examples/big-small-test-bar.json"></div>  -->
   <!-- <div class="react-container" data-config="/examples/big-small-test-negative.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/line-chart-max-increase.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/horizontal-chart-max-increase.json"></div> -->
@@ -63,14 +63,14 @@
   <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-horizontal/horizontal-stacked.json"></div> -->
 
   <!-- VERTICAL BAR CHARTS -->
-   <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/combo-line-chart.json"></div> -->
+   <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/combo-line-chart.json"></div>
   <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-categorical.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-stacked.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/stacked-vertical-bar-example-nonnumerics.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-confidence.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-confidence.json"></div>  -->
 
-  <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart.json"></div>
+  <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart.json"></div> -->
 
   <!-- <div class="react-container" data-config="/examples/area-chart.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/scatterplot.json"></div> -->

--- a/packages/chart/src/components/EditorPanel.jsx
+++ b/packages/chart/src/components/EditorPanel.jsx
@@ -597,6 +597,13 @@ const EditorPanel = () => {
     }
   }, [config.isLollipopChart, config.lollipopShape]) // eslint-disable-line
 
+  /// temporary force orientation untill we support Vartical deviaton bar
+  useEffect(() => {
+    if (config.visualizationType === 'Deviation Bar') {
+      updateConfig({ ...config, orientation: 'horizontal' })
+    }
+  }, [config.visualizationType])
+
   const ExclusionsList = useCallback(() => {
     const exclusions = [...config.exclusions.keys]
     return (
@@ -793,7 +800,7 @@ const EditorPanel = () => {
                   <Select value={config.visualizationType} fieldName='visualizationType' label='Chart Type' updateField={updateField} options={enabledChartTypes} />
                   {(config.visualizationType === 'Bar' || config.visualizationType === 'Combo') && <Select value={config.visualizationSubType || 'Regular'} fieldName='visualizationSubType' label='Chart Subtype' updateField={updateField} options={['regular', 'stacked']} />}
                   {config.visualizationType === 'Bar' && <Select value={config.orientation || 'vertical'} fieldName='orientation' label='Orientation' updateField={updateField} options={['vertical', 'horizontal']} />}
-                  {config.visualizationType === 'Deviation Bar' && <Select value={config.orientation || 'horizontal'} fieldName='orientation' label='Orientation' updateField={updateField} options={['horizontal', 'vertical']} />}
+                  {config.visualizationType === 'Deviation Bar' && <Select label='Orientation' options={['horizontal']} />}
                   {(config.visualizationType === 'Bar' || config.visualizationType === 'Deviation Bar') && <Select value={config.isLollipopChart ? 'lollipop' : config.barStyle || 'flat'} fieldName='barStyle' label='bar style' updateField={updateField} options={showBarStyleOptions()} />}
                   {(config.visualizationType === 'Bar' || config.visualizationType === 'Deviation Bar') && config.barStyle === 'rounded' && <Select value={config.tipRounding || 'top'} fieldName='tipRounding' label='tip rounding' updateField={updateField} options={['top', 'full']} />}
                   {(config.visualizationType === 'Bar' || config.visualizationType === 'Deviation Bar') && config.barStyle === 'rounded' && (


### PR DESCRIPTION
## Briefly describe your changes
Robin and Bill asked to hide vertical option when it is Deviation bar. added use effect to force it to be horizontal when user switches to Deviation bar.
## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [x] Standalone Full Editor
- [] CDC Internal Checks
