### PR TITLE
Feature/dev 7434a

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -1054,10 +1054,9 @@ export default function CdcChart({ configUrl, config: configObj, isEditor = fals
         {!missingRequiredSections() && !config.newViz && (
           <div className='cdc-chart-inner-container' aria-label={handleChartAriaLabels(config)} tabIndex={0}>
             <Title showTitle={config.showTitle} isDashboard={isDashboard} title={title} superTitle={config.superTitle} classes={['chart-title', `${config.theme}`, 'cove-component__header']} style={undefined} />
-            <SkipTo skipId={handleChartTabbing} skipMessage='Skip Over Chart Container' />
-
             {/* Filters */}
             {config.filters && !externalFilters && config.visualizationType !== 'Spark Line' && <Filters config={config} setConfig={setConfig} setFilteredData={setFilteredData} filteredData={filteredData} excludedData={excludedData} filterData={filterData} dimensions={dimensions} />}
+            <SkipTo skipId={handleChartTabbing} skipMessage='Skip Over Chart Container' />
             {/* Visualization */}
             {config?.introText && config.visualizationType !== 'Spark Line' && <section className='introText'>{parse(config.introText)}</section>}
             <div

--- a/packages/core/components/elements/SkipTo.tsx
+++ b/packages/core/components/elements/SkipTo.tsx
@@ -5,10 +5,40 @@ type SkipToProps = {
   skipMessage: string
 }
 
-const SkipTo: React.FC<SkipToProps> = ({ skipId, skipMessage }) => (
-  <a id='skip-nav' className='cdcdataviz-sr-only-focusable' href={`#${skipId}`}>
-    {skipMessage}
-  </a>
-)
+const SkipTo: React.FC<SkipToProps> = ({ skipId, skipMessage }) => {
+  const handleOnClick = () => {
+    // Navigate to the specific part of the page
+    const targetElement = document.getElementById(skipId)
+    if (targetElement) {
+      targetElement.scrollIntoView()
+      targetElement.setAttribute('tabIndex', '-1')
+      targetElement.focus()
+
+      // Setup to remove tabIndex on blur to maintain document flow
+      const blurListener = () => {
+        targetElement.removeAttribute('tabIndex')
+        targetElement.removeEventListener('blur', blurListener)
+      }
+      targetElement.addEventListener('blur', blurListener)
+    }
+  }
+  return (
+    <div
+      tabIndex={0}
+      id='skip-nav'
+      className='cdcdataviz-sr-only-focusable'
+      onClick={handleOnClick}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          handleOnClick()
+        }
+      }}
+      role='link'
+      aria-label={skipMessage}
+    >
+      {skipMessage}
+    </div>
+  )
+}
 
 export default SkipTo

--- a/packages/core/components/elements/SkipTo.tsx
+++ b/packages/core/components/elements/SkipTo.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react'
+
 type SkipToProps = {
   // id to skip to
   skipId: string
@@ -6,6 +8,7 @@ type SkipToProps = {
 }
 
 const SkipTo: React.FC<SkipToProps> = ({ skipId, skipMessage }) => {
+  const accessibleId = useId()
   const handleOnClick = () => {
     // Navigate to the specific part of the page
     const targetElement = document.getElementById(skipId)
@@ -24,7 +27,7 @@ const SkipTo: React.FC<SkipToProps> = ({ skipId, skipMessage }) => {
   return (
     <div
       tabIndex={0}
-      id='skip-nav'
+      id={`skip-nav--${accessibleId}`}
       className='cdcdataviz-sr-only-focusable'
       onClick={handleOnClick}
       onKeyDown={e => {

--- a/packages/core/styles/_global.scss
+++ b/packages/core/styles/_global.scss
@@ -38,7 +38,11 @@ strong {
   border: 0 !important;
   display: flex;
 }
-
+.cdcdataviz-sr-only-focusable:focus {
+  width: fit-content;
+  margin-bottom: 0.5em;
+  margin-left: 1em;
+}
 .inline-icon {
   width: 1em !important;
   height: auto !important;
@@ -80,9 +84,9 @@ strong {
   }
   &.danger {
     background-color: $red;
-    padding: 0em 0.6em 0.0em;
+    padding: 0em 0.6em 0em;
     height: 1.6em;
-    font-size: 0.8   em;
+    font-size: 0.8 em;
     color: #fff;
     &:hover {
       background-color: darken($red, 5%);
@@ -193,4 +197,3 @@ section.footnotes {
 .margin-left-href {
   margin-left: 15px;
 }
-


### PR DESCRIPTION
Updated Skip link component from a tag to div. a tag is not supported on Safari & Firefox when user presses TAB