### PR TITLE
[DEV-2183] Add legend bottom label reverse feature

### DIFF
--- a/packages/chart/src/components/Legend.jsx
+++ b/packages/chart/src/components/Legend.jsx
@@ -33,6 +33,8 @@ const Legend = () => {
 
   const { innerClasses, containerClasses } = useLegendClasses(config)
   const { visualizationType, visualizationSubType, series, runtime, orientation } = config
+  // create fn to reverse labels while legend is Bottom.  Legend-right , legend-left works by default.
+  const reverseLabels = labels => (config.legend.reverseLabelOrder && config.legend.position === 'bottom' ? labels.reverse() : labels)
 
   const createLegendLabels = defaultLabels => {
     const colorCode = config.legend?.colorCode
@@ -51,7 +53,7 @@ const Legend = () => {
         value: aboveColor
       }
 
-      return [labelBelow, labelAbove]
+      return reverseLabels([labelBelow, labelAbove])
     }
     if (visualizationType === 'Bar' && visualizationSubType === 'regular' && colorCode && series?.length === 1) {
       let palette = colorPalettes[config.palette]
@@ -76,7 +78,7 @@ const Legend = () => {
         return newLabel
       })
 
-      return uniqueLabels
+      return reverseLabels(uniqueLabels)
     }
 
     // get forecasting items inside of combo
@@ -116,7 +118,7 @@ const Legend = () => {
           seriesLabels.push(newLabel)
         })
 
-      return seriesLabels
+      return reverseLabels(seriesLabels)
     }
 
     // DEV-4161: replaceable series name in the legend
@@ -147,10 +149,10 @@ const Legend = () => {
         return newLabel
       })
 
-      return uniqueLabels
+      return reverseLabels(uniqueLabels)
     }
 
-    return defaultLabels
+    return reverseLabels(defaultLabels)
   }
 
   const isBottomOrSmallViewport = legend.position === 'bottom' || currentViewport === 'sm' || currentViewport === 'xs' || currentViewport === 'xxs'


### PR DESCRIPTION
## Briefly describe your changes
Added logic to reverse the  legend labels while legend is in bottom position
## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [x] Standalone Full Editor
- [ ] CDC Internal Checks
