### PR TITLE
[DEV-9286] Set default x-axis padding on date charts to zero

### DIFF
--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -742,7 +742,7 @@ const EditorPanel = () => {
       updatedConfig.orientation = 'vertical'
     }
     if (isDateScale(updatedConfig.xAxis) && !updatedConfig.xAxis.padding) {
-      updatedConfig.xAxis.padding = 6
+      updatedConfig.xAxis.padding = 0
     }
     // DEV-8008 - Remove Bar styling when Line is converted to Bar
     if (updatedConfig.visualizationType === 'Line') {

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -1276,7 +1276,7 @@ const LinearChart: React.FC<LinearChartProps> = props => {
           {config.filters && config.filters.values.length === 0 && data.length === 0 && (
             <Text
               x={Number(config.yAxis.size) + Number(xMax / 2)}
-              y={height / 2 - config.xAxis.padding / 2}
+              y={height / 2 - (config.xAxis.padding || 0) / 2}
               textAnchor='middle'
             >
               {config.chartMessage.noData}

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -125,7 +125,8 @@ export default {
     labelOffset: 65,
     axisPadding: 200,
     target: 0,
-    maxTickRotation: 0
+    maxTickRotation: 0,
+    padding: 0
   },
   table: {
     label: 'Data Table',


### PR DESCRIPTION
## Testing Steps

Create a chart with a "Date (Date Time Scale)" x-axis and see that the padding is 0 instead of 6%, and there are no gaps to the left of the data.