### PR TITLE
[dev-3305-update-state-edit] Fixed map init-state expand issue

### DIFF
--- a/packages/map/src/components/EditorPanel.jsx
+++ b/packages/map/src/components/EditorPanel.jsx
@@ -288,7 +288,7 @@ const EditorPanel = props => {
         setState({
           ...state,
           table: {
-            ...state.general,
+            ...state.table,
             expanded: value
           }
         })


### PR DESCRIPTION
## Briefly describe your changes
Fixed minor  issue with expandDataTable state update code.
And yes tested it in standone, editor and dashboard.

## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [x] Standalone Full Editor
- [ ] CDC Internal Checks
