### PR TITLE
no lerna required

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,15 @@
   "version": "0.0.0",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/core",
+    "packages/chart",
+    "packages/map",
+    "packages/filtered-text",
+    "packages/markup-include",
+    "packages/waffle-chart",
+    "packages/data-bite",
+    "packages/dashboard",
+    "packages/editor"
   ],
   "devDependencies": {
     "@babel/core": "^7.23.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "moduleName": "CdcCore",
   "main": "dist/cdccore",
   "scripts": {
+    "build": "echo 'no build required for @cdc/core'",
     "test": "vitest run --reporter verbose",
     "test-watch": "vitest watch --reporter verbose",
     "test-watch:ui": "vitest --ui"


### PR DESCRIPTION
Gives us the ability to use yarn for everything we are using lerna for. 

Examples: 

`lerna run build` -> `yarn workspaces run build`

`lerna run --scope @cdc/editor start` -> `yarn workspace @cdc/editor run start`