### PR TITLE
Updated cdcChart and useEditorPermissions 

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -674,6 +674,19 @@ export default function CdcChart({ configUrl, config: configObj, isEditor = fals
     }, [configObj.data]) // eslint-disable-line
   }
 
+// This will set the bump chart's default scaling type to date-time
+useEffect(() => {
+    if(['Bump Chart'].includes(config.visualizationType)) {
+        setConfig({ 
+            ...config,
+            xAxis: {
+                ...config.xAxis,
+                type: 'date-time'
+            }
+        })
+    }
+}, [config.visualizationType])
+
   // Generates color palette to pass to child chart component
   useEffect(() => {
     if (stateData && config.xAxis && config.runtime?.seriesKeys) {

--- a/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
+++ b/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
@@ -293,8 +293,6 @@ export const useEditorPermissions = () => {
   }
 
   const visSupportsDateCategoryAxisPadding = () => {
-    const disabledCharts = ['Bump Chart']
-    if (disabledCharts.includes(visualizationType)) return false
     return config.xAxis.type === 'date-time'
   }
 


### PR DESCRIPTION
- Set useEditorPermissions to include padding for bump chart again
- Set cdcChart to default the bump chart data scaling type to date-time upon first rendering