### PR TITLE
[DEV-6410d] Add single series tooltip for Area and Line chart

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
@@ -22,7 +22,8 @@ const PanelVisual: FC<PanelProps> = props => {
   const { config, updateConfig, colorPalettes, twoColorPalette } = useContext<ChartContext>(ConfigContext)
   const { visual } = config
   const { setLollipopShape, updateField } = useEditorPanelContext()
-  const { visHasBarBorders, visCanAnimate, visSupportsNonSequentialPallete, headerColors, visSupportsTooltipOpacity, visSupportsTooltipLines, visSupportsBarSpace, visSupportsBarThickness, visHasDataCutoff, visSupportsSequentialPallete, visSupportsReverseColorPalette } = useEditorPermissions()
+  const { visHasBarBorders, visCanAnimate, visSupportsNonSequentialPallete, headerColors, visSupportsTooltipOpacity, visSupportsTooltipLines, visSupportsBarSpace, visSupportsBarThickness, visHasDataCutoff, visSupportsSequentialPallete, visSupportsReverseColorPalette, visHasSingleSeriesTooltip } =
+    useEditorPermissions()
   const { twoColorPalettes, sequential, nonSequential } = useColorPalette(config, updateConfig)
 
   const updateColor = (property, _value) => {
@@ -312,7 +313,7 @@ const PanelVisual: FC<PanelProps> = props => {
             />
           </label>
         )}
-        {config.visualizationType === 'Bar' && <CheckBox value={config.tooltips.singleSeries} fieldName='singleSeries' section='tooltips' label='SHOW HOVER FOR SINGLE DATA SERIES' updateField={updateField} />}
+        {visHasSingleSeriesTooltip() && <CheckBox value={config.tooltips.singleSeries} fieldName='singleSeries' section='tooltips' label='SHOW HOVER FOR SINGLE DATA SERIES' updateField={updateField} />}
 
         <label>
           <span className='edit-label column-heading'>No Data Message</span>

--- a/packages/chart/src/components/EditorPanel/useEditorPermissions.js
+++ b/packages/chart/src/components/EditorPanel/useEditorPermissions.js
@@ -316,6 +316,16 @@ export const useEditorPermissions = () => {
     return false
   }
 
+  const visHasSingleSeriesTooltip = () => {
+    if (visualizationType === 'Bar' || visualizationType === 'Line') {
+      return true
+    }
+    if (visualizationType === 'Area Chart' && visualizationSubType === 'stacked') {
+      return true
+    }
+    return false
+  }
+
   return {
     enabledChartTypes,
     headerColors,
@@ -361,6 +371,7 @@ export const useEditorPermissions = () => {
     visSupportsValueAxisTicks,
     visSupportsReactTooltip,
     visSupportsValueAxisMax,
-    visSupportsValueAxisMin
+    visSupportsValueAxisMin,
+    visHasSingleSeriesTooltip
   }
 }

--- a/packages/chart/src/components/LinearChart.jsx
+++ b/packages/chart/src/components/LinearChart.jsx
@@ -798,7 +798,7 @@ const LinearChart = props => {
             <Annotation.Draggable xScale={xScale} yScale={yScale} xScaleAnnotation={xScaleAnnotation} xMax={xMax} svgRef={svgRef} onDragStateChange={handleDragStateChange} />
           </Group>
         </svg>
-        {!isDraggingAnnotation && tooltipData && Object.entries(tooltipData.data).length > 0 && tooltipOpen && showTooltip && tooltipData.dataYPosition && tooltipData.dataXPosition && !config.tooltips.singleSeries && (
+        {!isDraggingAnnotation && tooltipData && Object.entries(tooltipData.data).length > 0 && tooltipOpen && showTooltip && tooltipData.dataYPosition && tooltipData.dataXPosition && (
           <>
             <style>{`.tooltip {background-color: rgba(255,255,255, ${config.tooltips.opacity / 100}) !important;`}</style>
             <style>{`.tooltip {max-width:300px} !important; word-wrap: break-word; `}</style>

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -20,6 +20,44 @@ export const useTooltip = props => {
    * @param {Object} eventSvgCoords - The object containing the SVG coordinates of the event.
    * @return {Object} - The tooltip information with tooltip data.
    */
+
+  // function handles only Single series hovred data tooltips
+  function findDataKeyByThreshold(mouseY, datapoint) {
+    let sum = 0
+    let threshold = Number(yScale.invert(mouseY))
+    let hoveredKey = null
+    let hoveredValue = null
+
+    for (let key of config.runtime?.seriesKeys) {
+      if (datapoint.hasOwnProperty(key)) {
+        sum += Number(datapoint[key])
+        if (sum >= threshold) {
+          hoveredValue = datapoint[key]
+          hoveredKey = key
+          break
+        }
+      }
+    }
+
+    // Return null if no matching data is found
+    return [hoveredKey, hoveredValue]
+  }
+
+  const getFormattedValue = (seriesKey, value, config, getAxisPosition) => {
+    // handle case where data is missing
+    const showMissingDataValue = config.general.showMissingDataLabel && !value
+    let formattedValue = seriesKey === config.xAxis.dataKey ? value : formatNumber(value, getAxisPosition(seriesKey))
+    formattedValue = showMissingDataValue ? 'N/A' : formattedValue
+
+    const suppressed = config.preliminaryData?.find(pd => pd.label && pd.type === 'suppression' && pd.displayTooltip && value === pd.value && (!pd.column || seriesKey === pd.column))
+
+    if (suppressed) {
+      formattedValue = suppressed.label
+    }
+
+    return formattedValue
+  }
+
   const getTooltipInformation = (tooltipDataArray, eventSvgCoords) => {
     const { x, y } = eventSvgCoords
     let initialTooltipData = tooltipDataArray || {}
@@ -136,22 +174,27 @@ export const useTooltip = props => {
       if (visualizationType === 'Forest Plot') {
         tooltipItems.push([config.xAxis.dataKey, getClosestYValue(y)])
       }
-
-      if (visualizationType !== 'Pie' && visualizationType !== 'Forest Plot') {
+      // handle tooltip for all  hovered series
+      if (visualizationType !== 'Pie' && visualizationType !== 'Forest Plot' && !config.tooltips.singleSeries) {
         tooltipItems.push(
           ...getIncludedTooltipSeries()
             ?.filter(seriesKey => config.series?.find(item => item.dataKey === seriesKey && item?.tooltip) || config.xAxis?.dataKey == seriesKey)
             ?.flatMap(seriesKey => {
-              const shoMissingDataValue = config.general.showMissingDataLabel && !resolvedScaleValues[0]?.[seriesKey]
-              let formattedValue = seriesKey === config.xAxis.dataKey ? resolvedScaleValues[0]?.[seriesKey] : formatNumber(resolvedScaleValues[0]?.[seriesKey], getAxisPosition(seriesKey))
-              formattedValue = shoMissingDataValue ? 'N/A' : formattedValue
-              const suppressed = config.preliminaryData?.find(pd => pd.label && pd.type === 'suppression' && pd.displayTooltip && resolvedScaleValues[0]?.[seriesKey] === pd.value && (!pd.column || seriesKey === pd.column))
-              if (suppressed) {
-                formattedValue = suppressed.label
-              }
+              const value = resolvedScaleValues[0]?.[seriesKey]
+              const formattedValue = getFormattedValue(seriesKey, value, config, getAxisPosition)
               return [[seriesKey, formattedValue, getAxisPosition(seriesKey)]]
             })
         )
+      }
+
+      // handle tooltip for single hovered series
+      if (visualizationType !== 'Pie' && visualizationType !== 'Forest Plot' && config.tooltips.singleSeries) {
+        const [seriesKey, value] = findDataKeyByThreshold(y, resolvedScaleValues[0])
+        if (seriesKey && value) {
+          tooltipItems.push([config.xAxis.dataKey, config.xAxis.type === 'date' ? formatDate(parseDate(closestXScaleValue)) : closestXScaleValue])
+          const formattedValue = getFormattedValue(seriesKey, value, config, getAxisPosition)
+          tooltipItems.push([seriesKey, formattedValue])
+        }
       }
 
       return [...tooltipItems, ...additionalTooltipItems]

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -22,7 +22,7 @@ export const useTooltip = props => {
    */
 
   // function handles only Single series hovred data tooltips
-  function findDataKeyByThreshold(mouseY, datapoint) {
+  const findDataKeyByThreshold = (mouseY, datapoint) => {
     let sum = 0
     let threshold = Number(yScale.invert(mouseY))
     let hoveredKey = null

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -191,7 +191,7 @@ export const useTooltip = props => {
       if (visualizationType !== 'Pie' && visualizationType !== 'Forest Plot' && config.tooltips.singleSeries) {
         const [seriesKey, value] = findDataKeyByThreshold(y, resolvedScaleValues[0])
         if (seriesKey && value) {
-          tooltipItems.push([config.xAxis.dataKey, config.xAxis.type === 'date' ? formatDate(parseDate(closestXScaleValue)) : closestXScaleValue])
+          tooltipItems.push([config.xAxis.dataKey, closestXScaleValue])
           const formattedValue = getFormattedValue(seriesKey, value, config, getAxisPosition)
           tooltipItems.push([seriesKey, formattedValue])
         }


### PR DESCRIPTION
Testing Steps:

Select a Line Chart or an Area Chart (STACKED) and add multiple series.
Go to the VISUAL PANEL.
Click "Show hover for single data series."
After the checkbox is ON, hover over the lines in the Line Chart. You should only see the HOVERED series and its corresponding values.
Perform the same test for the stacked Area Chart.