### PR TITLE
Dev-9125 Customizable Apply Filter Button Label

### DIFF
--- a/packages/core/components/EditorPanel/Inputs.tsx
+++ b/packages/core/components/EditorPanel/Inputs.tsx
@@ -17,6 +17,7 @@ export type TextFieldProps = {
   value: string | number
   type?: 'text' | 'number' | 'textarea' | 'date'
   min?: number
+  maxLength?: number
   max?: number
   i?: number
   id?: string

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/DashboardFiltersEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/DashboardFiltersEditor.tsx
@@ -6,7 +6,7 @@ import {
   AccordionItemPanel
 } from 'react-accessible-accordion'
 import { useContext, useMemo, useState } from 'react'
-import { CheckBox, Select } from '@cdc/core/components/EditorPanel/Inputs'
+import { CheckBox, Select, TextField } from '@cdc/core/components/EditorPanel/Inputs'
 import Tooltip from '@cdc/core/components/ui/Tooltip'
 import Icon from '@cdc/core/components/ui/Icon'
 import FieldSetWrapper from '@cdc/core/components/EditorPanel/FieldSetWrapper'
@@ -129,6 +129,16 @@ const DashboardFiltersEditor: React.FC<DashboardFitlersEditorProps> = ({ vizConf
               </Tooltip>
             }
           />
+          {vizConfig.filterBehavior === 'Apply Button' && (
+            <TextField
+              label='Apply Filter Button Text'
+              maxLength={20}
+              value={vizConfig.applyFiltersButtonText}
+              updateField={(_section, _subsection, _key, value) => {
+                updateConfig({ ...vizConfig, applyFiltersButtonText: value })
+              }}
+            />
+          )}
           {vizConfig.filterBehavior === 'Filter Change' && (
             <CheckBox
               label='Auto Load'

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
@@ -181,7 +181,7 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
               handleOnChange={handleOnChange}
             />
             {visualizationConfig.filterBehavior === FilterBehavior.Apply && !visualizationConfig.autoLoad && (
-              <button onClick={applyFilters}>GO!</button>
+              <button onClick={applyFilters}>{visualizationConfig.applyFiltersButtonText || 'GO!'}</button>
             )}
           </div>
         </Layout.Responsive>

--- a/packages/dashboard/src/types/DashboardFilters.ts
+++ b/packages/dashboard/src/types/DashboardFilters.ts
@@ -2,6 +2,7 @@ import { CommonVisualizationProperties } from '@cdc/core/types/Visualization'
 
 export type DashboardFilters = {
   sharedFilterIndexes: number[]
+  applyFiltersButtonText: string
   autoLoad?: boolean
   type: 'dashboardFilters'
 } & CommonVisualizationProperties


### PR DESCRIPTION
https://websupport.cdc.gov/projects/DEV/issues/DEV-9125

Allow a user to change the text of the Apply Filter Button that currently says GO!
There is a 20 character limit to the text 
If the Text box is left empty then the button text will remain GO!

Scenario: Open a Default Editor and choose the Dashboard Viz, select the "United States: State Sample Data" and then press Configure Your Data button

Expected: There is a Visualization box

1. Drag a Filter Dropdowns into the Visualization Box
2. Click on the tools icon

Expected: Filter Dropdowns editor opens up with a blank screen on the right.

3. Click on the General Accordion Tab
4. Select Apply Button in the Filter Behavior box
5. Click on the Filters Accordion Tab
6. Click the down arrow next to New Dashboard Filter 1
7. Select Data in the Filter Type selector
8. Select Dropdown in the Filter Style selector
9. Select State from the Filter selector

Expected: A new text box will appear under the Filter Behavior box. The filter on the right side will have a button that says GO!

10. Type in a new value into the Apply Filter Button Text box

Expected: The GO! button will text will change to what was written in the Apply Filter Button Text box. There is a 20 character limit to the text box. 

11. Delete the Text Value in the Apply Filter Button Text box

Expected: The Filter button will return to GO!

## Self Review

My changes generate no new warnings
