### PR TITLE
[DEV-7417] start screen reader work for tables

### DIFF
--- a/packages/chart/index.html
+++ b/packages/chart/index.html
@@ -34,7 +34,7 @@
   -->
 
     <!-- GENERIC CHART TYPES -->
-    <!-- <div class="react-container" data-config="/examples/private/prod-line-config.json"></div> -->
+    <!-- <div class="react-container" data-config="/examples/feature/sankey/sankey-example-data.json"></div> -->
     <!-- <div class="react-container" data-config="/examples/private/chart-t.json"></div> -->
     <!-- <div class="react-container" data-config="/examples/feature/bar/additional-column-tooltip.json"></div> -->
     <!-- <div class="react-container" data-config="https://cdc.gov/poxvirus/mpox/modules/data-viz/mpx-trends_1.json"></div> -->
@@ -51,8 +51,8 @@
     <!-- <div class="react-container" data-config="/examples/feature/forecasting/forecasting.json"></div> -->
     <!-- <div class="react-container" data-config="/examples/feature/forecasting/combo-forecasting.json"></div> -->
     <!-- <div class="react-container" data-config="/examples/feature/forecasting/effective_reproduction.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-date.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-category.json"></div> -->
+    <div class="react-container" data-config="/examples/feature/area/area-chart-date.json"></div>
+    <div class="react-container" data-config="/examples/feature/area/area-chart-category.json"></div>
     <!-- <div class="react-container" data-config="/examples/feature/scatterplot/scatterplot.json"></div> -->
     <!-- <div class="react-container" data-config="/examples/feature/deviation/planet-deviation-config.json"></div> -->
     <!-- <div class="react-container" data-config="/examples/feature/boxplot/boxplot.json"></div> -->

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -2,7 +2,6 @@ import { getChartCellValue } from '../helpers/getChartCellValue'
 import { getSeriesName } from '../helpers/getSeriesName'
 import { getDataSeriesColumns } from '../helpers/getDataSeriesColumns'
 import { DownIcon, UpIcon } from './Icons'
-import { FaSort } from 'react-icons/fa'
 
 type ChartHeaderProps = { data; isVertical; config; setSortBy; sortBy; groupBy?; hasRowType? }
 
@@ -35,8 +34,6 @@ const ChartHeader = ({ data, isVertical, config, setSortBy, sortBy, groupBy, has
             <th
               style={{ minWidth: (config.table.cellMinWidth || 0) + 'px' }}
               key={`col-header-${column}__${index}`}
-              tabIndex={0}
-              title={text}
               role='columnheader'
               scope='col'
               onClick={() => {
@@ -52,11 +49,26 @@ const ChartHeader = ({ data, isVertical, config, setSortBy, sortBy, groupBy, has
               className={sortBy.column === column ? (sortBy.asc ? 'sort sort-asc' : 'sort sort-desc') : 'sort'}
               {...(sortBy.column === column ? (sortBy.asc ? { 'aria-sort': 'ascending' } : { 'aria-sort': 'descending' }) : null)}
             >
-              {text}
-              {column === sortBy.column && <span className={'sort-icon'}>{!sortBy.asc ? <UpIcon /> : <DownIcon />}</span>}
-              <button>
-                <span className='cdcdataviz-sr-only'>{`Sort by ${text} in ${sortBy.column === column ? (!sortBy.asc ? 'descending' : 'ascending') : 'descending'} `} order</span>
-              </button>
+              {text && (
+                <button
+                  data-column-index={index}
+                  onClick={() => {
+                    setSortBy({ column: text, asc: sortBy.column === text ? !sortBy.asc : false, colIndex: index })
+                  }}
+                  onKeyDown={e => {
+                    if (e.keyCode === 13) {
+                      e.preventDefault()
+                      setSortBy({ column: text, asc: sortBy.column === text ? !sortBy.asc : false, colIndex: index })
+                    }
+                  }}
+                  aria-label={`${text}`}
+                >
+                  <span aria-hidden>{text}</span>
+                  {sortBy.column === text && <span className='cdcdataviz-sr-only'>{`Sort by ${text} in ${sortBy.column === text ? (!sortBy.asc ? 'descending' : 'ascending') : 'descending'} order`}</span>}
+                  <div style={{ display: 'inline-block', margin: '0 0 0 12px' }} aria-hidden></div>
+                  {index === sortBy.colIndex && <span className={'sort-icon'}>{!sortBy.asc ? <UpIcon /> : <DownIcon />}</span>}
+                </button>
+              )}
             </th>
           )
         })}
@@ -74,8 +86,6 @@ const ChartHeader = ({ data, isVertical, config, setSortBy, sortBy, groupBy, has
             <th
               style={{ minWidth: (config.table.cellMinWidth || 0) + 'px' }}
               key={`col-header-${text}__${index}`}
-              tabIndex={0}
-              title={text}
               role='columnheader'
               scope='col'
               onClick={() => {
@@ -89,25 +99,26 @@ const ChartHeader = ({ data, isVertical, config, setSortBy, sortBy, groupBy, has
               className={sortBy.column === text ? (sortBy.asc ? 'sort sort-asc' : 'sort sort-desc') : 'sort'}
               {...(sortBy.column === text ? (sortBy.asc ? { 'aria-sort': 'ascending' } : { 'aria-sort': 'descending' }) : null)}
             >
-              {text === '__series__' ? '' : text}
-              {/* empty div replicates style of old button */}
-              <div style={{ display: 'inline-block', margin: '0 0 0 12px' }} tabIndex={-1}></div>
-              <FaSort
-                role='button'
-                className='cdcdataviz-sr-only-focusable'
-                tabIndex={0}
-                onKeyDown={e => {
-                  console.log(sortBy)
-                  if (e.keyCode === 13) {
-                    e.preventDefault()
-
+              {text !== '__series__' && (
+                <button
+                  data-column-index={index}
+                  onClick={() => {
                     setSortBy({ column: text, asc: sortBy.column === text ? !sortBy.asc : false, colIndex: index })
-                  }
-                }}
-              />
-              <span className='cdcdataviz-sr-only'>{`The data table is currently sorted by the following column: ${String(sortBy.column)}.`}</span>
-              <span className='cdcdataviz-sr-only'>{`Press enter to sort by ${text} in ${sortBy.column === text ? (!sortBy.asc ? 'descending' : 'ascending') : 'descending'} order`}</span>
-              {index === sortBy.colIndex && <span className={'sort-icon'}>{!sortBy.asc ? <UpIcon /> : <DownIcon />}</span>}
+                  }}
+                  onKeyDown={e => {
+                    if (e.keyCode === 13) {
+                      e.preventDefault()
+                      setSortBy({ column: text, asc: sortBy.column === text ? !sortBy.asc : false, colIndex: index })
+                    }
+                  }}
+                  aria-label={text}
+                >
+                  <span aria-hidden>{text}</span>
+                  {sortBy.column === text && <span className='cdcdataviz-sr-only'>{`Sort by ${text} in ${sortBy.column === text ? (!sortBy.asc ? 'descending' : 'ascending') : 'descending'} order`}</span>}
+                  <div style={{ display: 'inline-block', margin: '0 0 0 12px' }} aria-hidden></div>
+                  {index === sortBy.colIndex && <span className={'sort-icon'}>{!sortBy.asc ? <UpIcon /> : <DownIcon />}</span>}
+                </button>
+              )}
             </th>
           )
         })}

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -2,6 +2,7 @@ import { getChartCellValue } from '../helpers/getChartCellValue'
 import { getSeriesName } from '../helpers/getSeriesName'
 import { getDataSeriesColumns } from '../helpers/getDataSeriesColumns'
 import { DownIcon, UpIcon } from './Icons'
+import { FaSort } from 'react-icons/fa'
 
 type ChartHeaderProps = { data; isVertical; config; setSortBy; sortBy; groupBy?; hasRowType? }
 
@@ -68,6 +69,7 @@ const ChartHeader = ({ data, isVertical, config, setSortBy, sortBy, groupBy, has
         {['__series__', ...Object.keys(data)].slice(sliceVal).map((row, index) => {
           let column = config.xAxis?.dataKey
           let text = row !== '__series__' ? getChartCellValue(row, column, config, data) : '__series__'
+
           return (
             <th
               style={{ minWidth: (config.table.cellMinWidth || 0) + 'px' }}
@@ -88,10 +90,24 @@ const ChartHeader = ({ data, isVertical, config, setSortBy, sortBy, groupBy, has
               {...(sortBy.column === text ? (sortBy.asc ? { 'aria-sort': 'ascending' } : { 'aria-sort': 'descending' }) : null)}
             >
               {text === '__series__' ? '' : text}
+              {/* empty div replicates style of old button */}
+              <div style={{ display: 'inline-block', margin: '0 0 0 12px' }} tabIndex={-1}></div>
+              <FaSort
+                role='button'
+                className='cdcdataviz-sr-only-focusable'
+                tabIndex={0}
+                onKeyDown={e => {
+                  console.log(sortBy)
+                  if (e.keyCode === 13) {
+                    e.preventDefault()
+
+                    setSortBy({ column: text, asc: sortBy.column === text ? !sortBy.asc : false, colIndex: index })
+                  }
+                }}
+              />
+              <span className='cdcdataviz-sr-only'>{`The data table is currently sorted by the following column: ${String(sortBy.column)}.`}</span>
+              <span className='cdcdataviz-sr-only'>{`Press enter to sort by ${text} in ${sortBy.column === text ? (!sortBy.asc ? 'descending' : 'ascending') : 'descending'} order`}</span>
               {index === sortBy.colIndex && <span className={'sort-icon'}>{!sortBy.asc ? <UpIcon /> : <DownIcon />}</span>}
-              <button>
-                <span className='cdcdataviz-sr-only'>{`Sort by ${text} in ${sortBy.column === text ? (!sortBy.asc ? 'descending' : 'ascending') : 'descending'} `} order</span>
-              </button>
             </th>
           )
         })}

--- a/packages/core/styles/_data-table.scss
+++ b/packages/core/styles/_data-table.scss
@@ -31,7 +31,6 @@ div.data-table-heading {
 }
 
 table.horizontal {
-
   th,
   td {
     min-width: 200px;
@@ -102,18 +101,6 @@ table.data-table {
       background-position: right 0.5em center;
       background-size: 10px 5px;
     }
-
-    /* doesnt work
-    th.sort-asc,
-    td.sort-asc {
-      background-image: url(../assets/icon-caret-filled-up.svg);
-    }
-
-    th.sort-desc,
-    td.sort-desc {
-      background-image: url(../assets/icon-caret-filled-down.svg);
-    }
-    */
 
     // format the white triangle sort icon in data table headers
     .sort-icon {

--- a/packages/core/styles/v2/layout/_data-table.scss
+++ b/packages/core/styles/v2/layout/_data-table.scss
@@ -161,7 +161,6 @@
   }
 }
 
-
 .cove-data-table__footer {
   margin-top: 1rem;
 }


### PR DESCRIPTION
### Accessible data tables

@joshlacey I'm testing the data table accessibility with Sharon. Here are some items I've updated:
* Skip over empty headers
* Remove title/tabIndex attribute on th. This was getting read out multiple times and is still read to the user as far as I'm seeing.
* Adjusted button structure inside of th / removed sort by description in favor for aria-sortby
