### PR TITLE
Adds Support for Line Types to Dynamic Series

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -388,6 +388,8 @@ export default function CdcChart({
           ) {
             newConfig.runtime.series.push({
               dataKey: seriesKey,
+              type: newConfig.dynamicSeriesType,
+              lineType: newConfig.dynamicSeriesLineType,
               tooltip: true
             })
           }

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -21,6 +21,7 @@ import VizFilterEditor from '@cdc/core/components/EditorPanel/VizFilterEditor'
 import Tooltip from '@cdc/core/components/ui/Tooltip'
 import { Select, TextField, CheckBox } from '@cdc/core/components/EditorPanel/Inputs'
 import { viewports } from '@cdc/core/helpers/getViewport'
+import { approvedCurveTypes } from '@cdc/core/helpers/lineChartHelpers'
 
 // chart components
 import Panels from './components/Panels'
@@ -1434,6 +1435,26 @@ const EditorPanel = () => {
                         fieldName='dynamicSeries'
                         label='Dynamically generate series'
                         updateField={updateField}
+                      />
+                    )}
+                    {config.dynamicSeries && config.visualizationType === 'Line' && (
+                      <Select
+                        fieldName='dynamicSeriesType'
+                        value={config.dynamicSeriesType}
+                        label='Series Type'
+                        initial='Select'
+                        updateField={updateField}
+                        options={['Line','dashed-sm', 'dashed-md', 'dashed-lg']}
+                      />
+                    )}
+                    {config.dynamicSeries && config.visualizationType === 'Line' && config.dynamicSeriesType === 'Line' && (
+                      <Select
+                        fieldName='dynamicSeriesLineType'
+                        value={config.dynamicSeriesLineType ? config.dynamicSeriesLineType : 'curveLinear'}
+                        label='Line Type'
+                        initial='Select'
+                        updateField={updateField}
+                        options={Object.keys(approvedCurveTypes).map(curveName => approvedCurveTypes[curveName])}
                       />
                     )}
                     {(!visSupportsDynamicSeries() || !config.dynamicSeries) && (

--- a/packages/core/components/Filters.tsx
+++ b/packages/core/components/Filters.tsx
@@ -134,6 +134,8 @@ export const useFilters = props => {
             ) {
               runtime.series.push({
                 dataKey: seriesKey,
+                type: visualizationConfig.dynamicSeriesType,
+                lineType: visualizationConfig.dynamicSeriesLineType,
                 tooltip: true
               })
             }


### PR DESCRIPTION
## Testing Steps

1. Run chart package
2. Select line chart type
3. Enable dynamic series checkbox
4. Ensure that series type dropdown shows below once enabled
5. Ensure series type dropdown options work and control the series type
6. When series type is "Line" ensure another dropdown appears controlling curve type

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
