### PR TITLE
fix [dev-9461] data-table-standalone-expanded-by-default

### DIFF
--- a/packages/core/components/DataTable/DataTableStandAlone.tsx
+++ b/packages/core/components/DataTable/DataTableStandAlone.tsx
@@ -15,25 +15,56 @@ type StandAloneProps = {
   updateConfig?: (Visualization) => void
 }
 
-const DataTableStandAlone: React.FC<StandAloneProps> = ({ visualizationKey, config, updateConfig, viewport, isEditor }) => {
-  const [filteredData, setFilteredData] = useState<Record<string, any>[]>(filterVizData(config.filters, config.formattedData))
+const DataTableStandAlone: React.FC<StandAloneProps> = ({
+  visualizationKey,
+  config,
+  updateConfig,
+  viewport,
+  isEditor
+}) => {
+  const [filteredData, setFilteredData] = useState<Record<string, any>[]>(
+    filterVizData(config.filters, config.formattedData)
+  )
 
   useEffect(() => {
     // when using editor changes to filter should update the data
-    setFilteredData(filterVizData(config.filters, config?.formattedData?.length > 0 ? config.formattedData : config.data))
+    setFilteredData(
+      filterVizData(config.filters, config?.formattedData?.length > 0 ? config.formattedData : config.data)
+    )
   }, [config.filters])
 
   if (isEditor)
     return (
-      <EditorWrapper component={DataTableStandAlone} visualizationKey={visualizationKey} visualizationConfig={config} updateConfig={updateConfig} type={'Table'} viewport={viewport}>
+      <EditorWrapper
+        component={DataTableStandAlone}
+        visualizationKey={visualizationKey}
+        visualizationConfig={config}
+        updateConfig={updateConfig}
+        type={'Table'}
+        viewport={viewport}
+      >
         <DataTableEditorPanel key={visualizationKey} config={config} updateConfig={updateConfig} />
       </EditorWrapper>
     )
 
   return (
     <>
-      <Filters config={config} setConfig={updateConfig} setFilteredData={setFilteredData} filteredData={filteredData} excludedData={config.formattedData} />
-      <DataTable expandDataTable={true} config={config} rawData={config.data} runtimeData={filteredData} tabbingId={visualizationKey} tableTitle={config.table.label} viewport={viewport || 'lg'} />
+      <Filters
+        config={config}
+        setConfig={updateConfig}
+        setFilteredData={setFilteredData}
+        filteredData={filteredData}
+        excludedData={config.formattedData}
+      />
+      <DataTable
+        expandDataTable={config.table.expanded}
+        config={config}
+        rawData={config.data}
+        runtimeData={filteredData}
+        tabbingId={visualizationKey}
+        tableTitle={config.table.label}
+        viewport={viewport || 'lg'}
+      />
     </>
   )
 }


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

1) create standalone table.

Expected: Toggling 'expand by default' and navigating to the dashboard preview should show a matching expanded state on page load.

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
