### PR TITLE
(283) Bug fix: Territory Hexagon

### DIFF
--- a/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
+++ b/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
@@ -135,11 +135,11 @@ const TerritoryHexagon = ({ label, text, stroke, strokeWidth, textColor, territo
     )
   }
 
-  return (
+  return territoryData && (
     <svg viewBox='0 0 45 51' className='territory-wrapper--hex'>
       <g {...props}>
         <polygon stroke={stroke} strokeWidth={strokeWidth} points='22 0 44 12.702 44 38.105 22 50.807 0 38.105 0 12.702' />
-        {state.general.displayAsHex && hexagonLabel(territoryData ? territoryData : geo, stroke, false)}
+        {state.general.displayAsHex && hexagonLabel(territoryData, stroke, false)}
       </g>
     </svg>
   )


### PR DESCRIPTION
## 283

We are using the COVE library to create some visualizations in our web application (DNPAO Data Trends and Maps tool), and we found a bug in the hex map. When changing filters, such as switching between different years of data, we occasionally get the error "Something went wrong with component UsaMap". This occurs when a `<CdcMap>` component has a dynamic `data` prop and value changes such that the new value has fewer defined territories than the previous value.
 
In investigating the bug, we found that the error is happening at the end of `Territory.Hexagon.tsx`, where "geo is undefined" (section of code picture attached). In the code, there is a ternary conditional that returns a variable called `geo` which is never defined. We believe that modifying the code to not show the territory hexagon when there is no data (mirroring the behavior of the non-hex map) would fix the error.

## Testing Steps

Create a hex map with a dynamic `data` attribute of its `config`, then update this value such that there are fewer territories defined than the previous value.

## Screenshots

![image](https://github.com/user-attachments/assets/a20ea9c0-5d59-487d-8cc3-a50f7224d645)

![image](https://github.com/user-attachments/assets/c4da07cc-77c7-4583-ac57-665c361c2ce8)

