### PR TITLE
Fix [dev-8899] MultiDashboard: tab ordering UI glitches  & <Icon/> updated

### DIFF
--- a/packages/core/components/ui/Icon.tsx
+++ b/packages/core/components/ui/Icon.tsx
@@ -76,9 +76,25 @@ const iconHash = {
   command: iconCommand
 }
 
+export type IconType = keyof typeof iconHash
+
 export const ICON_TYPES = Object.keys(iconHash)
 
-const Icon = ({ display = '', base = undefined, alt = '', size = undefined, color = undefined, style = undefined, ...attributes }) => {
+type IconProps = {
+  /* Define the icon to display */
+  display: keyof typeof iconHash
+  /* Returns icon data as plain svg */
+  base?: boolean
+  /* Sets alt text for the icon */
+  alt: string
+  /* Override the width of the icon (scales height proportionally)*/
+  size?: number
+  /* Override the color of the icon */
+  color?: string
+  style?: string
+}
+
+const Icon: React.FC<IconProps> = ({ display = '', base = undefined, alt = '', size = undefined, color = undefined, style = undefined, ...attributes }) => {
   const IconObj = iconHash[display] || null
 
   const filteredAttrs = { ...attributes }
@@ -102,19 +118,6 @@ const Icon = ({ display = '', base = undefined, alt = '', size = undefined, colo
       )}
     </>
   )
-}
-
-Icon.propTypes = {
-  /* Define the icon to display */
-  display: PropTypes.oneOf(Object.keys(iconHash)),
-  /* Returns icon data as plain svg */
-  base: PropTypes.bool,
-  /* Sets alt text for the icon */
-  alt: PropTypes.string,
-  /* Override the width of the icon (scales height proportionally)*/
-  size: PropTypes.number,
-  /* Override the color of the icon */
-  color: PropTypes.string
 }
 
 export default Icon

--- a/packages/dashboard/src/components/MultiConfigTabs/MultiConfigTabs.tsx
+++ b/packages/dashboard/src/components/MultiConfigTabs/MultiConfigTabs.tsx
@@ -23,7 +23,8 @@ const Tab = ({ name, handleClick, tabs, index, active }) => {
   const { overlay } = useGlobalContext()
   const inputRef = createRef<HTMLInputElement>()
 
-  const onBlur = () => {
+  const saveName = e => {
+    e.stopPropagation()
     const newVal = inputRef.current.value
     const sameName = newVal === name
     const blankName = !newVal
@@ -64,15 +65,26 @@ const Tab = ({ name, handleClick, tabs, index, active }) => {
   const canMoveRight = index <= tabs.length - 2
 
   return (
-    <li className='nav-item'>
+    <li className='nav-item d-flex mt-0'>
+      {canMoveLeft && editing && <button onClick={() => handleReorder(index, -1)}>{'<'}</button>}
       <div className={`edit nav-link${active ? ' active' : ''}`} aria-current={active ? 'page' : null} onClick={onClick}>
-        {canMoveLeft && <button onClick={() => handleReorder(index, -1)}>{'<'}</button>}
-        {editing ? <input type='text' defaultValue={name} onBlur={onBlur} ref={inputRef} /> : <>{name}</>}
-        {canMoveRight && <button onClick={() => handleReorder(index, 1)}>{'>'}</button>}
-        <button className='remove' onClick={handleRemove}>
-          X
-        </button>
+        {editing ? (
+          <div className='d-flex'>
+            <input type='text' defaultValue={name} onBlur={saveName} ref={inputRef} />
+            <button className='btn btn-link save' onClick={saveName}>
+              save
+            </button>
+          </div>
+        ) : (
+          <>
+            {name}
+            <button className='remove' onClick={handleRemove}>
+              X
+            </button>
+          </>
+        )}
       </div>
+      {canMoveRight && editing && <button onClick={() => handleReorder(index, 1)}>{'>'}</button>}
     </li>
   )
 }


### PR DESCRIPTION
## Testing Steps

1) Create a dashboard.
2) Add visualizations.
3) click "Make Multi-Visualization"
4) Add another tab.
5) Click the left arrow 

Expected: One tab should have visualizations and the other should not.

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
I also fixed the Icon so that we can get type hints for the icon types. I did this thinking I would use an icon on the tabs but ended up not using it. I can pull that change into another PR though if you'd like.
