### PR TITLE
Fixes Map Breaking, Special Class Filter Issue

### DIFF
--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -690,12 +690,7 @@ const CdcMap = ({ className, config, navigationHandler: customNavigationHandler,
 
           dataSet.forEach((row, dataIndex) => {
             let number = row[state.columns.primary.name]
-            let updated = 0
-
-            // check if we're seperating zero out
-            updated = state.legend.separateZero && hasZeroInData ? index : index
-            // check for special classes
-            updated = state.legend.specialClasses ? updated + state.legend.specialClasses.length : index
+            let updated = result.length - 1
 
             if (result[updated]?.min === (null || undefined) || result[updated]?.max === (null || undefined)) return
 


### PR DESCRIPTION
@adamdoe I'd appreciate if you looked at this one a little closer. 

Super niche issue: If you have an equalnumber style map, with special class, and filter, and certain sub-filter datasets don't have a value for the special class, the map blanks (I can send example config if needed). Looks like the issue is that in generateRuntimeLegend, the special classes are only added if a row in the data has that special class value, but the index when iterating for equalnumber accounts for a special class being added either way. I changed the index to go off of the last thing added to result, since somehting is added to result in the code block above. Not sure the ramifications of this, but it appears to fix the issue for me.