### PR TITLE
23719 provide option to freeze header in data table

### DIFF
--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -124,6 +124,7 @@ export default {
     label: 'Data Table',
     expanded: true,
     limitHeight: false,
+    freezeDataTableHeader: false,
     height: '',
     caption: '',
     showDownloadUrl: false,

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -186,7 +186,7 @@ const DataTable = (props: DataTableProps) => {
         <section id={tabbingId.replace('#', '')} className={`data-table-container ${viewport}`} aria-label={accessibilityLabel}>
           <SkipNav skipId={skipId} />
           <ExpandCollapse expanded={expanded} setExpanded={setExpanded} tableTitle={tableTitle} />
-          <div className={`${config.table.freezeDataTableHeader && config.table.limitHeight === false? "freeze-header": ""}`} style={limitHeight}>
+          <div className={`${config.table.freezeDataTableHeader ?'freeze-header':''}`} style={limitHeight}>
             <Table
               wrapColumns={wrapColumns}
               childrenMatrix={config.type === 'map' ? mapCellMatrix({ rows, wrapColumns, ...props, runtimeData: _runtimeData }) : chartCellMatrix({ rows, ...props, runtimeData: _runtimeData, isVertical, sortBy, hasRowType })}

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -186,7 +186,7 @@ const DataTable = (props: DataTableProps) => {
         <section id={tabbingId.replace('#', '')} className={`data-table-container ${viewport}`} aria-label={accessibilityLabel}>
           <SkipNav skipId={skipId} />
           <ExpandCollapse expanded={expanded} setExpanded={setExpanded} tableTitle={tableTitle} />
-          <div className='table-container' style={limitHeight}>
+          <div className={`${config.table.freezeDataTableHeader && config.table.limitHeight === false? "freeze-header": ""}`} style={limitHeight}>
             <Table
               wrapColumns={wrapColumns}
               childrenMatrix={config.type === 'map' ? mapCellMatrix({ rows, wrapColumns, ...props, runtimeData: _runtimeData }) : chartCellMatrix({ rows, ...props, runtimeData: _runtimeData, isVertical, sortBy, hasRowType })}

--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -126,6 +126,7 @@ const DataTable: React.FC<DataTableProps> = ({ config, updateField, isDashboard,
         <span className='edit-label column-heading'>Table Cell Min Width</span>
         <input type='number' value={config.table.cellMinWidth ? config.table.cellMinWidth : 0} onChange={e => updateField('table', null, 'cellMinWidth', e.target.value)} />
       </label>
+      <CheckBox section='table' fieldName='freezeDataTableHeader' value={config.table.freezeDataTableHeader} label='Freeze Data Table Header' updateField={updateField} />
     </>
   )
 }

--- a/packages/core/styles/_global.scss
+++ b/packages/core/styles/_global.scss
@@ -194,3 +194,6 @@ section.footnotes {
   margin-left: 15px;
 }
 
+  .freeze-header {   
+    max-height:20px;  
+  }

--- a/packages/core/types/Table.ts
+++ b/packages/core/types/Table.ts
@@ -7,6 +7,7 @@ export type Table = {
   caption?: string
   limitHeight?: boolean
   height?: number
+  freezeDataTableHeader?: boolean
   expanded?: boolean
   showDataTableLink?: boolean
   showDownloadUrl?: boolean

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -777,6 +777,15 @@ const EditorPanel = props => {
           }
         })
         break
+      case 'freezeTableHeader':
+        setState({
+          ...state,
+          table: {
+            ...state.table,
+            freezeDataTableHeader: value
+          }
+        })
+        break
       case 'chooseState':
         let fipsCode = Object.keys(supportedStatesFipsCodes).find(key => supportedStatesFipsCodes[key] === value)
         let stateName = value
@@ -2748,6 +2757,18 @@ const EditorPanel = props => {
                       />
                       <span className='edit-label'>Enable Pdf Download</span>
                     </label> */}
+                  <label className='checkbox'>
+                    <input
+                      type='checkbox'
+                      id='freezeHeader'
+                      checked={state.table.freezeDataTableHeader}
+                      onChange={event => {
+                        handleEditorChanges('freezeTableHeader', event.target.checked)
+                      }}
+                      disabled={state.table.limitHeight === true}
+                    />
+                    <span className='edit-label'>Freeze Data Table Header</span>
+                  </label>
                 </AccordionItemPanel>
               </AccordionItem>
             )}

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -72,6 +72,7 @@ export default {
     label: 'Data Table',
     expanded: false,
     limitHeight: false,
+    freezeDataTableHeader: false,
     height: '',
     caption: '',
     showDownloadUrl: false,

--- a/packages/map/src/scss/datatable.scss
+++ b/packages/map/src/scss/datatable.scss
@@ -3,4 +3,7 @@
   @include breakpointClass(md) {
     margin: 5px 1em;
   }
+  .freeze-header {   
+    max-height:200px;
+  }
 }

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -126,6 +126,7 @@ export type MapConfig = Visualization & {
     label: string
     expanded: boolean
     limitHeight: boolean
+    freezeDataTableHeader: boolean
     height: string
     caption: string
     showDownloadUrl: boolean


### PR DESCRIPTION
Charts:please note the existing behavior is that on all screens the scroll behavor already exist. On larger screens in order see the scroll behavior table rows have take up all the visual screen to cause the scroll.
Upon this discovery one might want to consider if  Freeze Data Table Header is still needed in Charts component or Editor component.
![extra rows exsiting scroll behavior high row count 13-10_36_39](https://github.com/CDCgov/cdc-open-viz/assets/14172006/40facdaa-0734-4ac5-b43a-60c2e6f28f08)
