### PR TITLE
[9293] Hide Null values from hover

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -89,7 +89,7 @@ export default function CdcChart({
   const [loading, setLoading] = useState(true)
   const [colorScale, setColorScale] = useState(null)
   const [config, setConfig] = useState<ChartConfig>({} as ChartConfig)
-  const [stateData, setStateData] = useState(configObj.data || [])
+  const [stateData, setStateData] = useState(configObj?.data || [])
   const [excludedData, setExcludedData] = useState<Record<string, number>[] | undefined>(undefined)
   const [filteredData, setFilteredData] = useState<Record<string, any>[] | undefined>(undefined)
   const [seriesHighlight, setSeriesHighlight] = useState<string[]>(

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -199,7 +199,9 @@ export const useTooltip = props => {
             ?.flatMap(seriesKey => {
               const value = resolvedScaleValues[0]?.[seriesKey]
               const formattedValue = getFormattedValue(seriesKey, value, config, getAxisPosition)
-              return [[seriesKey, formattedValue, getAxisPosition(seriesKey)]]
+              return config.general.hideNullValue && !value
+                ? []
+                : [[seriesKey, formattedValue, getAxisPosition(seriesKey)]]
             })
         )
       }


### PR DESCRIPTION
## [Replace With Ticket Number]
Updated logic for missing data on tooltips. On Stacked bar charts we have checkbox on general panel "Remove Null values from hover" which now removed whole row if value is null ( before it used to remove only value while keeping series name)
this goes to October sprint.
<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
