### PR TITLE
Feature: [dev-8797] viz filter parent

### DIFF
--- a/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
@@ -10,6 +10,7 @@ import FieldSetWrapper from '../FieldSetWrapper'
 
 import FilterOrder from './components/FilterOrder'
 import { useMemo, useState } from 'react'
+import MultiSelect from '../../MultiSelect'
 
 type VizFilterProps = {
   config: Visualization
@@ -31,8 +32,8 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
     updateField(null, null, 'filters', filters)
   }
 
-  const updateFilterProp = (prop, index, value) => {
-    updateField('filters', index, prop, value)
+  const updateFilterProp = (prop, filterIndex, value) => {
+    updateField('filters', filterIndex, prop, value)
   }
 
   const updateFilterStyle = (index, value) => {
@@ -62,7 +63,7 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
 
   const addNewFilter = () => {
     const filters = config.filters ? [...config.filters] : []
-    const newVizFilter: VizFilter = { values: [], filterStyle: 'dropdown' } as VizFilter
+    const newVizFilter: VizFilter = { values: [], filterStyle: 'dropdown', id: Date.now() } as VizFilter
     filters.push(newVizFilter)
     updateField(null, null, 'filters', filters)
   }
@@ -86,6 +87,10 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
     filtersCopy[filterIndex] = filterItem
 
     updateField(null, null, 'filters', filtersCopy)
+  }
+
+  const getParentFilterOptions = (index: number): { label: string; value: number }[] => {
+    return config.filters.filter((f, i) => i !== index).map(({ label, columnName, id }) => ({ label: label || columnName, value: id }))
   }
 
   return (
@@ -117,7 +122,7 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
               if (filter.type === 'url') return <></>
 
               return (
-                <FieldSetWrapper fieldName={filter.columnName} fieldKey={index} fieldType='Filter' controls={openControls} deleteField={() => removeFilter(index)}>
+                <FieldSetWrapper key={filter.columnName} fieldName={filter.columnName} fieldKey={index} fieldType='Filter' controls={openControls} deleteField={() => removeFilter(index)}>
                   <label>
                     <span className='edit-label column-heading'>Filter</span>
                     <select
@@ -206,6 +211,26 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
                       onChange={e => {
                         updateFilterProp('setByQueryParameter', index, e.target.value)
                       }}
+                    />
+                  </label>
+                  <label>
+                    <span className='edit-label column-heading'>
+                      Filter Parents{' '}
+                      <Tooltip style={{ textTransform: 'none' }}>
+                        <Tooltip.Target>
+                          <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                        </Tooltip.Target>
+                        <Tooltip.Content>
+                          <p>A selected parent's value will be used to filter the available options of this child filter.</p>
+                        </Tooltip.Content>
+                      </Tooltip>
+                    </span>
+                    <MultiSelect
+                      fieldName='parents'
+                      updateField={(_section, _subsection, _fieldname, value) => {
+                        updateFilterProp('parents', index, value)
+                      }}
+                      options={getParentFilterOptions(index)}
                     />
                   </label>
 

--- a/packages/core/components/MultiSelect/MultiSelect.tsx
+++ b/packages/core/components/MultiSelect/MultiSelect.tsx
@@ -6,7 +6,7 @@ import './multiselect.styles.css'
 import { UpdateFieldFunc } from '../../types/UpdateFieldFunc'
 
 interface Option {
-  value: string
+  value: string | number
   label: string
 }
 
@@ -17,7 +17,7 @@ interface MultiSelectProps {
   options: Option[]
   updateField: UpdateFieldFunc<string[]>
   label?: string
-  selected?: string[]
+  selected?: (string | number)[]
   limit?: number
 }
 

--- a/packages/core/helpers/addValuesToFilters.ts
+++ b/packages/core/helpers/addValuesToFilters.ts
@@ -1,11 +1,13 @@
 import _ from 'lodash'
 import { getQueryStringFilterValue } from '@cdc/core/helpers/queryStringUtils'
+import { VizFilter } from '../types/VizFilter'
 
 type Filter = {
   columnName: string
-  values: string[]
+  values: (string | number)[]
   filterStyle?: string
-  active?: string | string[]
+  active?: string | number | (string | number)[]
+  parents?: (string | number)[]
 }
 
 // Gets filter values from dataset
@@ -31,24 +33,47 @@ const generateValuesForFilter = (columnName, data: any[] | Record<string, any[]>
       })
     })
   }
-
   return values
 }
 
+const handleVizParents = (filter: VizFilter, data: any[], filtersLookup: Record<string, Filter>) => {
+  let filteredData = data
+  filter.parents.forEach(parentKey => {
+    const parent = filtersLookup[parentKey]
+    if (parent?.active) {
+      filteredData = filteredData.filter(d => {
+        if (Array.isArray(parent.active)) {
+          return parent.active.includes(d[parent.columnName])
+        }
+        return parent.active == d[parent.columnName]
+      })
+    }
+  })
+  return filteredData
+}
+
 export const addValuesToFilters = <T>(filters: Filter[], data: any[] | Record<string, any[]>): Array<T> => {
+  const filtersLookup = _.keyBy(filters, 'id')
   return filters?.map(filter => {
     const filterCopy = _.cloneDeep(filter)
-
-    const filterValues = generateValuesForFilter(filter.columnName, data)
+    let filteredData = data
+    if (Array.isArray(data) && filter.parents?.length) {
+      // handling VizFilter data
+      filteredData = handleVizParents(filter as VizFilter, data, filtersLookup)
+    }
+    const filterValues = generateValuesForFilter(filter.columnName, filteredData)
     filterCopy.values = filterValues
     if (filterValues.length > 0) {
-      const defaultValues = filterCopy.filterStyle === 'multi-select' ? filterCopy.values : filterCopy.values[0]
-
       const queryStringFilterValue = getQueryStringFilterValue(filterCopy)
       if (queryStringFilterValue) {
         filterCopy.active = queryStringFilterValue
+      } else if (filterCopy.filterStyle === 'multi-select') {
+        const defaultValues = filterCopy.values
+        const active: (string | number)[] = Array.isArray(filterCopy.active) ? filterCopy.active : [filterCopy.active]
+        filterCopy.active = active.filter(val => defaultValues.includes(val))
       } else {
-        filterCopy.active = filterCopy.active || defaultValues
+        const defaultValue = filterCopy.values[0]
+        filterCopy.active = filterCopy.values.includes(filterCopy.active as string | number) ? filterCopy.active : defaultValue
       }
     }
     return filterCopy

--- a/packages/core/helpers/coveUpdateWorker.ts
+++ b/packages/core/helpers/coveUpdateWorker.ts
@@ -9,31 +9,27 @@ import versionNeedsUpdate from './ver/versionNeedsUpdate'
 import { UpdateFunction } from 'json-edit-react'
 
 export const coveUpdateWorker = config => {
-  if (config.multiDashboards) {
-    config.multiDashboards.forEach((dashboard, index) => {
-      dashboard.type = 'dashboard'
-      config.multiDashboards[index] = coveUpdateWorker(dashboard)
-    })
-  }
   let genConfig = config
 
-  const runVersionUpdates = () => {
-    const versions = [
-      ['4.24.3', update_4_24_3],
-      ['4.24.4', update_4_24_4],
-      ['4.24.5', update_4_24_5],
-      ['4.24.7', update_4_24_7, true],
-      ['4.24.9', update_4_24_9]
-    ]
+  const versions = [
+    ['4.24.3', update_4_24_3],
+    ['4.24.4', update_4_24_4],
+    ['4.24.5', update_4_24_5],
+    ['4.24.7', update_4_24_7, true],
+    ['4.24.9', update_4_24_9]
+  ]
 
-    versions.forEach(([version, updateFunction, alwaysRun]: [string, UpdateFunction, boolean?]) => {
-      if (versionNeedsUpdate(genConfig.version, version) || alwaysRun) {
-        genConfig = updateFunction(genConfig)
-      }
-    })
-  }
-
-  runVersionUpdates()
+  versions.forEach(([version, updateFunction, alwaysRun]: [string, UpdateFunction, boolean?]) => {
+    if (versionNeedsUpdate(genConfig.version, version) || alwaysRun) {
+      genConfig = updateFunction(genConfig)
+    }
+    if (genConfig.multiDashboards) {
+      genConfig.multiDashboards.forEach((dashboard, index) => {
+        dashboard.type = 'dashboard'
+        genConfig.multiDashboards[index] = coveUpdateWorker(dashboard)
+      })
+    }
+  })
 
   return genConfig
 }

--- a/packages/core/helpers/tests/addValuesToFilters.test.ts
+++ b/packages/core/helpers/tests/addValuesToFilters.test.ts
@@ -1,0 +1,27 @@
+import { VizFilter } from '../../types/VizFilter'
+import { addValuesToFilters } from '../addValuesToFilters'
+import { describe, it, expect, vi } from 'vitest'
+
+describe('addValuesToFilters', () => {
+  const parentFilter = { columnName: 'parentColumn', id: 11, active: 'apple', values: [] } as VizFilter
+  const parentFilter2 = { columnName: 'parentColumn2', id: 22, active: '1', values: [] } as VizFilter
+  const childFilter = { columnName: 'childColumn', id: 33, parents: [11, 22], values: [] } as VizFilter
+  const data = [
+    { parentColumn: 'apple', parentColumn2: 3, childColumn: 'a' },
+    { parentColumn: 'apple', parentColumn2: 1, childColumn: 'b' },
+    { parentColumn: 'pear', parentColumn2: 4, childColumn: 'c' }
+  ]
+  const filters: VizFilter[] = [parentFilter, childFilter, parentFilter2]
+  it('adds filter values based on parent active values', () => {
+    const newFilters = addValuesToFilters<VizFilter>(filters, data)
+    expect(newFilters[0].values).toEqual(['apple', 'pear'])
+    expect(newFilters[2].values).toEqual([3, 1, 4])
+    expect(newFilters[1].values).toEqual(['b'])
+
+    filters[0].active = 'pear'
+    const newFilters2 = addValuesToFilters<VizFilter>(filters, data)
+    expect(newFilters2[0].values).toEqual(['apple', 'pear'])
+    expect(newFilters2[2].values).toEqual([3, 1, 4])
+    expect(newFilters2[1].values).toEqual([])
+  })
+})

--- a/packages/core/helpers/ver/4.24.9.ts
+++ b/packages/core/helpers/ver/4.24.9.ts
@@ -1,4 +1,6 @@
 import _ from 'lodash'
+import { AnyVisualization } from '../../types/Visualization'
+import { VizFilter } from '../../types/VizFilter'
 
 const patchSingleStateZoom = newConfig => {
   // Map zooming is a default feature created for world maps
@@ -8,10 +10,27 @@ const patchSingleStateZoom = newConfig => {
   }
 }
 
+const doesNotHaveIds = (filters: VizFilter[]) => filters?.some(f => !f.id)
+
+export const addIdsToVisFilters = config => {
+  if (config.type === 'dashboard') {
+    config.visualizations = Object.keys(config.visualizations).reduce((acc, curr) => {
+      const viz: AnyVisualization & { filters: VizFilter[] } = config.visualizations[curr]
+      if (viz.filters?.length && doesNotHaveIds(viz.filters)) {
+        acc[curr].filters = viz.filters.map((filter, i) => ({ ...filter, id: Date.now() + i }))
+      }
+      return acc
+    }, config.visualizations)
+  } else if (config.filters?.length && doesNotHaveIds(config.filters)) {
+    config.filters = config.filters.map((filter, i) => ({ ...filter, id: Date.now() + i }))
+  }
+}
+
 const update_4_24_9 = config => {
   const ver = '4.24.9'
   const newConfig = _.cloneDeep(config)
   patchSingleStateZoom(newConfig)
+  addIdsToVisFilters(newConfig)
   newConfig.version = ver
   return newConfig
 }

--- a/packages/core/helpers/ver/tests/4.24.9.test.ts
+++ b/packages/core/helpers/ver/tests/4.24.9.test.ts
@@ -1,0 +1,22 @@
+import { addIdsToVisFilters } from '../4.24.9'
+import { coveUpdateWorker } from '../../coveUpdateWorker'
+import { expect, describe, it } from 'vitest'
+
+describe('addIdsToVisFilters', () => {
+  it('adds ids to vis filters on dashboards', () => {
+    const mockConfig = { type: 'dashboard', visualizations: { a: { filters: [{}] } } } as any
+    addIdsToVisFilters(mockConfig)
+    expect(mockConfig.visualizations.a.filters[0].id).toBeDefined()
+  })
+  it('adds ids to vis filters on non dashboards', () => {
+    const mockConfig = { filters: [{}] } as any
+    addIdsToVisFilters(mockConfig)
+    expect(mockConfig.filters[0].id).toBeDefined()
+  })
+  it('adds ids to nested multi-dashboards', () => {
+    const mockConfig = { type: 'dashboard', rows: [], visualizations: { a: { filters: [{}] } }, multiDashboards: [{ rows: [], visualizations: { a: { filters: [{}] } } }] }
+    const convertedConfig = coveUpdateWorker(mockConfig)
+    expect(convertedConfig.visualizations.a.filters[0].id).toBeDefined()
+    expect(convertedConfig.multiDashboards[0].visualizations.a.filters[0].id).toBeDefined()
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "moduleName": "CdcCore",
   "main": "dist/cdccore",
   "scripts": {
-    "test": "vitest run --reporter verbose",
+    "test": "vitest run --environment jsdom --reporter verbose",
     "test-watch": "vitest watch --reporter verbose",
     "test-watch:ui": "vitest --ui"
   },

--- a/packages/core/types/VizFilter.ts
+++ b/packages/core/types/VizFilter.ts
@@ -2,6 +2,8 @@ export type FilterBase = {
   columnName: string
   values: string[]
   showDropdown: boolean
+  id: number
+  parents: number[]
 }
 
 export type GeneralFilter = FilterBase & {


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: User in the Editor has selected Dashboard Visualization. User has selected the "United States: State Sample Data" as the data source and navigated to the Configure tab.

1) Drag and drop a bar chart to the visualization panel. 
2) Select valid-data-map.csv as the data source. (vertical, not multiple series)
3) click the tools icon.
4) Select Rate for the Data Series.
5) Select Location for the Data Key.
6) Add Filters: 
    Filter 1: Location
    Filter 2: State
7) on Filter 2 select Location as the parent filter.

Expected: In the preview selecting different Location options in the first filter will change the filter options in the second State filter, as well as update the data visualization. 

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
