### PR TITLE
Simplify LineChart DOM

### DIFF
--- a/packages/chart/src/components/LineChart/index.tsx
+++ b/packages/chart/src/components/LineChart/index.tsx
@@ -76,27 +76,16 @@ const LineChart = (props: LineChartProps) => {
               opacity={legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(seriesKey) === -1 ? 0.5 : 1}
               display={legend.behavior === 'highlight' || (seriesHighlight.length === 0 && !legend.dynamicLegend) || seriesHighlight.indexOf(seriesKey) !== -1 ? 'block' : 'none'}
             >
+              {/* tooltips */}
+              <Bar key={'bars'} width={Number(xMax)} height={Number(yMax)} fill={DEBUG ? 'red' : 'transparent'} fillOpacity={0.05} onMouseMove={e => handleTooltipMouseOver(e, tableData)} onMouseOut={handleTooltipMouseOff} onClick={e => handleTooltipClick(e, data)} />
               {data.map((d, dataIndex) => {
-                // Find the series object from the config.runtime.series array that has a dataKey matching the seriesKey variable.
-                const series = config.runtime.series.find(({ dataKey }) => dataKey === seriesKey)
-                const { axis } = series
-
-                const hasMultipleSeries = Object.keys(config.runtime.seriesLabels).length > 1
-                const labeltype = axis === 'Right' ? 'rightLabel' : 'label'
-                let label = config.runtime.yAxis[labeltype]
-
-                // if has muiltiple series dont show legend value on tooltip
-                if (!hasMultipleSeries) label = config.isLegendValue ? config.runtime.seriesLabels[seriesKey] : label
 
                 return (
                   d[seriesKey] !== undefined &&
                   d[seriesKey] !== '' &&
                   d[seriesKey] !== null &&
                   isNumber(d[seriesKey]) && (
-                    <Group key={`series-${seriesKey}-point-${dataIndex}`} className='checkwidth'>
-                      {/* tooltips */}
-                      <Bar key={'bars'} width={Number(xMax)} height={Number(yMax)} fill={DEBUG ? 'red' : 'transparent'} fillOpacity={0.05} onMouseMove={e => handleTooltipMouseOver(e, tableData)} onMouseOut={handleTooltipMouseOff} onClick={e => handleTooltipClick(e, data)} />
-
+                    <React.Fragment key={`series-${seriesKey}-point-${dataIndex}`}>
                       {/* Render label */}
                       {config.labels && (
                         <Text x={xPos(d)} y={seriesAxis === 'Right' ? yScaleRight(getYAxisData(d, seriesKey)) : yScale(getYAxisData(d, seriesKey))} fill={'#000'} textAnchor='middle'>
@@ -104,7 +93,7 @@ const LineChart = (props: LineChartProps) => {
                         </Text>
                       )}
 
-                      {(lineDatapointStyle === 'hidden' || lineDatapointStyle === 'always show') && (
+                      {lineDatapointStyle === 'always show' && (
                         <LineChartCircle
                           mode='ALWAYS_SHOW_POINTS'
                           dataIndex={dataIndex}
@@ -145,7 +134,7 @@ const LineChart = (props: LineChartProps) => {
                         seriesAxis={seriesAxis}
                         key={`isolated-circle-${dataIndex}`}
                       />
-                    </Group>
+                    </React.Fragment>
                   )
                 )
               })}


### PR DESCRIPTION
This PR simplifies line chart DOM in two ways:

* Moves the transparent `<rect>` used for the tooltip mouse listener outside the data loop. This renders it once instead of once for each data point in the chart.

* Changes a Group to a Fragment so the `<g>` isn't rendered for every data point when it's empty (which is for most charts, I'd assume, now that the rect was moved).

For a sample chart from the Respiratory Illness page, this reduces DOM nodes from about 800 to 200.

It also removes some variables that no longer appear to be used.

## Testing Steps

Load up some detailed line charts and see that they still work and they have fewer nodes. 
