### PR TITLE
fixed storybook build

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     ]
   },
   "scripts": {
+    "clean": "find . -name 'node_modules' -o -name 'dist' -type d -prune -exec rm -rf '{}' +",
     "publish": "npx lerna publish",
     "storybook": "storybook dev -p 6006",
     "storybook-docs": "storybook dev --docs",

--- a/packages/core/components/DataTable/DataTableStandAlone.tsx
+++ b/packages/core/components/DataTable/DataTableStandAlone.tsx
@@ -1,14 +1,24 @@
 import { ViewPort } from '../../types/ViewPort'
 import { Visualization } from '../../types/Visualization'
+import EditorWrapper from '../EditorWrapper/EditorWrapper'
 import DataTable from './DataTable'
+import DataTableEditorPanel from './components/DataTableEditorPanel'
 
 type StandAloneProps = {
   visualizationKey: string
   config: Visualization
   viewport?: ViewPort
+  isEditor?: boolean
+  updateConfig?: Function
 }
 
-const DataTableStandAlone: React.FC<StandAloneProps> = ({ visualizationKey, config, viewport }) => {
+const DataTableStandAlone: React.FC<StandAloneProps> = ({ visualizationKey, config, viewport, isEditor, updateConfig }) => {
+  if (isEditor)
+    return (
+      <EditorWrapper component={DataTableStandAlone} visualizationKey={visualizationKey} visualizationConfig={config} updateConfig={updateConfig} type={'Table'} viewport={viewport}>
+        <DataTableEditorPanel key={visualizationKey} config={config} updateConfig={updateConfig} />
+      </EditorWrapper>
+    )
   return <DataTable expandDataTable={true} config={config} rawData={config.data} runtimeData={config.formattedData} tabbingId={visualizationKey} tableTitle={config.table.label} viewport={viewport || 'lg'} />
 }
 

--- a/packages/core/components/DataTable/components/DataTableEditorPanel.tsx
+++ b/packages/core/components/DataTable/components/DataTableEditorPanel.tsx
@@ -1,4 +1,4 @@
-import { AccordionItem, AccordionItemButton, AccordionItemHeading, AccordionItemPanel } from 'react-accessible-accordion'
+import { Accordion, AccordionItem, AccordionItemButton, AccordionItemHeading, AccordionItemPanel } from 'react-accessible-accordion'
 import DataTableEditor from '../../EditorPanel/DataTableEditor'
 import { Visualization } from '@cdc/core/types/Visualization'
 import { updateFieldFactory } from '@cdc/core/helpers/updateFieldFactory'
@@ -25,7 +25,7 @@ const DataTableEditorPanel: React.FC<DataTableEditorProps> = ({ config, updateCo
 
   const columns = Object.keys(config.columns || {})
   return (
-    <>
+    <Accordion allowZeroExpanded={true}>
       <ColumnsEditor config={config} updateField={updateField} deleteColumn={deleteColumn} />
       <AccordionItem>
         <AccordionItemHeading>
@@ -35,7 +35,7 @@ const DataTableEditorPanel: React.FC<DataTableEditorProps> = ({ config, updateCo
           <DataTableEditor config={config} columns={columns} updateField={updateField} isDashboard={true} />
         </AccordionItemPanel>
       </AccordionItem>
-    </>
+    </Accordion>
   )
 }
 

--- a/packages/core/components/EditorWrapper/EditorWrapper.tsx
+++ b/packages/core/components/EditorWrapper/EditorWrapper.tsx
@@ -1,16 +1,12 @@
 import React from 'react'
-import { Accordion } from 'react-accessible-accordion'
-import Header from '../Header'
-import { Visualization } from '@cdc/core/types/Visualization'
-import { ViewPort } from '@cdc/core/types/ViewPort'
+import { Visualization } from '../../types/Visualization'
+import { ViewPort } from '../../types/ViewPort'
 import './editor-wrapper.style.css'
 
 type StandAloneComponentProps = {
   visualizationKey: string
   config: Visualization
-  isEditor: boolean
   setConfig: Function
-  isDashboard: boolean
   configUrl: string
   setEditing: Function
   hostname: string
@@ -30,19 +26,16 @@ const EditorWrapper: React.FC<React.PropsWithChildren<EditorProps>> = ({ childre
   const [displayPanel, setDisplayPanel] = React.useState(true)
   return (
     <>
-      <Header visualizationKey={visualizationKey} subEditor={type} />
       <div className='editor-wrapper'>
         <button className={`editor-toggle ${displayPanel ? '' : 'collapsed'}`} title={displayPanel ? `Collapse Editor` : `Expand Editor`} onClick={() => setDisplayPanel(!displayPanel)} />
         <section className={`${displayPanel ? '' : 'hidden'} editor-panel cove`}>
           <div aria-level={2} role='heading' className='heading-2'>
             Configure {type}
           </div>
-          <form>
-            <Accordion allowZeroExpanded={true}>{children}</Accordion>
-          </form>
+          <form>{children}</form>
         </section>
         <div className='preview-wrapper'>
-          <Component visualizationKey={visualizationKey} config={visualizationConfig} isEditor={true} setConfig={updateConfig} isDashboard={true} configUrl={undefined} setEditing={undefined} hostname={undefined} viewport={viewport} />
+          <Component visualizationKey={visualizationKey} config={visualizationConfig} setConfig={updateConfig} configUrl={undefined} setEditing={undefined} hostname={undefined} viewport={viewport} />
         </div>
       </div>
     </>

--- a/packages/core/components/EditorWrapper/editor-wrapper.style.css
+++ b/packages/core/components/EditorWrapper/editor-wrapper.style.css
@@ -1,6 +1,7 @@
 .editor-wrapper {
   --editorPanelWidth: 350px;
   position: relative;
+  min-height: 80vh;
   .editor-panel {
     :is(form) {
       border-right: var(--lightGray) 1px solid;

--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -56,8 +56,6 @@ import _ from 'lodash'
 import EditorContext from '../../editor/src/ConfigContext'
 import { getApiFilterKey } from './helpers/getApiFilterKey'
 import Filters, { APIFilterDropdowns, DropdownOptions } from './components/Filters'
-import EditorWrapper from './components/EditorWrapper/EditorWrapper'
-import DataTableEditorPanel from '@cdc/core/components/DataTable/components/DataTableEditorPanel'
 import DataTableStandAlone from '@cdc/core/components/DataTable/DataTableStandAlone'
 import { ViewPort } from '@cdc/core/types/ViewPort'
 import VisualizationRow from './components/VisualizationRow'
@@ -604,9 +602,10 @@ export default function CdcDashboard({ initialState, isEditor = false, isDebug =
             break
           case 'table':
             body = (
-              <EditorWrapper component={DataTableStandAlone} visualizationKey={visualizationKey} visualizationConfig={visualizationConfig} updateConfig={_updateConfig} type={'Table'} viewport={currentViewport}>
-                <DataTableEditorPanel key={visualizationKey} config={visualizationConfig} updateConfig={_updateConfig} />
-              </EditorWrapper>
+              <>
+                <Header visualizationKey={visualizationKey} subEditor='Table' />
+                <DataTableStandAlone visualizationKey={visualizationKey} config={visualizationConfig} isEditor={true} updateConfig={_updateConfig} />
+              </>
             )
             break
           default:


### PR DESCRIPTION
Storybook was not building the editor panel Accordion for the standalone table. After these changes it's fixed. I've already rebuilt storybook with this change so that we can have this for the demo tomorrow. No urgency in getting this out.

1) In storybook go to Pages/Dashboard/Pivot Filter.
2) in the config panel below toggle the isEditor to true
3) in dashboard click on the tools icon to bring up the table editor.

Expected: you should see the Columns and Data Table accordions on the left.