### PR TITLE
[DEV-6472-solr] initial work for solr requests

### DIFF
--- a/packages/editor/src/components/DataImport.jsx
+++ b/packages/editor/src/components/DataImport.jsx
@@ -26,6 +26,20 @@ import '../scss/data-import.scss'
 
 import '@cdc/core/styles/v2/components/data-designer.scss'
 
+const isSolrCsv = dataUrl => {
+  if (dataUrl.includes('wt=csv')) {
+    return true
+  }
+  return false
+}
+
+const isSolrJson = dataUrl => {
+  if (dataUrl?.includes('wt=json')) {
+    return true
+  }
+  return false
+}
+
 export default function DataImport() {
   const { config, setConfig, errors, setErrors, errorMessages, maxFileSize, setGlobalActive, tempConfig, setTempConfig, sharepath } = useContext(ConfigContext)
 
@@ -81,15 +95,15 @@ export default function DataImport() {
   const loadExternal = async () => {
     let dataURL = ''
     // Is URL valid?
+
     try {
-      dataURL = new URL(externalURL, window.location.origin)
+      dataURL = isSolrCsv(externalURL) || isSolrJson(externalURL) ? externalURL : new URL(externalURL, window.location.origin)
     } catch {
       throw errorMessages.urlInvalid
     }
     let responseBlob = null
 
-    const fileExtension = Object.keys(supportedDataTypes).find(extension => dataURL.pathname.endsWith(extension))
-
+    const fileExtension = isSolrCsv(externalURL) ? '.csv' : isSolrJson(externalURL) ? '.json' : Object?.keys(supportedDataTypes).find(extension => dataURL.pathname.endsWith(extension))
     try {
       // eslint-disable-next-line no-unused-vars
       const response = await axios
@@ -100,9 +114,9 @@ export default function DataImport() {
           responseBlob = response.data
 
           // Sometimes the files are coming in as plain text types... Maybe when saved from Macs
-          if (fileExtension === '.csv' && responseBlob.type === 'text/plain') {
+          if ((fileExtension === '.csv' && responseBlob.type === 'text/plain') || isSolrCsv(externalURL)) {
             responseBlob = responseBlob.slice(0, responseBlob.size, 'text/csv')
-          } else if (fileExtension === '.json' && responseBlob.type === 'text/plain') {
+          } else if ((fileExtension === '.json' && responseBlob.type === 'text/plain') || isSolrJson(externalURL)) {
             responseBlob = responseBlob.slice(0, responseBlob.size, 'application/json')
           }
         })
@@ -171,7 +185,7 @@ export default function DataImport() {
 
       if (fileSourceType === 'url') {
         let urlData = new URL(path, window.location.origin)
-        fileExtension = Object.keys(supportedDataTypes).find(extension => urlData.pathname.endsWith(extension))
+        fileExtension = isSolrCsv(externalURL) ? '.csv' : isSolrJson(externalURL) ? '.json' : Object.keys(supportedDataTypes).find(extension => urlData.pathname.endsWith(extension))
       }
 
       return fileExtension
@@ -197,7 +211,7 @@ export default function DataImport() {
         case 'text/plain':
         case 'application/json':
           try {
-            text = JSON.parse(text)
+            text = isSolrJson(externalURL) ? JSON.parse(text).response.docs : JSON.parse(text)
           } catch (errors) {
             setErrors([errorMessages.formatting])
             return


### PR DESCRIPTION
### DEV-6472

You should be able to pull example files from the original ticket, save them under a private folder in editor/example/private as `wt=json` or `wt=csv`. You can then mock the request using something like `http://localhost:8080/example/private/wt=csv` Based on if the wt value is found we determine if the solr request is csv or json and get the data. 