### PR TITLE
[DEV-5142] Add help tooltip text for Regions tab

### DIFF
--- a/packages/chart/src/components/EditorPanel.jsx
+++ b/packages/chart/src/components/EditorPanel.jsx
@@ -192,7 +192,22 @@ const Regions = memo(({ config, updateConfig }) => {
               <TextField value={background} label='Background' fieldName='background' updateField={(section, subsection, fieldName, value) => regionUpdate(fieldName, value, i)} />
             </div>
             <div className='two-col-inputs'>
-              <TextField value={from} label='From Value' fieldName='from' updateField={(section, subsection, fieldName, value) => regionUpdate(fieldName, value, i)} />
+              <TextField
+                value={from}
+                label='From Value'
+                fieldName='from'
+                updateField={(section, subsection, fieldName, value) => regionUpdate(fieldName, value, i)}
+                tooltip={
+                  <Tooltip style={{ textTransform: 'none' }}>
+                    <Tooltip.Target>
+                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                    </Tooltip.Target>
+                    <Tooltip.Content>
+                      <p>The date needs to be in the original format of the data. Not the displayed format of the data.</p>
+                    </Tooltip.Content>
+                  </Tooltip>
+                }
+              />
               <TextField value={to} label='To Value' fieldName='to' updateField={(section, subsection, fieldName, value) => regionUpdate(fieldName, value, i)} />
             </div>
           </div>


### PR DESCRIPTION
applied help text tooltip to all charts that have the "Region" dialog.