### PR TITLE
[DEV-4215-brush-updates] Render only one set of brush handles on data…

### DIFF
--- a/packages/chart/index.html
+++ b/packages/chart/index.html
@@ -35,7 +35,7 @@
 
   <!-- GENERIC CHART TYPES -->
   <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-date-city-temperature.json"></div> -->
-  <div class="react-container" data-config="/examples/feature/area/area-chart-date-apple.json"></div>
+  <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-date-apple.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/feature/forest-plot/forest-plot.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/private/datatable-issue.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/feature/filters/filter-testing.json"></div> -->
@@ -45,7 +45,7 @@
   <!-- <div class="react-container" data-config="/examples/feature/forecasting/forecasting.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/feature/forecasting/combo-forecasting.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/feature/forecasting/effective_reproduction.json"></div> -->
-  <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-date.json"></div> -->
+  <div class="react-container" data-config="/examples/feature/area/area-chart-date.json"></div>
   <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-category.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/feature/scatterplot/scatterplot.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/feature/deviation/planet-deviation-config.json"></div> -->

--- a/packages/chart/src/components/AreaChart.jsx
+++ b/packages/chart/src/components/AreaChart.jsx
@@ -63,6 +63,14 @@ const AreaChart = ({ xScale, yScale, yMax, xMax, getXAxisData, getYAxisData, cha
     return isBrush ? yScale(d[s.dataKey]) / 4 : yScale(d[s.dataKey])
   }
 
+  // prevents duplicate brush handles being rendered
+  const getFirstBrushHandleOnly = (children, index) => {
+    if (index === 0) {
+      return children
+    }
+    // else dont return the other brush handles
+  }
+
   return (
     data && (
       <svg>
@@ -113,20 +121,7 @@ const AreaChart = ({ xScale, yScale, yMax, xMax, getXAxisData, getYAxisData, cha
                   curve={curveType}
                   strokeDasharray={s.type ? handleLineType(s.type) : 0}
                 />
-
-                  {/* circles that appear on hover */}
-                  {/* !isBrush && tooltipData && Object.entries(tooltipData.data).length > 0 && (
-                  <circle
-                    cx={config.xAxis.type === 'categorical' ? xScale(tooltipData.data[config.xAxis.dataKey]) : xScale(parseDate(tooltipData.data[config.xAxis.dataKey]))}
-                    cy={yScale(tooltipData.data[index][1])}
-                    r={4.5}
-                    opacity={1}
-                    fillOpacity={1}
-                    fill={displayArea ? (colorScale ? colorScale(config.runtime.seriesLabels ? config.runtime.seriesLabels[s.dataKey] : s.dataKey) : '#000') : 'transparent'}
-                    style={{ filter: 'unset', opacity: 1 }}
-                  />
-                  ) */}
-                  {children}
+                  {getFirstBrushHandleOnly(children, index)}
                 </React.Fragment>
               )
             })}

--- a/packages/chart/src/components/LinearChart.jsx
+++ b/packages/chart/src/components/LinearChart.jsx
@@ -1084,7 +1084,7 @@ export default function LinearChart() {
           />
         )}
         {/* brush */}
-        {showChartBrush && (config.visualizationType === 'Area Chart' || config.visualizationType === 'Bar' || config.visualizationType === 'Combo') && (
+        {showChartBrush && config.visualizationType === 'Area Chart' && (
           <>
             <AreaChart className='brushChart' xScale={xScaleBrush} yScale={yScaleBrush} yMax={yMaxBrush} xMax={xMaxBrush} height={yMaxBrush / 4} chartRef={svgRef} handleTooltipMouseOver={disableMouseOver} handleTooltipMouseOff={disableMouseOver} isDebug={isDebug} isBrush={true}>
               <PatternLines id={pattern_id} height={8} width={8} stroke={accent_color} strokeWidth={1} orientation={['diagonal']} style={styles} />

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -4,7 +4,7 @@ export default {
   title: '',
   showTitle: true,
   showDownloadMediaButton: false,
-  showChartBrush: true,
+  showChartBrush: false,
   theme: 'theme-blue',
   animate: false,
   fontSize: 'medium',


### PR DESCRIPTION
## Briefly describe your changes
Set default of showChartBrush to false
Added code to AreaChart to only render ONE brush handle instead of one for each data series which was confusing and overlapping.

## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [x] Standalone Full Editor
- [ ] CDC Internal Checks
