### PR TITLE
Feature/826_data-viz-state-level-county-maps-type-of-navigation-map

### DIFF
--- a/packages/map/src/components/EditorPanel.jsx
+++ b/packages/map/src/components/EditorPanel.jsx
@@ -1616,7 +1616,7 @@ const EditorPanel = props => {
                     <option value='data'>Data</option>
                     {state.general.geoType === 'us-county' && <option value='us-geocode'>Geocode</option>}
                     {state.general.geoType === 'world' && <option value='world-geocode'>Geocode</option>}
-                    <option value='navigation'>Navigation</option>
+                    {state.general.geoType !== 'us-county' && <option value='navigation'>Navigation</option>}
                     {(state.general.geoType === 'world' || state.general.geoType === 'us') && <option value='bubble'>Bubble</option>}
                   </select>
                 </label>


### PR DESCRIPTION
* [DEV-826] update map type options for US-County Level geography subtype

![image](https://github.com/CDCgov/cdc-open-viz/assets/24421398/4d46d045-6630-4aec-832c-9d0d1ea5a55e)
