### PR TITLE
[DEV-4207-make-hawaii-label-visible] Make Hawaii label always black s…

### DIFF
--- a/packages/map/src/components/UsaMap.jsx
+++ b/packages/map/src/components/UsaMap.jsx
@@ -188,12 +188,18 @@ const UsaMap = props => {
 
     // Dynamic text color
     if (chroma.contrast(textColor, bgColor) < 3.5) {
-      textColor = '#202020'
+      textColor = '#202020' // dark gray
+    }
+
+    // always make HI black since it is off to the side
+    if (abbr === 'US-HI') {
+      textColor = '#000'
     }
 
     let x = 0,
       y = 5
 
+    // used to nudge/move some of the labels for better readability
     if (nudges[abbr] && false === isHex) {
       x += nudges[abbr][0]
       y += nudges[abbr][1]


### PR DESCRIPTION
## Briefly describe your changes
If Hawaii in dark legend category then state label is set to white but then you cant see it bc it is nudged off to the left in the white area and not on top of the state geo.  This simple fix simply always sets the Hawaii state label to black.

## Checklist before requesting a review
- [ ] My pull request was branched from and targets the test branch
- [ ] I have performed a self-review of my code
- [ ] I have manually tested all packages affected (bonus points for automations)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [ ] Standalone Component
- [ ] Standalone Full Editor
- [ ] CDC Internal Checks
