### PR TITLE
Fix: dev-8345 Stand-alone Table Excludes Option Doesn't Communicate Between Panels

### DIFF
--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -41,6 +41,7 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
 
   const excludeColumns = (section, subSection, fieldName, excludedColNames: string[]) => {
     const newColumns = _.cloneDeep(config.columns)
+
     const colNames: string[] = []
     for (let colKey in newColumns) {
       const col = newColumns[colKey]
@@ -48,6 +49,8 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
       if (excludedColNames.includes(col.name)) {
         // ensure all excluded columns are set to false
         newColumns[colKey].dataTable = false
+      } else {
+        newColumns[colKey].dataTable = true
       }
     }
     excludedColNames.forEach(colName => {


### PR DESCRIPTION
## DEV-8345
https://websupport.cdc.gov/projects/DEV/issues/DEV-8345

When you remove a column from the Exclude Columns section, it puts it back on the data table and it automatically checks "Show in Data Table" in the Column Configuration 

## Testing Steps

Scenario:

Open a Default Editor and choose the Dashboard Viz and in Configuration, upload [dev-8345-stand-alone-table-excludes.json](https://github.com/user-attachments/files/17416079/dev-8345-stand-alone-table-excludes.json) to Advanced Options, then click the tools Icon on the Table Viz

Instructions:

1. 	Open the Data Table section 
2. 	In the Exclude Columns multiselect, choose STATE

Expectations: The STATE column in the Table should be removed

3. 	Open Columns Section
4. Open the STATE configuration

Expectations: The "Show in data table" checkbox is not checked

5. 	Open the Data Table section again
6. Click the X next to STATE in the Exclude Columns Section

Expectations: The STATE column in the Table should be shown again

7. 	Open the Columns Section 
8. Open the STATE configuration

Expectations: The "Show in data table" checkbox is checked 

## Self Review

- My changes generate no new warnings
