### PR TITLE
[DEV-9340] Feature: Option to place Y Axis labels above Gridlines

### DIFF
--- a/packages/chart/src/_stories/Chart.stories.tsx
+++ b/packages/chart/src/_stories/Chart.stories.tsx
@@ -6,6 +6,7 @@ import lineChartTwoPointsRegressionTest from './_mock/line_chart_two_points_regr
 import lineChartTwoPointsNewChart from './_mock/line_chart_two_points_new_chart.json'
 import lollipop from './_mock/lollipop.json'
 import forestPlot from '../../examples/feature/forest-plot/forest-plot.json'
+import horizontalBarConfig from './_mock/horizontal_bar.json'
 
 const meta: Meta<typeof Chart> = {
   title: 'Components/Templates/Chart',
@@ -47,4 +48,9 @@ export const Forest_Plot: Story = {
   }
 }
 
+export const Horizontal_Bar: Story = {
+  args: {
+    config: horizontalBarConfig
+  }
+}
 export default meta

--- a/packages/chart/src/_stories/Chart.stories.tsx
+++ b/packages/chart/src/_stories/Chart.stories.tsx
@@ -5,6 +5,7 @@ import Chart from '../CdcChart'
 import lineChartTwoPointsRegressionTest from './_mock/line_chart_two_points_regression_test.json'
 import lineChartTwoPointsNewChart from './_mock/line_chart_two_points_new_chart.json'
 import lollipop from './_mock/lollipop.json'
+import forestPlot from '../../examples/feature/forest-plot/forest-plot.json'
 
 const meta: Meta<typeof Chart> = {
   title: 'Components/Templates/Chart',
@@ -37,6 +38,12 @@ export const Suppression: Story = {
   args: {
     config: SuppressedConfig,
     isEditor: false
+  }
+}
+
+export const Forest_Plot: Story = {
+  args: {
+    config: forestPlot
   }
 }
 

--- a/packages/chart/src/_stories/ChartPrefixSuffix.stories.tsx
+++ b/packages/chart/src/_stories/ChartPrefixSuffix.stories.tsx
@@ -98,7 +98,7 @@ export const Top_Suffix_On_Line: Story = {
       { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
       { path: ['dataFormat', 'suffix'], value: ' Somethings per Something' },
       { path: ['yAxis', 'gridLines'], value: true },
-      { path: ['yAxis', 'labelsOnGridlines'], value: true },
+      { path: ['yAxis', 'labelsAboveGridlines'], value: true },
       { path: ['yAxis', 'hideAxis'], value: true }
     ])
   }
@@ -107,9 +107,10 @@ export const Top_Suffix_On_Line: Story = {
 export const Values_On_Line_All_Suffix: Story = {
   args: {
     config: editConfigKeys(annotationConfig, [
-      { path: ['yAxis', 'labelsOnGridlines'], value: true },
+      { path: ['yAxis', 'labelsAboveGridlines'], value: true },
       { path: ['dataFormat', 'suffix'], value: ' units' },
-      { path: ['yAxis', 'gridLines'], value: true }
+      { path: ['yAxis', 'gridLines'], value: true },
+      { path: ['yAxis', 'hideAxis'], value: true }
     ])
   }
 }
@@ -120,8 +121,20 @@ export const Values_on_Line_Top_Suffix_Only_Area_Worst_Case: Story = {
       { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
       { path: ['dataFormat', 'prefix'], value: 'pre' },
       { path: ['dataFormat', 'suffix'], value: ' Somethings per Something' },
-      { path: ['yAxis', 'labelsOnGridlines'], value: true },
+      { path: ['yAxis', 'labelsAboveGridlines'], value: true },
       { path: ['yAxis', 'gridLines'], value: true }
+    ])
+  }
+}
+
+export const Top_Suffix_Above_Gridlines_With_Options: Story = {
+  args: {
+    config: editConfigKeys(annotationConfig, [
+      { path: ['yAxis', 'tickRotation'], value: 45 },
+      { path: ['yAxis', 'tickLabelColor'], value: 'red' },
+      { path: ['yAxis', 'labelsAboveGridlines'], value: true },
+      { path: ['yAxis', 'gridLines'], value: true },
+      { path: ['yAxis', 'hideAxis'], value: true }
     ])
   }
 }

--- a/packages/chart/src/_stories/ChartPrefixSuffix.stories.tsx
+++ b/packages/chart/src/_stories/ChartPrefixSuffix.stories.tsx
@@ -92,4 +92,38 @@ export const Horizontal_Bar: Story = {
   }
 }
 
+export const Top_Suffix_On_Line: Story = {
+  args: {
+    config: editConfigKeys(barConfig, [
+      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
+      { path: ['dataFormat', 'suffix'], value: ' Somethings per Something' },
+      { path: ['yAxis', 'gridLines'], value: true },
+      { path: ['yAxis', 'labelsOnGridlines'], value: true },
+      { path: ['yAxis', 'hideAxis'], value: true }
+    ])
+  }
+}
+
+export const Values_On_Line_All_Suffix: Story = {
+  args: {
+    config: editConfigKeys(annotationConfig, [
+      { path: ['yAxis', 'labelsOnGridlines'], value: true },
+      { path: ['dataFormat', 'suffix'], value: ' units' },
+      { path: ['yAxis', 'gridLines'], value: true }
+    ])
+  }
+}
+
+export const Values_on_Line_Top_Suffix_Only_Area_Worst_Case: Story = {
+  args: {
+    config: editConfigKeys(annotationConfig, [
+      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
+      { path: ['dataFormat', 'prefix'], value: 'pre' },
+      { path: ['dataFormat', 'suffix'], value: ' Somethings per Something' },
+      { path: ['yAxis', 'labelsOnGridlines'], value: true },
+      { path: ['yAxis', 'gridLines'], value: true }
+    ])
+  }
+}
+
 export default meta

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1805,9 +1805,9 @@ const EditorPanel = () => {
                       )}
                       {visSupportsValueAxisGridLines() && (
                         <CheckBox
-                          value={config.yAxis.labelsOnGridlines}
+                          value={config.yAxis.labelsAboveGridlines}
                           section='yAxis'
-                          fieldName='labelsOnGridlines'
+                          fieldName='labelsAboveGridlines'
                           label='Labels above gridlines'
                           updateField={updateField}
                           disabled={!config.yAxis.gridLines}

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1808,7 +1808,7 @@ const EditorPanel = () => {
                           value={config.yAxis.labelsOnGridlines}
                           section='yAxis'
                           fieldName='labelsOnGridlines'
-                          label='Labels on top of gridlines'
+                          label='Labels above gridlines'
                           updateField={updateField}
                           disabled={!config.yAxis.gridLines}
                           title={!config.yAxis.gridLines ? 'Show gridlines to enable' : ''}

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1803,6 +1803,17 @@ const EditorPanel = () => {
                           updateField={updateField}
                         />
                       )}
+                      {visSupportsValueAxisGridLines() && (
+                        <CheckBox
+                          value={config.yAxis.labelsOnGridlines}
+                          section='yAxis'
+                          fieldName='labelsOnGridlines'
+                          label='Labels on top of gridlines'
+                          updateField={updateField}
+                          disabled={!config.yAxis.gridLines}
+                          title={!config.yAxis.gridLines ? 'Show gridlines to enable' : ''}
+                        />
+                      )}
                       <CheckBox
                         value={config.yAxis.enablePadding}
                         section='yAxis'

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -308,7 +308,8 @@ const LinearChart: React.FC<LinearChartProps> = props => {
 
   useEffect(() => {
     const textElement = document.querySelector(`#suffix`)
-    if (!textElement) return
+    if (!textElement && !suffixWidth) return
+    if (!textElement) return setSuffixWidth(0)
     const textWidth = textElement.getBBox().width
     setSuffixWidth(textWidth)
   }, [config.dataFormat.suffix, config.dataFormat.onlyShowTopPrefixSuffix])

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -37,6 +37,7 @@ import useTopAxis from '../hooks/useTopAxis'
 import { useTooltip as useCoveTooltip } from '../hooks/useTooltip'
 import { useEditorPermissions } from './EditorPanel/useEditorPermissions'
 import Annotation from './Annotations'
+import { BlurStrokeText } from '@cdc/core/components/BlurStrokeText'
 
 type LinearChartProps = {
   parentWidth: number
@@ -1087,7 +1088,7 @@ const LinearChart: React.FC<LinearChartProps> = props => {
                                 {/* SPECIAL ONE CHAR CASE: a one character top-only suffix does not overflow */}
                                 {/* IF VALUES ON LINE: suffix is combined with value to avoid having to calculate varying (now left-aligned) value widths */}
                                 {onlyShowTopPrefixSuffix && lastTick && !labelsOnGridlines && (
-                                  <Text
+                                  <BlurStrokeText
                                     id='suffix'
                                     display={isLogarithmicAxis ? showTicks : 'block'}
                                     dx={isLogarithmicAxis ? -6 : 0}
@@ -1098,17 +1099,16 @@ const LinearChart: React.FC<LinearChartProps> = props => {
                                     textAnchor={suffixOneChar ? 'end' : 'start'}
                                     fill={config.yAxis.tickLabelColor}
                                     stroke={'#fff'}
-                                    strokeWidth={6}
                                     paintOrder={'stroke'} // keeps stroke under fill
                                     strokeLinejoin='round'
                                     style={{ whiteSpace: 'pre-wrap' }} // prevents leading spaces from being trimmed
                                   >
                                     {suffix}
-                                  </Text>
+                                  </BlurStrokeText>
                                 )}
 
                                 {/* VALUE */}
-                                <Text
+                                <BlurStrokeText
                                   display={isLogarithmicAxis ? showTicks : 'block'}
                                   dx={isLogarithmicAxis ? -6 : 0}
                                   x={suffixOneChar ? labelX - suffixWidth : labelX}
@@ -1117,14 +1117,14 @@ const LinearChart: React.FC<LinearChartProps> = props => {
                                   verticalAnchor={config.runtime.horizontal ? 'start' : labelVerticalAnchor}
                                   textAnchor={config.runtime.horizontal || labelsOnGridlines ? 'start' : 'end'}
                                   fill={config.yAxis.tickLabelColor}
-                                  stroke={labelsOnGridlines ? '#fff' : 'none'}
+                                  stroke={'#fff'}
+                                  disableStroke={!labelsOnGridlines}
                                   strokeLinejoin='round'
-                                  strokeWidth={6}
                                   paintOrder={'stroke'} // keeps stroke under fill
                                   style={{ whiteSpace: 'pre-wrap' }} // prevents leading spaces from being trimmed
                                 >
                                   {`${tick.formattedValue}${combineDomSuffixWithValue ? suffix : ''}`}
-                                </Text>
+                                </BlurStrokeText>
                               </>
                             )}
                         </Group>

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -960,22 +960,22 @@ const LinearChart: React.FC<LinearChartProps> = props => {
 
                       // Vertical value/suffix vars
                       const { suffix, onlyShowTopPrefixSuffix } = config.dataFormat
-                      const { labelsOnGridlines, hideAxis } = config.yAxis
+                      const { labelsAboveGridlines, hideAxis } = config.yAxis
                       const lastTick = props.ticks.length - 1 === i
                       const suffixOneChar = suffix.length === 1
                       const hideTopTick = lastTick && onlyShowTopPrefixSuffix && suffix && !suffixOneChar
                       const valueOnLinePadding = hideAxis ? -8 : -12
-                      const labelXPadding = labelsOnGridlines ? valueOnLinePadding : 2
-                      const labelYPadding = labelsOnGridlines ? 4 : 0
+                      const labelXPadding = labelsAboveGridlines ? valueOnLinePadding : 2
+                      const labelYPadding = labelsAboveGridlines ? 4 : 0
                       const labelX = tick.to.x - labelXPadding
                       const labelY = tick.to.y - labelYPadding
-                      const labelVerticalAnchor = labelsOnGridlines ? 'end' : 'middle'
+                      const labelVerticalAnchor = labelsAboveGridlines ? 'end' : 'middle'
                       const combineDomSuffixWithValue =
-                        onlyShowTopPrefixSuffix && labelsOnGridlines && suffix && lastTick
+                        onlyShowTopPrefixSuffix && labelsAboveGridlines && suffix && lastTick
 
                       return (
                         <Group key={`vx-tick-${tick.value}-${i}`} className={'vx-axis-tick'}>
-                          {!runtime.yAxis.hideTicks && !labelsOnGridlines && !hideTopTick && (
+                          {!runtime.yAxis.hideTicks && !labelsAboveGridlines && !hideTopTick && (
                             <Line
                               key={`${tick.value}--hide-hideTicks`}
                               from={tick.from}
@@ -1088,7 +1088,7 @@ const LinearChart: React.FC<LinearChartProps> = props => {
                                 {/* top suffix is shown alone and is allowed to 'overflow' to the right */}
                                 {/* SPECIAL ONE CHAR CASE: a one character top-only suffix does not overflow */}
                                 {/* IF VALUES ON LINE: suffix is combined with value to avoid having to calculate varying (now left-aligned) value widths */}
-                                {onlyShowTopPrefixSuffix && lastTick && !labelsOnGridlines && (
+                                {onlyShowTopPrefixSuffix && lastTick && !labelsAboveGridlines && (
                                   <BlurStrokeText
                                     id='suffix'
                                     display={isLogarithmicAxis ? showTicks : 'block'}
@@ -1116,10 +1116,10 @@ const LinearChart: React.FC<LinearChartProps> = props => {
                                   y={labelY + (config.runtime.horizontal ? horizontalTickOffset : 0)}
                                   angle={-Number(config.yAxis.tickRotation) || 0}
                                   verticalAnchor={config.runtime.horizontal ? 'start' : labelVerticalAnchor}
-                                  textAnchor={config.runtime.horizontal || labelsOnGridlines ? 'start' : 'end'}
+                                  textAnchor={config.runtime.horizontal || labelsAboveGridlines ? 'start' : 'end'}
                                   fill={config.yAxis.tickLabelColor}
                                   stroke={'#fff'}
-                                  disableStroke={!labelsOnGridlines}
+                                  disableStroke={!labelsAboveGridlines}
                                   strokeLinejoin='round'
                                   paintOrder={'stroke'} // keeps stroke under fill
                                   style={{ whiteSpace: 'pre-wrap' }} // prevents leading spaces from being trimmed

--- a/packages/core/components/BlurStrokeText.tsx
+++ b/packages/core/components/BlurStrokeText.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Text } from '@visx/text'
+
+// Extension for visx Text component that creates a second text element and a def with a blur effect to create a feathered stroke effect using a filter with Gaussian blur. No actual stroke is used
+
+export interface BlurStrokeTextProps extends React.ComponentProps<typeof Text> {
+  blurRadius?: number
+  stroke?: string
+  strokeWidth?: number
+  strokeMiterLimit?: number
+  disableStroke?: boolean
+  disableBlur?: boolean
+}
+
+export const BlurStrokeText: React.FC<BlurStrokeTextProps> = ({
+  blurRadius = 1,
+  stroke = 'white',
+  strokeWidth = 4.5,
+  strokeMiterLimit = 2,
+  disableStroke = false,
+  disableBlur = false,
+  ...props
+}) => {
+  return (
+    <>
+      <defs>
+        <filter id='blur' x='-50%' y='-50%' width='200%' height='200%'>
+          <feGaussianBlur in='SourceGraphic' stdDeviation={blurRadius} />
+        </filter>
+      </defs>
+      {!disableStroke && (
+        <Text
+          {...props}
+          filter={disableBlur ? undefined : 'url(#blur)'}
+          fill={stroke}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+          strokeMiterlimit={strokeMiterLimit}
+        />
+      )}
+      <Text {...props} />
+    </>
+  )
+}

--- a/packages/core/components/EditorPanel/Inputs.tsx
+++ b/packages/core/components/EditorPanel/Inputs.tsx
@@ -27,7 +27,8 @@ export type CheckboxProps = {
   min?: number
   i?: number
   className?: string
-} & Input
+} & Input &
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value'>
 
 export type SelectProps = {
   value?: string
@@ -40,7 +41,20 @@ export type SelectProps = {
 } & Input
 
 const TextField = memo((props: TextFieldProps) => {
-  const { display = true, label, tooltip, section = null, subsection = null, fieldName, updateField, value: stateValue, type = 'text', i = null, min = null, ...attributes } = props
+  const {
+    display = true,
+    label,
+    tooltip,
+    section = null,
+    subsection = null,
+    fieldName,
+    updateField,
+    value: stateValue,
+    type = 'text',
+    i = null,
+    min = null,
+    ...attributes
+  } = props
   const [value, setValue] = useState(stateValue)
   const [debouncedValue] = useDebounce(value, 500)
 
@@ -93,7 +107,17 @@ const TextField = memo((props: TextFieldProps) => {
 })
 
 const CheckBox = memo((props: CheckboxProps) => {
-  const { display = true, label, value, fieldName, section = null, subsection = null, tooltip, updateField, ...attributes } = props
+  const {
+    display = true,
+    label,
+    value,
+    fieldName,
+    section = null,
+    subsection = null,
+    tooltip,
+    updateField,
+    ...attributes
+  } = props
   if (!display) {
     return <></>
   }
@@ -117,7 +141,20 @@ const CheckBox = memo((props: CheckboxProps) => {
 })
 
 const Select = memo((props: SelectProps) => {
-  const { display = true, label, value, options, fieldName, section = null, subsection = null, required = false, tooltip, updateField, initial: initialValue, ...attributes } = props
+  const {
+    display = true,
+    label,
+    value,
+    options,
+    fieldName,
+    section = null,
+    subsection = null,
+    required = false,
+    tooltip,
+    updateField,
+    initial: initialValue,
+    ...attributes
+  } = props
   let optionsJsx = options.map((optionName, index) => (
     <option value={optionName} key={index}>
       {optionName}

--- a/packages/core/components/_stories/BlurStrokeTest.stories.tsx
+++ b/packages/core/components/_stories/BlurStrokeTest.stories.tsx
@@ -1,0 +1,27 @@
+import { a } from 'vitest/dist/suite-IbNSsUWN'
+import { BlurStrokeText } from '../BlurStrokeText'
+import { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta<typeof BlurStrokeText> = {
+  title: 'Components/Atoms/BlurStrokeText',
+  component: BlurStrokeText
+}
+
+export default meta
+
+type Story = StoryObj<typeof BlurStrokeText>
+
+export const Default: Story = {
+  render: args => (
+    <svg width='300' height='100' style={{ backgroundColor: '#464646' }}>
+      <BlurStrokeText {...args}>A feathered stroke option</BlurStrokeText>
+    </svg>
+  ),
+  args: {
+    fontSize: 15,
+    y: 50,
+    x: 50,
+    blurRadius: 1,
+    disableStroke: false
+  }
+}

--- a/packages/core/types/Axis.ts
+++ b/packages/core/types/Axis.ts
@@ -20,6 +20,7 @@ export type Axis = {
   label?: string
   labelOffset?: number
   labelPlacement?: string
+  labelsOnGridlines?: boolean
   manual?: boolean
   manualStep?: number
   max?: string

--- a/packages/core/types/Axis.ts
+++ b/packages/core/types/Axis.ts
@@ -20,7 +20,7 @@ export type Axis = {
   label?: string
   labelOffset?: number
   labelPlacement?: string
-  labelsOnGridlines?: boolean
+  labelsAboveGridlines?: boolean
   manual?: boolean
   manualStep?: number
   max?: string


### PR DESCRIPTION
## [DEV-9340](https://websupport-cdc.msappproxy.net/browse/DEV-9340)

Option to have Y Axis labels sit above of gridlines.

<img width="663" alt="Screenshot 2024-09-26 at 5 27 41 PM" src="https://github.com/user-attachments/assets/f1454ef0-aa25-46ec-84a7-0c4ece8ae192">

### Compatability
Only available on vertical LinearCharts

## New Feature: BlurStrokeText
<img width="318" alt="Screenshot 2024-09-27 at 4 38 56 PM" src="https://github.com/user-attachments/assets/1c040c4f-86cb-4733-b52d-90e025748495">
Extends the visx Text component. Used to add a softer stroke to text

## Testing Steps
Check out storybook previews and 
<img width="229" alt="Screenshot 2024-09-26 at 5 30 06 PM" src="https://github.com/user-attachments/assets/3dfd2d5b-bad6-4e2b-9212-ce59ba0f516c">

Build a chart in the editor and select the "Labels above gridlines" checkbox
***Show gridlines must be checked**
<img width="306" alt="Screenshot 2024-09-26 at 5 35 30 PM" src="https://github.com/user-attachments/assets/fecddc38-7afe-45ab-ab9c-31d77ca5bb6b">

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
