### PR TITLE
Fix: [DEV-7047] error changing column layout

### DIFF
--- a/packages/dashboard/src/_stories/Dashboard.stories.tsx
+++ b/packages/dashboard/src/_stories/Dashboard.stories.tsx
@@ -73,12 +73,13 @@ export const PivotFilter: Story = {
 
 faker.seed(123)
 
-const countries = _.times(10, faker.location.country)
+const countries = _.times(5, faker.location.country)
 const categories = _.times(3, val => `category-${val + 1}`)
 
 const data = []
-countries.forEach(country => {
-  categories.forEach(category => {
+countries.forEach((country, i) => {
+  categories.forEach((category, j) => {
+    if ((i + j) % 3 === 0) return
     data.push({
       Country: country,
       'Sample Categories': category,

--- a/packages/dashboard/src/components/Row.tsx
+++ b/packages/dashboard/src/components/Row.tsx
@@ -42,14 +42,21 @@ const RowMenu: React.FC<RowMenuProps> = ({ rowIdx }) => {
   const setRowLayout = (layout: number[], toggle = undefined) => {
     const newRows = _.cloneDeep(rows)
     newRows[rowIdx].toggle = toggle
-    const r = newRows[rowIdx].columns
+    const rowColumns = newRows[rowIdx].columns
+    const columnsWithWidgets = rowColumns.filter(c => c.widget)
 
-    const totalWidgets = r.filter(c => c.widget).length
+    const totalWidgets = columnsWithWidgets.length
     if (totalWidgets > layout.length) {
       // don't let them change to a smaller layout and lose viz config work
       return
     } else {
-      newRows[rowIdx].columns = layout.map((width, i) => (r[i] ? { ...r[i], width } : { width }))
+      // a 3 column becoming a 2 column with only a VizConfig in the second column will maintain order
+      // a 2 column becoming a 1 column with only a VizConfig in the second column will move the VizConfig to the first column
+      const mapRow = rowColumns.length > layout.length ? columnsWithWidgets : rowColumns
+      newRows[rowIdx].columns = layout.map((width, colIndex) => {
+        const col = mapRow[colIndex]
+        return col ? { ...col, width } : { width }
+      })
     }
 
     updateConfig({ ...config, rows: newRows })


### PR DESCRIPTION
the multi-viz enhancement introduced a bug where changing the column layout would trigger an error if the first viz column was blank and you were shifting the layout to have less columns. 

let me know if we need a separate ticket for this, but for now I just tagged the original MultiViz ticket