### PR TITLE
DRAFT: [DEV-784-special-classes-last] Added back special classes last in legend

### DIFF
--- a/packages/map/src/CdcMap.jsx
+++ b/packages/map/src/CdcMap.jsx
@@ -501,9 +501,18 @@ const CdcMap = ({ className, config, navigationHandler: customNavigationHandler,
 
       legendMemo.current = newLegendMemo
 
+      // before returning the legend result
+      // add property for bin number and set to index location
       result.forEach((row, i) => {
         row.bin = i // set bin number to index
       })
+
+      // Move all special legend items from "Special Classes"  to the end of the legend
+      if (state.legend.showSpecialClassesLast) {
+        let specialRows = result.filter(d => d.special === true)
+        let otherRows = result.filter(d => !d.special)
+        result = [...otherRows, ...specialRows]
+      }
 
       return result
     }
@@ -959,11 +968,11 @@ const CdcMap = ({ className, config, navigationHandler: customNavigationHandler,
   }
 
   // this is passed DOWN into the various components
-  // then they do a lookup based on the bin number as index into here (TT)
+  // then they do a lookup based on the bin number as index into here
   const applyLegendToRow = rowObj => {
     try {
       if (!rowObj) throw new Error('COVE: No rowObj in applyLegendToRow')
-      // Navigation map
+      // Navigation mapchanged
       if ('navigation' === state.general.type) {
         let mapColorPalette = colorPalettes[state.color] || colorPalettes['bluegreenreverse']
         return generateColorsArray(mapColorPalette[3])
@@ -975,7 +984,7 @@ const CdcMap = ({ className, config, navigationHandler: customNavigationHandler,
         let idx = legendMemo.current.get(hash)
         if (runtimeLegend[idx]?.disabled) return false
 
-        // DEV-784 changed to use bin prop to get color instead of idx
+        // changed to use bin prop to get color instead of idx
         // bc we re-order legend when showSpecialClassesLast is checked
         let legendBinColor = runtimeLegend.find(o => o.bin === idx)?.color
         return generateColorsArray(legendBinColor, runtimeLegend[idx]?.special)

--- a/packages/map/src/components/EditorPanel.jsx
+++ b/packages/map/src/components/EditorPanel.jsx
@@ -2205,17 +2205,18 @@ const EditorPanel = props => {
                       </label>
                     )}
                     {/* always show */}
-                    {/*
-                    <label className='checkbox'>
-                      <input
-                        type='checkbox'
-                        checked={legend.showSpecialClassesLast}
-                        onChange={event => {
-                          handleEditorChanges('legendShowSpecialClassesLast', event.target.checked)
-                        }}
-                      />
-                      <span className='edit-label'>Show Special Classes Last</span>
-                    </label> */}
+                    {
+                      <label className='checkbox'>
+                        <input
+                          type='checkbox'
+                          checked={legend.showSpecialClassesLast}
+                          onChange={event => {
+                            handleEditorChanges('legendShowSpecialClassesLast', event.target.checked)
+                          }}
+                        />
+                        <span className='edit-label'>Show Special Classes Last</span>
+                      </label>
+                    }
                     {'category' !== legend.type && (
                       <label className='checkbox'>
                         <input type='checkbox' checked={legend.separateZero || false} onChange={event => handleEditorChanges('separateZero', event.target.checked)} />


### PR DESCRIPTION
## Briefly describe your changes
Restored code from March that allows you to click a checkbox and move the special classes in the map legend to last.
Got it working in editor and dashboards as well.

## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [x] Standalone Full Editor
- [ ] CDC Internal Checks
