### PR TITLE
Bugfix/DEV 4612 suppress fullgeoname on all maps but us-county

### DIFF
--- a/packages/core/components/DataTable.jsx
+++ b/packages/core/components/DataTable.jsx
@@ -145,15 +145,13 @@ const DataTable = props => {
   const DownloadButton = memo(() => {
     if (rawData !== undefined) {
       let csvData
-      if (config.type === 'chart' || config.general.type === 'bubble' || !config.table.showFullGeoNameInCSV) {
-        // Just Unparse
-        csvData = Papa.unparse(rawData)
-      } else if ((config.general.geoType !== 'single-state' && config.general.geoType !== 'us-county') || config.general.type === 'us-geocode') {
-        // Unparse + Add column for full Geo name
-        csvData = Papa.unparse(rawData.map(row => ({ FullGeoName: displayGeoName(row[config.columns.geo.name]), ...row })))
-      } else {
+      // only use fullGeoName on County maps and no other
+      if (config.general.geoType === 'us-county') {
         // Unparse + Add column for full Geo name along with State
         csvData = Papa.unparse(rawData.map(row => ({ FullGeoName: formatLegendLocation(row[config.columns.geo.name]), ...row })))
+      } else {
+        // Just Unparse
+        csvData = Papa.unparse(rawData)
       }
 
       const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' })


### PR DESCRIPTION
## Briefly describe your changes
The FullGeoName was showing up on too many maps that didn't make sense to be there.
Now limiting it to ONLY the us-county maps.

## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [x] Standalone Full Editor
- [ ] CDC Internal Checks
