### PR TITLE
Feature/charts-data-series-remaining

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
@@ -427,7 +427,7 @@ const SeriesDropdownConfidenceInterval = props => {
 const SeriesInputName = props => {
   const { series, index: i } = props
   const { config, updateConfig } = useContext(ConfigContext)
-  const adjustableNameSeriesTypes = ['Bar', 'Line', 'Area Chart', 'Combo', 'Deviation', 'Paired', 'Scatter', 'dashed-sm', 'dashed-md', 'dashed-lg']
+  const adjustableNameSeriesTypes = ['Bar', 'Line', 'Area Chart', 'Combo', 'Deviation Bar', 'Paired Bar', 'Scatter Plot', 'dashed-sm', 'dashed-md', 'dashed-lg']
 
   if (!adjustableNameSeriesTypes.includes(series.type)) return
 
@@ -468,7 +468,7 @@ const SeriesDisplayInTooltip = props => {
   const { series, index } = props
   const { config, updateConfig } = useContext(ConfigContext)
 
-  if(['Paired Bar', 'Scatter Plot', 'Deviation Bar'].includes(config.visualizationType)) return
+  if (['Paired Bar', 'Scatter Plot', 'Deviation Bar'].includes(config.visualizationType)) return
 
   const toggleTooltip = seriesIndex => {
     let copiedSeries = [...config.series]


### PR DESCRIPTION
I do not have the ticker number, but the description is as follows:

> Currently, the logic for Data Series renaming is that the renaming field, that appears when you expand an added Data Series, shows up depending on the chart you are building when you add the Data Series.
> 
> - For example, when buildng a bar chart, the "Series Name" field appears when you toggle the Data Series open.
> - But if you then switch to scatter plot, add a second Data Series, and expand that Data Series, there is no "Series Name" field to edit.
> - In this ticket, please change the functionality so that the "Series Name" field is shown when you expand the Data Series to see its sub-options.
> - Note: Box Plot does not allow you to expand the Data Series to see sub-options, and that is the expected behavior. Box plot does not show a legend and the hovers are set.

![Screenshot 2024-03-12 164651](https://github.com/CDCgov/cdc-open-viz/assets/24421398/8475adc4-730e-4f06-90ae-93866f6ee875)
![Screenshot 2024-03-12 164743](https://github.com/CDCgov/cdc-open-viz/assets/24421398/3b51ca4f-8e35-4a11-b9de-d188c0573bee)
![Screenshot 2024-03-12 170033](https://github.com/CDCgov/cdc-open-viz/assets/24421398/3f780551-acdf-4305-8a1b-7cc5a30ac1b0)
![Screenshot 2024-03-12 170300](https://github.com/CDCgov/cdc-open-viz/assets/24421398/bf13d82b-9a8f-4e35-9dc1-b571d220845d)
