### PR TITLE
[DEV-930-fix-iniitial-state] Fixed download link and initial state

### DIFF
--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -16,7 +16,7 @@ export default {
   roundingStyle: 'standard',
   tipRounding: 'top',
   general: {
-    showDownloadButton: true
+    showDownloadButton: false
   },
   padding: {
     left: 5,

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -117,7 +117,8 @@ export default {
     showDownloadUrl: false,
     showDataTableLink: true,
     indexLabel: '',
-    showVertical: false
+    download: false,
+    showVertical: true
   },
   orientation: 'vertical',
   color: 'pinkpurple',

--- a/packages/core/components/DataTable.jsx
+++ b/packages/core/components/DataTable.jsx
@@ -428,7 +428,7 @@ const DataTable = props => {
       <ErrorBoundary component='DataTable'>
         <CoveMediaControls.Section classes={['download-links']}>
           <CoveMediaControls.Link config={config} />
-          {config.table.download && <DownloadButton />}
+          {(config.table.download || config.general.showDownloadButton) && <DownloadButton />}
         </CoveMediaControls.Section>
         <section id={tabbingId.replace('#', '')} className={`data-table-container ${viewport}`} aria-label={accessibilityLabel}>
           <a id='skip-nav' className='cdcdataviz-sr-only-focusable' href={`#${skipId}`}>

--- a/packages/core/components/DataTable.jsx
+++ b/packages/core/components/DataTable.jsx
@@ -428,7 +428,7 @@ const DataTable = props => {
       <ErrorBoundary component='DataTable'>
         <CoveMediaControls.Section classes={['download-links']}>
           <CoveMediaControls.Link config={config} />
-          {config.general.showDownloadButton && <DownloadButton />}
+          {config.table.download && <DownloadButton />}
         </CoveMediaControls.Section>
         <section id={tabbingId.replace('#', '')} className={`data-table-container ${viewport}`} aria-label={accessibilityLabel}>
           <a id='skip-nav' className='cdcdataviz-sr-only-focusable' href={`#${skipId}`}>

--- a/packages/map/src/components/EditorPanel.jsx
+++ b/packages/map/src/components/EditorPanel.jsx
@@ -420,6 +420,11 @@ const EditorPanel = props => {
           general: {
             ...state.general,
             showDownloadButton: !state.general.showDownloadButton
+          },
+          table: {
+            // setting both bc DataTable new core needs it here
+            ...state.table,
+            download: !state.general.showDownloadButton
           }
         })
         break

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -5,7 +5,7 @@ export default {
     title: '',
     showTitle: true,
     showSidebar: true,
-    showDownloadButton: true,
+    showDownloadButton: false,
     showDownloadMediaButton: false,
     displayAsHex: false,
     displayStateLabels: false,
@@ -70,6 +70,7 @@ export default {
     showDownloadUrl: false,
     showDataTableLink: true,
     forceDisplay: true,
+    download: false,
     indexLabel: ''
   },
   tooltips: {


### PR DESCRIPTION
## Briefly describe your changes
Checkbox for Show Download CSV Link was not working right and also wrong initial state.  Fixed and tested on charts and maps (and in dashboard)
Also if Show Vertical was checked then it was always showing the Download CSV Link and ignoring the checkbox setting.
Both are fixed.

Set Show Vertical to be default TRUE so that the default for DataTable is now vertical. 

## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [x] Standalone Full Editor
- [ ] CDC Internal Checks
