### PR TITLE
[DEV-5271] Fix hex bug

### DIFF
--- a/packages/map/src/components/HexShapeSettings.jsx
+++ b/packages/map/src/components/HexShapeSettings.jsx
@@ -44,8 +44,9 @@ const HexSettingDisplayAsHexMap = props => {
   const { state, handleEditorChanges } = props
 
   return (
-    'us' === state.general.geoType &&
-    'data' === state.general.type && (
+    state.general.geoType === 'us' &&
+    state.general.type !== ' navigation' &&
+    state.general.type !== 'bubble' && (
       <label className='checkbox mt-4'>
         <input
           type='checkbox'


### PR DESCRIPTION
## Briefly describe your changes
fixed a checkbox to display a map as a hex map for the U.S. map data visualization module is missing.
## Checklist before requesting a review
- [x] My pull request was branched from and targets the test branch
- [x] I have performed a self-review of my code
- [x] I have manually tested all packages affected (bonus points for automations)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked to ensure there aren't other open pull requests for the same change

## Did you test your feature in the following environments?
- [x] Standalone Component
- [x] Standalone Full Editor
- [ ] CDC Internal Checks
