### PR TITLE
Fix: [dev-8065] dashboard preview api filters

### DIFF
--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -319,12 +319,13 @@ export default function CdcDashboard({ initialState, isEditor = false, isDebug =
   }
 
   useEffect(() => {
+    if (state.tabSelected && state.tabSelected !== 'Dashboard Preview') return
     const { config } = state
     if (config.filterBehavior !== FilterBehavior.Apply) {
       reloadURLData()
     }
     loadAPIFilters()
-  }, [])
+  }, [state.tabSelected])
 
   const updateChildConfig = (visualizationKey, newConfig) => {
     const config = _.cloneDeep(state.config)


### PR DESCRIPTION
1) Create a dashboard visualization.

2) add this data source: [nccd-cove-public-api.apps.ecpaas-dev.cdc.gov/od-public?$datakey=nyctaxi](https://nccd-cove-public-api.apps.ecpaas-dev.cdc.gov/od-public?$datakey=nyctaxi)

3) click the dashboard filter tab and create a new filter.
4) select URL filter.

5) set the filter url to: [nccd-cove-public-api.apps.ecpaas-dev.cdc.gov/od-public?$datakey=nyctaxi](https://nccd-cove-public-api.apps.ecpaas-dev.cdc.gov/od-public?$datakey=nyctaxi)&$select=dropoff_zip

6) set the key and value to: dropoff_zip
7) select the dashboard preview tab

Expected: the new dropdown should show a list of zip options.