### PR TITLE
[DEV-4343] hide items for 4.23.6

### DIFF
--- a/packages/chart/src/components/EditorPanel.jsx
+++ b/packages/chart/src/components/EditorPanel.jsx
@@ -831,7 +831,7 @@ const EditorPanel = () => {
     'Box Plot',
     'Combo',
     'Deviation Bar',
-    'Forecasting',
+    // 'Forecasting',
     'Line',
     'Paired Bar',
     'Pie',
@@ -1544,7 +1544,7 @@ const EditorPanel = () => {
                 )}
 
                 {/* start: anchors */}
-                {visHasAnchors() && config.orientation !== 'horizontal' ? (
+                {visHasAnchors() && config.orientation !== 'horizontal' && (
                   <div className='edit-block'>
                     <h3>Anchors</h3>
                     <Accordion allowZeroExpanded>
@@ -1668,7 +1668,9 @@ const EditorPanel = () => {
                       Add Anchor
                     </button>
                   </div>
-                ) : (
+                )}
+
+                {visHasAnchors() && config.orientation === 'horizontal' && (
                   <div className='edit-block'>
                     <h3>Anchors</h3>
                     <Accordion allowZeroExpanded>
@@ -2163,7 +2165,7 @@ const EditorPanel = () => {
                 )}
 
                 {/* anchors */}
-                {visHasAnchors() && config.orientation !== 'horizontal' ? (
+                {visHasAnchors() && config.orientation !== 'horizontal' && (
                   <div className='edit-block'>
                     <h3>Anchors</h3>
                     <Accordion allowZeroExpanded>
@@ -2287,7 +2289,9 @@ const EditorPanel = () => {
                       Add Anchor
                     </button>
                   </div>
-                ) : (
+                )}
+
+                {visHasAnchors() && config.orientation === 'horizontal' && (
                   <div className='edit-block'>
                     <h3>Anchors</h3>
                     <Accordion allowZeroExpanded>

--- a/packages/editor/src/components/ChooseTab.jsx
+++ b/packages/editor/src/components/ChooseTab.jsx
@@ -142,14 +142,14 @@ export default function ChooseTab() {
             <Tooltip.Content>Highlight a piece of data in relationship to a data set.</Tooltip.Content>
           </Tooltip>
         </li>
-        <li>
+        {/* <li>
           <Tooltip>
             <Tooltip.Target>
               <IconButton label='Gauge Chart' type='chart' subType='Gauge' icon={<GaugeChartIcon />} />
             </Tooltip.Target>
             <Tooltip.Content>Specify the calculation of a single data point (such as a percentage value) and present it on a horizontal scale.</Tooltip.Content>
           </Tooltip>
-        </li>
+        </li> */}
       </ul>
 
       <div className='heading-2'>Charts</div>
@@ -222,14 +222,14 @@ export default function ChooseTab() {
             <Tooltip.Content>Display an area chart</Tooltip.Content>
           </Tooltip>
         </li>
-        <li>
+        {/* <li>
           <Tooltip>
             <Tooltip.Target>
               <IconButton label='Forecast Chart' type='chart' subType='Forecasting' orientation='vertical' icon={<InfoIcon />} />
             </Tooltip.Target>
             <Tooltip.Content>Display a forecasting chart</Tooltip.Content>
           </Tooltip>
-        </li>
+        </li> */}
       </ul>
 
       <div className='heading-2'>Maps</div>

--- a/packages/editor/src/components/SampleData.jsx
+++ b/packages/editor/src/components/SampleData.jsx
@@ -34,12 +34,12 @@ const sampleData = {
       text: 'Area Chart Sample Data',
       fileName: 'valid-area-chart.json',
       data: validAreaChart
-    },
-    {
-      text: 'Forecast Chart Data',
-      fileName: 'valid-forecast-data.csv',
-      data: validForecastData
     }
+    // {
+    //   text: 'Forecast Chart Data',
+    //   fileName: 'valid-forecast-data.csv',
+    //   data: validForecastData
+    // }
   ],
   maps: [
     {

--- a/packages/map/src/components/EditorPanel.jsx
+++ b/packages/map/src/components/EditorPanel.jsx
@@ -2848,7 +2848,7 @@ const EditorPanel = props => {
                     ))}
                 </AccordionItemPanel>
               </AccordionItem>
-              <AccordionItem>
+              {/* <AccordionItem>
                 <AccordionItemHeading>
                   <AccordionItemButton>Custom Map Layers</AccordionItemButton>
                 </AccordionItemHeading>
@@ -2893,7 +2893,7 @@ const EditorPanel = props => {
                     Add Map Layer
                   </button>
                 </AccordionItemPanel>
-              </AccordionItem>
+              </AccordionItem> */}
             </Accordion>
           </form>
           <AdvancedEditor loadConfig={loadConfig} state={state} convertStateToConfig={convertStateToConfig} />

--- a/packages/waffle-chart/src/components/EditorPanel.jsx
+++ b/packages/waffle-chart/src/components/EditorPanel.jsx
@@ -197,12 +197,17 @@ const EditorPanel = memo(props => {
   }
   //visualizationType
 
+  const approvedWaffleChartOptions = [
+    'Waffle'
+    // 'Gauge'
+  ]
+
   const editorContent = (
     <Accordion>
       <Accordion.Section title='General'>
         <div className='cove-accordion__panel-section'>
           <div style={{ width: '100%', display: 'block' }} className='cove-input-group'>
-            <InputSelect value={config.visualizationType} fieldName='visualizationType' label='Chart Type' updateField={updateField} options={['Waffle', 'Gauge']} className='cove-input' />
+            <InputSelect value={config.visualizationType} fieldName='visualizationType' label='Chart Type' updateField={updateField} options={approvedWaffleChartOptions} className='cove-input' />
             {config.visualizationType === 'Gauge' && <InputSelect value={config.visualizationSubType} fieldName='visualizationSubType' label='Chart Subtype' updateField={updateField} options={['Linear']} className='cove-input' />}
           </div>
         </div>
@@ -321,13 +326,16 @@ const EditorPanel = memo(props => {
             </div>
           </li>
         </ul>
-
-        <hr className='cove-accordion__divider' />
-        <div className='cove-accordion__panel-section reverse-labels'>
-          <InputText inline size='small' value={config.valueDescription} label='Value Descriptor' fieldName='valueDescription' updateField={updateField} />
-          <InputCheckbox inline size='small' value={config.showPercent} label='Show Percentage' fieldName='showPercent' updateField={updateField} />
-          <InputCheckbox inline size='small' label='Show Denominator' value={config.showDenominator} fieldName='showDenominator' updateField={updateField} />
-        </div>
+        {false && (
+          <>
+            <hr className='cove-accordion__divider' />
+            <div className='cove-accordion__panel-section reverse-labels'>
+              <InputText inline size='small' value={config.valueDescription} label='Value Descriptor' fieldName='valueDescription' updateField={updateField} />
+              <InputCheckbox inline size='small' value={config.showPercent} label='Show Percentage' fieldName='showPercent' updateField={updateField} />
+              <InputCheckbox inline size='small' label='Show Denominator' value={config.showDenominator} fieldName='showDenominator' updateField={updateField} />
+            </div>
+          </>
+        )}
         <label style={{ marginBottom: '1rem' }}>
           <span className='edit-label'>Data Point Filters</span>
           <Tooltip style={{ textTransform: 'none' }}>

--- a/packages/waffle-chart/src/data/initial-state.js
+++ b/packages/waffle-chart/src/data/initial-state.js
@@ -1,6 +1,6 @@
 export default {
   title: 'Waffle Chart',
-  visualizationType: 'Gauge',
+  visualizationType: 'Waffle',
   visualizationSubType: 'linear',
   showPercent: true,
   showDenominator: true,


### PR DESCRIPTION
- hide gauge tile
- hide gauge option in waffle chart
- hide forecasting tile
- hide forecasting option in chart
- hide anchors in pie charts
- hide forecast sample data
- hide custom map layers
- default to waffle chart over gauge since gauge isn't an option

## Briefly describe your changes

## Checklist before requesting a review
- [ ] My pull request was branched from and targets the test branch
- [ ] I have performed a self-review of my code
- [ ] I have manually tested all packages affected (bonus points for automations)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [ ] Standalone Component
- [ ] Standalone Full Editor
- [ ] CDC Internal Checks
