### PR TITLE
dev-9150 Fix double data requests for charts and maps

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -744,7 +744,7 @@ export default function CdcChart({
   }, [externalFilters]) // eslint-disable-line
 
   // Load data when configObj data changes
-  if (configObj) {
+  if (configObj && isDashboard) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       loadConfig()

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -1625,7 +1625,7 @@ const CdcMap = ({
     reloadURLData()
   }, [JSON.stringify(state.filters)])
 
-  if (config) {
+  if (config && isDashboard) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       loadConfig(config)


### PR DESCRIPTION
When charts or maps are embedded like `<CdcChart configUrl=`, they make one data request on page load, but when they're embedded like `<CdcChart config=`, they make two. Since they're embedded with `configUrl=` when viewing charts locally but with `config=` [in WCMS](https://github.com/cdcent/TemplatePackage/blob/master/src/contrib/widgets/openVizWrapper/src/Wrapper.js#L181), we only see the issue on live charts.

This `useEffect` (which is only added when loading the chart with a `configObj`) is what's causing the double-request. I think the [original intent](https://github.com/CDCgov/cdc-open-viz/commit/1ceec2b2de09c6a3cc8d16c494304395ddce2777) of the `useEffect` was for dashboard filtering, but it's a little hard to tell if this change will have other side effects.

To test that this fixes the issue, `chart/src/index.jsx` can be changed to:

```
import React from 'react'
import ReactDOM from 'react-dom/client'

import CdcChart from './CdcChart'

import 'react-tooltip/dist/react-tooltip.css'

let isEditor = window.location.href.includes('editor=true')
let isDebug = window.location.href.includes('debug=true')

let domContainer = document.getElementsByClassName('react-container')[0]

let configUrl = domContainer.attributes['data-config'].value;
let config = (await (await fetch(configUrl)).json());

ReactDOM.createRoot(domContainer).render(
  <CdcChart config={config} isEditor={isEditor} isDebug={isDebug} />
  //<CdcChart configUrl={configUrl} isEditor={isEditor} isDebug={isDebug} />
)
```