### PR TITLE
Fix: [dev-8409] dashboard filters change filter active

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
@@ -81,7 +81,7 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({ apiFilterDro
 
   const handleOnChange = (index: number, value: string | string[]) => {
     const newConfig = _.cloneDeep(dashboardConfig)
-    let newSharedFilters = changeFilterActive(index, value, newConfig)
+    let newSharedFilters = changeFilterActive(index, value, newConfig.dashboard.sharedFilters, visualizationConfig)
 
     if (dashboardConfig.filterBehavior === FilterBehavior.Apply) {
       const isAutoSelectFilter = visualizationConfig.autoLoad


### PR DESCRIPTION
noticed a regression issue on https://wcms-wp-test.cdc.gov/wcms/wp-admin/post.php?action=edit&post=73617 where child filters weren't loading.