### PR TITLE
[DEV-9416] X-axis improvements for time series charts

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -880,11 +880,11 @@ export default function CdcChart({
   const formatDate = (date, prevDate) => {
     let formattedDate = timeFormat(config.runtime[section].dateDisplayFormat)(date)
     // Handle the case where all months work with '%b.' except for May
-    if (config.runtime[section].dateDisplayFormat.includes('%b.') && formattedDate.includes('May.')) {
+    if (config.runtime[section].dateDisplayFormat?.includes('%b.') && formattedDate.includes('May.')) {
       formattedDate = formattedDate.replace(/May\./g, 'May')
     }
     // Show years only once
-    if (config.xAxis.showYearsOnce && config.runtime[section].dateDisplayFormat.includes('%Y') && prevDate) {
+    if (config.xAxis.showYearsOnce && config.runtime[section].dateDisplayFormat?.includes('%Y') && prevDate) {
       const prevFormattedDate = timeFormat(config.runtime[section].dateDisplayFormat)(prevDate)
       const year = formattedDate.match(/\d{4}/)
       const prevYear = prevFormattedDate.match(/\d{4}/)

--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -665,7 +665,7 @@ export default function CdcChart({
   const resizeObserver = new ResizeObserver(entries => {
     for (let entry of entries) {
       let { width, height } = entry.contentRect
-      let svgMarginWidth = 32
+      let svgMarginWidth = 30
       let editorWidth = 350
 
       width = isEditor ? width - editorWidth : width
@@ -877,8 +877,22 @@ export default function CdcChart({
     }
   }
 
-  const formatDate = date => {
-    return timeFormat(config.runtime[section].dateDisplayFormat)(date)
+  const formatDate = (date, prevDate) => {
+    let formattedDate = timeFormat(config.runtime[section].dateDisplayFormat)(date)
+    // Handle the case where all months work with '%b.' except for May
+    if (config.runtime[section].dateDisplayFormat.includes('%b.') && formattedDate.includes('May.')) {
+      formattedDate = formattedDate.replace(/May\./g, 'May')
+    }
+    // Show years only once
+    if (config.xAxis.showYearsOnce && config.runtime[section].dateDisplayFormat.includes('%Y') && prevDate) {
+      const prevFormattedDate = timeFormat(config.runtime[section].dateDisplayFormat)(prevDate)
+      const year = formattedDate.match(/\d{4}/)
+      const prevYear = prevFormattedDate.match(/\d{4}/)
+      if (year && prevYear && year[0] === prevYear[0]) {
+        formattedDate = formattedDate.replace(year, '')
+      }
+    }
+    return formattedDate
   }
 
   const formatTooltipsDate = date => {

--- a/packages/chart/src/_stories/ChartAxisLabels.stories.tsx
+++ b/packages/chart/src/_stories/ChartAxisLabels.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SimplifiedLineConfig from './_mock/simplified_line.json'
+
+import Chart from '../CdcChart'
+import { editConfigKeys } from '../helpers/configHelpers'
+
+const meta: Meta<typeof Chart> = {
+  title: 'Components/Templates/Chart/Axis Labels',
+  component: Chart
+}
+
+type Story = StoryObj<typeof Chart>
+
+export const Abbreviated_Dates: Story = {
+  args: {
+    config: editConfigKeys(SimplifiedLineConfig, [{ path: ['xAxis', 'showYearsOnce'], value: true }])
+  }
+}
+
+export default meta

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -2817,6 +2817,29 @@ const EditorPanel = () => {
                         }
                         updateField={updateField}
                       />
+                      <CheckBox
+                        value={config.xAxis.showYearsOnce}
+                        section='xAxis'
+                        fieldName='showYearsOnce'
+                        label='Show years once'
+                        tooltip={
+                          <Tooltip style={{ textTransform: 'none' }}>
+                            <Tooltip.Target>
+                              <Icon
+                                display='question'
+                                style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
+                              />
+                            </Tooltip.Target>
+                            <Tooltip.Content>
+                              <p>
+                                When this option is checked and the date format for the axis includes years, each year
+                                will only be shown once in the axis.
+                              </p>
+                            </Tooltip.Content>
+                          </Tooltip>
+                        }
+                        updateField={updateField}
+                      />
                       {visHasBrushChart() && (
                         <CheckBox
                           value={config.brush?.active}

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -107,6 +107,7 @@ const LinearChart: React.FC<LinearChartProps> = ({ parentHeight, parentWidth }) 
   const triggerRef = useRef()
   const xAxisLabelRefs = useRef([])
   const xAxisTitleRef = useRef(null)
+  const prevTickRef = useRef(null)
 
   const dataRef = useIntersectionObserver(triggerRef, {
     freezeOnceVisible: false
@@ -140,6 +141,16 @@ const LinearChart: React.FC<LinearChartProps> = ({ parentHeight, parentWidth }) 
     const legendShowingLeftOrRight = !isForestPlot && !legendHidden && !legendOnTopOrBottom && !legendWrapped
 
     if (!legendShowingLeftOrRight) return initialWidth
+
+    if (legendRef.current) {
+      const legendStyle = getComputedStyle(legendRef.current)
+      return (
+        initialWidth -
+        legendRef.current.getBoundingClientRect().width -
+        parseInt(legendStyle.marginLeft) -
+        parseInt(legendStyle.marginRight)
+      )
+    }
 
     return initialWidth * 0.73
   }, [dimensions[0], config.legend, currentViewport])
@@ -219,7 +230,11 @@ const LinearChart: React.FC<LinearChartProps> = ({ parentHeight, parentWidth }) 
       tick = 0
     }
 
-    if (isDateScale(runtime.xAxis) && config.visualizationType !== 'Forest Plot') return formatDate(tick)
+    if (isDateScale(runtime.xAxis) && config.visualizationType !== 'Forest Plot') {
+      const formattedDate = formatDate(tick, prevTickRef.current)
+      prevTickRef.current = tick
+      return formattedDate
+    }
     if (orientation === 'horizontal' && config.visualizationType !== 'Forest Plot')
       return formatNumber(tick, 'left', shouldAbbreviate)
     if (config.xAxis.type === 'continuous' && config.visualizationType !== 'Forest Plot')
@@ -1336,7 +1351,8 @@ const LinearChart: React.FC<LinearChartProps> = ({ parentHeight, parentWidth }) 
                   ? getTickValues(
                       xAxisDataMapped,
                       xScale,
-                      config.xAxis.type === 'date-time' ? countNumOfTicks('xAxis') : getManualStep()
+                      config.xAxis.type === 'date-time' ? countNumOfTicks('xAxis') : getManualStep(),
+                      config
                     )
                   : undefined
               }
@@ -1386,6 +1402,11 @@ const LinearChart: React.FC<LinearChartProps> = ({ parentHeight, parentWidth }) 
                     return
                   }
                 })
+
+                // Force wrap when showing years once so it's easier to read
+                if (config.xAxis.showYearsOnce) {
+                  areTicksTouching = true
+                }
 
                 const dynamicMarginTop =
                   areTicksTouching && config.isResponsiveTicks ? tickWidthMax + DEFAULT_TICK_LENGTH + 20 : 0

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -153,7 +153,7 @@ const LinearChart: React.FC<LinearChartProps> = ({ parentHeight, parentWidth }) 
     }
 
     return initialWidth * 0.73
-  }, [dimensions[0], config.legend, currentViewport])
+  }, [dimensions[0], config.legend, currentViewport, legendRef.current])
 
   // Used to calculate the y position of the x-axis title
   const bottomLabelStart = useMemo(() => {

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -127,7 +127,8 @@ export default {
     axisPadding: 200,
     target: 0,
     maxTickRotation: 0,
-    padding: 0
+    padding: 0,
+    showYearsOnce: false
   },
   table: {
     label: 'Data Table',

--- a/packages/core/types/Axis.ts
+++ b/packages/core/types/Axis.ts
@@ -40,6 +40,7 @@ export type Axis = {
   sortKey?: string
   showTargetLabel?: boolean
   size?: number
+  showYearsOnce?: boolean
   target?: number
   targetLabel?: string
   tickRotation?: number


### PR DESCRIPTION
## [DEV-9416]

This does four main things: 

* Makes abbreviated months with period work correctly for May
* Adds option to show each year only once in axis labels
* Padding only applies to left side
* Calculates the width of the chart correctly so gridlines extend to the end of the x-axis

## Testing Steps

Use the config attached to the ticket.

* Note that May is correctly formatted
* Toggle the "show years once" button in the date/category axis and see it has the desired effect
* Adjust the padding option in the date/category axis and see that it applies only to the left side
* Note that gridlines extend to the end of the x-axis

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

![Screenshot 2024-10-09 at 9 59 25 AM](https://github.com/user-attachments/assets/20615384-28f8-419c-bb15-3e6d50565d1f)


