### PR TITLE
[DEV-7434] change css for Skip Container link

### DIFF
--- a/packages/core/styles/_global.scss
+++ b/packages/core/styles/_global.scss
@@ -26,17 +26,27 @@ strong {
 }
 
 .cdcdataviz-sr-only,
-.cdcdataviz-sr-only-focusable:not(:focus) {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
-  border: 0 !important;
-  display: flex;
+.cdcdataviz-sr-only-focusable {
+  position: relative;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+}
+
+.cdcdataviz-sr-only,
+.cdcdataviz-sr-only-focusable:focus {
+  clip-path: none;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  position: relative;
+  z-index: 1;
 }
 
 .inline-icon {
@@ -80,9 +90,9 @@ strong {
   }
   &.danger {
     background-color: $red;
-    padding: 0em 0.6em 0.0em;
+    padding: 0em 0.6em 0em;
     height: 1.6em;
-    font-size: 0.8   em;
+    font-size: 0.8 em;
     color: #fff;
     &:hover {
       background-color: darken($red, 5%);
@@ -193,4 +203,3 @@ section.footnotes {
 .margin-left-href {
   margin-left: 15px;
 }
-


### PR DESCRIPTION
Hidden tab stop between skip over chart container and filter buttons. Content hidden from sighted users needs to be hidden from all users, made not keyboard focusable. 