### PR TITLE
dev-8923 Memory leak fixed

### DIFF
--- a/packages/markup-include/src/CdcMarkupInclude.tsx
+++ b/packages/markup-include/src/CdcMarkupInclude.tsx
@@ -31,8 +31,21 @@ type CdcMarkupIncludeProps = {
 
 import Title from '@cdc/core/components/ui/Title'
 
-const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({ configUrl, config: configObj, isDashboard = true, isEditor = false, setConfig: setParentConfig }) => {
-  const initialState = { config: configObj, loading: true, urlMarkup: '', markupError: null, errorMessage: null, coveLoadedHasRan: false }
+const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({
+  configUrl,
+  config: configObj,
+  isDashboard = true,
+  isEditor = false,
+  setConfig: setParentConfig
+}) => {
+  const initialState = {
+    config: configObj,
+    loading: true,
+    urlMarkup: '',
+    markupError: null,
+    errorMessage: null,
+    coveLoadedHasRan: false
+  }
 
   const [state, dispatch] = useReducer(markupIncludeReducer, initialState)
 
@@ -92,7 +105,8 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({ configUrl, config: 
       let errorList = {
         200: 'This is likely due to a CORS restriction policy from the remote origin address.',
         404: 'The requested source URL cannot be found. Please verify the link address provided.',
-        proto: 'Provided source URL must include https:// or http:// before the address (depending on the source content type).'
+        proto:
+          'Provided source URL must include https:// or http:// before the address (depending on the source content type).'
       }
 
       message += errorList[errorCode]
@@ -138,7 +152,10 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({ configUrl, config: 
   const filterOutConditions = (workingData, conditionList) => {
     const { columnName, isOrIsNotEqualTo, value } = conditionList[0]
 
-    const newWorkingData = isOrIsNotEqualTo === 'is' ? workingData.filter(dataObject => dataObject[columnName] === value) : workingData.filter(dataObject => dataObject[columnName] !== value)
+    const newWorkingData =
+      isOrIsNotEqualTo === 'is'
+        ? workingData.filter(dataObject => dataObject[columnName] === value)
+        : workingData.filter(dataObject => dataObject[columnName] !== value)
 
     conditionList.shift()
     return conditionList.length === 0 ? newWorkingData : filterOutConditions(newWorkingData, conditionList)
@@ -150,7 +167,10 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({ configUrl, config: 
     const convertedInlineMarkup = inlineMarkup.replace(variableRegexPattern, variableTag => {
       const workingVariable = markupVariables.filter(variable => variable.tag === variableTag)[0]
       if (workingVariable === undefined) return [variableTag]
-      const workingData = workingVariable && workingVariable.conditions.length === 0 ? data : filterOutConditions(data, [...workingVariable.conditions])
+      const workingData =
+        workingVariable && workingVariable.conditions.length === 0
+          ? data
+          : filterOutConditions(data, [...workingVariable.conditions])
 
       const variableValues: string[] = _.uniq(workingData?.map(dataObject => dataObject[workingVariable.columnName]))
       const variableDisplay = []
@@ -168,12 +188,13 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({ configUrl, config: 
 
       let finalDisplay = variableDisplay[0]
 
-      if(workingVariable.addCommas && !isNaN(parseFloat(finalDisplay))){
+      if (workingVariable.addCommas && !isNaN(parseFloat(finalDisplay))) {
         finalDisplay = parseFloat(finalDisplay)
-        finalDisplay = finalDisplay.toLocaleString('en-US', {useGrouping: true})
+        finalDisplay = finalDisplay.toLocaleString('en-US', { useGrouping: true })
       }
 
-      const displayInfoMessage = '<span class="font-weight-bold display-Info-message">One or more of the following values will appear in the place of this variable placeholder:</span>'
+      const displayInfoMessage =
+        '<span class="font-weight-bold display-Info-message">One or more of the following values will appear in the place of this variable placeholder:</span>'
 
       const newReplacementForVariable = `<span class="cove-tooltip-variable">${variableTag}<span class="cove-tooltip-value">${displayInfoMessage}<br/>${finalDisplay}</span></span><span class="cove-markup-include-variable-value">${finalDisplay}</span>`
 
@@ -209,11 +230,6 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({ configUrl, config: 
       dispatch({ type: 'SET_COVE_LOADED_HAS_RAN', payload: true })
     }
   }, [config, container])
-
-  //Reload config if config object provided/updated
-  useEffect(() => {
-    loadConfig().catch(err => console.log(err))
-  }, [configObj?.data])
 
   //Reload any functions when config is updated
   useEffect(() => {


### PR DESCRIPTION
## Testing Steps

Scenario: In Cove Editor running on your local environment, Select Dashboard, Select some Data set, drag and drop a markup include section onto the visualization panel. Open the Editor.

1) Open the browser console and find the file packages/dashboard/CdcDashboardComponent.
2) put a breakpoint in the updateChildConfig function. (line 228)

Expected you should not immediately hit a breakpoint.

You hit the breakpoint a few times on load but there is no infinite loop.

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings

## Additional Notes

Functional changes are on lines 233, the deleting of useEffect. The rest of the changes are just linter changes.
