### PR TITLE
Hotfix/mpox linearchart string num tickcount bug

### DIFF
--- a/packages/chart/src/components/LinearChart.jsx
+++ b/packages/chart/src/components/LinearChart.jsx
@@ -320,15 +320,15 @@ export default function LinearChart() {
       // to fix edge case of small numbers with decimals
       if (tickCount === undefined && !config.dataFormat.roundTo) {
         // then it is set to Auto
-        if (max <= 3) {
+        if (Number(max) <= 3) {
           tickCount = 2
         } else {
           tickCount = 4 // same default as standalone components
         }
       }
-      if (tickCount > max) {
+      if (Number(tickCount) > Number(max)) {
         // cap it and round it so its an integer
-        tickCount = min < 0 ? Math.round(max) * 2 : Math.round(max)
+        tickCount = Number(min) < 0 ? Math.round(max) * 2 : Math.round(max)
       }
     }
 


### PR DESCRIPTION
## Briefly describe your changes
Hot fix for tickCount issue rekated 3163 PR
There is an if statement comparing to numbers in variables but if they come in as "strings" javascript is not converting them and it leads to non-sensical results --- tickCount of 110000 creates a massive drawing of tickmarks

## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [ ] Standalone Full Editor
- [ ] CDC Internal Checks
