### PR TITLE
Refactor [DEV-9285] top suffix behavior and implementation adjustment

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -46,7 +46,6 @@ import MediaControls from '@cdc/core/components/MediaControls'
 import Annotation from './components/Annotations'
 
 // Helpers
-import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 import { publish, subscribe, unsubscribe } from '@cdc/core/helpers/events'
 import useDataVizClasses from '@cdc/core/helpers/useDataVizClasses'
 import numberFromString from '@cdc/core/helpers/numberFromString'
@@ -1534,7 +1533,6 @@ const CdcChart = ({
     formatDate,
     formatNumber,
     formatTooltipsDate,
-    getTextWidth,
     getXAxisData,
     getYAxisData,
     handleChartAriaLabels,

--- a/packages/chart/src/_stories/ChartPrefixSuffix.stories.tsx
+++ b/packages/chart/src/_stories/ChartPrefixSuffix.stories.tsx
@@ -43,11 +43,20 @@ export const Top_Suffix_With_Options: Story = {
   }
 }
 
-export const Top_Suffix_One_Char: Story = {
+export const Top_Suffix_No_Space: Story = {
   args: {
     config: editConfigKeys(annotationConfig, [
       { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
-      { path: ['dataFormat', 'suffix'], value: '%' }
+      { path: ['dataFormat', 'suffix'], value: 'lbs' }
+    ])
+  }
+}
+
+export const Top_Suffix_With_Space: Story = {
+  args: {
+    config: editConfigKeys(annotationConfig, [
+      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
+      { path: ['dataFormat', 'suffix'], value: 'lbs of something' }
     ])
   }
 }

--- a/packages/chart/src/components/Axis/Categorical.Axis.tsx
+++ b/packages/chart/src/components/Axis/Categorical.Axis.tsx
@@ -7,9 +7,10 @@ import ConfigContext from '../../ConfigContext'
 import chroma from 'chroma-js'
 import createBarElement from '@cdc/core/components/createBarElement'
 import { useBarChart } from '../../hooks/useBarChart'
+import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 
 const CategoricalYAxis = ({ yMax, leftSize, max, xMax }) => {
-  const { config, getTextWidth } = useContext(ConfigContext)
+  const { config } = useContext(ConfigContext)
   const { fontSize } = useBarChart()
 
   const { orientation } = config

--- a/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
@@ -14,6 +14,7 @@ import { BarGroup } from '@visx/shape'
 import { getContrastColor } from '@cdc/core/helpers/cove/accessibility'
 import createBarElement from '@cdc/core/components/createBarElement'
 import { getBarConfig, testZeroValue } from '../helpers'
+import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 
 // Third party libraries
 import chroma from 'chroma-js'
@@ -24,9 +25,38 @@ import { ChartContext } from '../../../types/ChartContext'
 
 export const BarChartHorizontal = () => {
   const { xScale, yScale, yMax, seriesScale } = useContext<BarChartContextValues>(BarChartContext)
-  const { transformedData: data, tableData, colorScale, seriesHighlight, config, formatNumber, formatDate, parseDate, setSharedFilter, isNumber, getTextWidth, getYAxisData, getXAxisData } = useContext<ChartContext>(ConfigContext)
-  const { isHorizontal, barBorderWidth, updateBars, assignColorsToValues, section, fontSize, isLabelBelowBar, displayNumbersOnBar, lollipopBarWidth, lollipopShapeSize, getHighlightedBarColorByValue, getHighlightedBarByValue, getAdditionalColumn, hoveredBar, onMouseLeaveBar, onMouseOverBar } =
-    useBarChart()
+  const {
+    transformedData: data,
+    tableData,
+    colorScale,
+    seriesHighlight,
+    config,
+    formatNumber,
+    formatDate,
+    parseDate,
+    setSharedFilter,
+    isNumber,
+    getYAxisData,
+    getXAxisData
+  } = useContext<ChartContext>(ConfigContext)
+  const {
+    isHorizontal,
+    barBorderWidth,
+    updateBars,
+    assignColorsToValues,
+    section,
+    fontSize,
+    isLabelBelowBar,
+    displayNumbersOnBar,
+    lollipopBarWidth,
+    lollipopShapeSize,
+    getHighlightedBarColorByValue,
+    getHighlightedBarByValue,
+    getAdditionalColumn,
+    hoveredBar,
+    onMouseLeaveBar,
+    onMouseOverBar
+  } = useBarChart()
 
   const { HighLightedBarUtils } = useHighlightedBars(config)
 
@@ -49,13 +79,29 @@ export const BarChartHorizontal = () => {
         >
           {barGroups => {
             return updateBars(barGroups).map((barGroup, index) => (
-              <Group className={`bar-group-${barGroup.index}-${barGroup.x0}--${index} ${config.orientation}`} key={`bar-group-${barGroup.index}-${barGroup.x0}--${index}`} id={`bar-group-${barGroup.index}-${barGroup.x0}--${index}`} top={barGroup.y}>
+              <Group
+                className={`bar-group-${barGroup.index}-${barGroup.x0}--${index} ${config.orientation}`}
+                key={`bar-group-${barGroup.index}-${barGroup.x0}--${index}`}
+                id={`bar-group-${barGroup.index}-${barGroup.x0}--${index}`}
+                top={barGroup.y}
+              >
                 {barGroup.bars.map((bar, index) => {
                   const scaleVal = config.yAxis.type === 'logarithmic' ? 0.1 : 0
-                  let highlightedBarValues = config.highlightedBarValues.map(item => item.value).filter(item => item !== ('' || undefined))
-                  highlightedBarValues = config.xAxis.type === 'date' ? HighLightedBarUtils.formatDates(highlightedBarValues) : highlightedBarValues
-                  let transparentBar = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(bar.key) === -1
-                  let displayBar = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(bar.key) !== -1
+                  let highlightedBarValues = config.highlightedBarValues
+                    .map(item => item.value)
+                    .filter(item => item !== ('' || undefined))
+                  highlightedBarValues =
+                    config.xAxis.type === 'date'
+                      ? HighLightedBarUtils.formatDates(highlightedBarValues)
+                      : highlightedBarValues
+                  let transparentBar =
+                    config.legend.behavior === 'highlight' &&
+                    seriesHighlight.length > 0 &&
+                    seriesHighlight.indexOf(bar.key) === -1
+                  let displayBar =
+                    config.legend.behavior === 'highlight' ||
+                    seriesHighlight.length === 0 ||
+                    seriesHighlight.indexOf(bar.key) !== -1
                   let barHeight = config.barHeight
                   let numbericBarHeight = parseInt(!config.isLollipopChart ? barHeight : lollipopBarWidth)
                   if (isNaN(numbericBarHeight)) {
@@ -65,10 +111,17 @@ export const BarChartHorizontal = () => {
                   const defaultBarWidth = Math.abs(xScale(bar.value) - xScale(scaleVal))
                   const isPositiveBar = bar.value >= 0 && isNumber(bar.value)
 
-                  const { barWidthHorizontal: barWidth, isSuppressed, getAbsentDataLabel } = getBarConfig({ bar, defaultBarWidth, config, isNumber, getTextWidth, isVertical: false })
+                  const {
+                    barWidthHorizontal: barWidth,
+                    isSuppressed,
+                    getAbsentDataLabel
+                  } = getBarConfig({ bar, defaultBarWidth, config, isNumber, isVertical: false })
                   const barX = bar.value < 0 ? Math.abs(xScale(bar.value)) : xScale(scaleVal)
                   const yAxisValue = formatNumber(bar.value, 'left')
-                  const xAxisValue = config.runtime[section].type === 'date' ? formatDate(parseDate(data[barGroup.index][config.runtime.originalXAxis.dataKey])) : data[barGroup.index][config.runtime.originalXAxis.dataKey]
+                  const xAxisValue =
+                    config.runtime[section].type === 'date'
+                      ? formatDate(parseDate(data[barGroup.index][config.runtime.originalXAxis.dataKey]))
+                      : data[barGroup.index][config.runtime.originalXAxis.dataKey]
 
                   const barPosition = !isPositiveBar ? 'below' : 'above'
                   const absentDataLabel = getAbsentDataLabel(yAxisValue)
@@ -96,7 +149,9 @@ export const BarChartHorizontal = () => {
                   // create new Index for bars with negative values
                   const newIndex = bar.value < 0 ? -1 : index
 
-                  let yAxisTooltip = config.runtime.yAxis.label ? `${config.runtime.yAxis.label}: ${xAxisValue}` : xAxisValue
+                  let yAxisTooltip = config.runtime.yAxis.label
+                    ? `${config.runtime.yAxis.label}: ${xAxisValue}`
+                    : xAxisValue
                   const additionalColTooltip = getAdditionalColumn(hoveredBar)
                   const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${yAxisValue}`
                   const tooltip = `<ul>
@@ -108,15 +163,28 @@ export const BarChartHorizontal = () => {
                   // configure colors
                   let labelColor = '#000000'
                   labelColor = HighLightedBarUtils.checkFontColor(yAxisValue, highlightedBarValues, labelColor) // Set if background is transparent'
-                  let barColor = config.runtime.seriesLabels && config.runtime.seriesLabels[bar.key] ? colorScale(config.runtime.seriesLabels[bar.key]) : colorScale(bar.key)
+                  let barColor =
+                    config.runtime.seriesLabels && config.runtime.seriesLabels[bar.key]
+                      ? colorScale(config.runtime.seriesLabels[bar.key])
+                      : colorScale(bar.key)
                   barColor = assignColorsToValues(barGroups.length, barGroup.index, barColor) // Color code by category
                   const isRegularLollipopColor = config.isLollipopChart && config.lollipopColorStyle === 'regular'
                   const isTwoToneLollipopColor = config.isLollipopChart && config.lollipopColorStyle === 'two-tone'
                   const isHighlightedBar = highlightedBarValues?.includes(xAxisValue)
                   const highlightedBarColor = getHighlightedBarColorByValue(xAxisValue)
                   const highlightedBar = getHighlightedBarByValue(xAxisValue)
-                  const borderColor = isHighlightedBar ? highlightedBarColor : config.barHasBorder === 'true' ? '#000' : 'transparent'
-                  const borderWidth = isHighlightedBar ? highlightedBar.borderWidth : config.isLollipopChart ? 0 : config.barHasBorder === 'true' ? barBorderWidth : 0
+                  const borderColor = isHighlightedBar
+                    ? highlightedBarColor
+                    : config.barHasBorder === 'true'
+                    ? '#000'
+                    : 'transparent'
+                  const borderWidth = isHighlightedBar
+                    ? highlightedBar.borderWidth
+                    : config.isLollipopChart
+                    ? 0
+                    : config.barHasBorder === 'true'
+                    ? barBorderWidth
+                    : 0
                   const displaylollipopShape = testZeroValue(bar.value) ? 'none' : 'block'
 
                   // update label color
@@ -176,7 +244,12 @@ export const BarChartHorizontal = () => {
 
                           const hasAsterisk = String(pd.symbol).includes('Asterisk')
                           const verticalAnchor = hasAsterisk ? 'middle' : 'end'
-                          const iconSize = pd.symbol === 'Asterisk' ? barHeight * 1.2 : pd.symbol === 'Double Asterisk' ? barHeight : barHeight / 1.5
+                          const iconSize =
+                            pd.symbol === 'Asterisk'
+                              ? barHeight * 1.2
+                              : pd.symbol === 'Double Asterisk'
+                              ? barHeight
+                              : barHeight / 1.5
                           const fillColor = pd.displayGray ? '#8b8b8a' : '#000'
                           return (
                             <Text // prettier-ignore
@@ -240,7 +313,13 @@ export const BarChartHorizontal = () => {
                           </Text>
                         )}
                         {isLabelBelowBar && !config.yAxis.hideLabel && (
-                          <Text x={config.yAxis.hideAxis ? 0 : 5} y={barGroup.height} dy={4} verticalAnchor={'start'} textAnchor={'start'}>
+                          <Text
+                            x={config.yAxis.hideAxis ? 0 : 5}
+                            y={barGroup.height}
+                            dy={4}
+                            verticalAnchor={'start'}
+                            textAnchor={'start'}
+                          >
                             {config.runtime.yAxis.type === 'date'
                               ? formatDate(parseDate(data[barGroup.index][config.runtime.originalXAxis.dataKey]))
                               : isHorizontal

--- a/packages/chart/src/components/BarChart/components/BarChart.StackedHorizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.StackedHorizontal.tsx
@@ -5,6 +5,7 @@ import { BarStackHorizontal } from '@visx/shape'
 import { Group } from '@visx/group'
 import { Text } from '@visx/text'
 import { getContrastColor } from '@cdc/core/helpers/cove/accessibility'
+import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 
 // types
 import BarChartContext, { type BarChartContextValues } from './context'
@@ -22,7 +23,6 @@ const BarChartStackedHorizontal = () => {
     config,
     formatDate,
     formatNumber,
-    getTextWidth,
     parseDate,
     seriesHighlight,
     setSharedFilter,
@@ -37,18 +37,38 @@ const BarChartStackedHorizontal = () => {
     config.visualizationSubType === 'stacked' &&
     isHorizontal && (
       <>
-        <BarStackHorizontal data={data} keys={barStackedSeriesKeys} height={yMax} y={d => d[config.runtime.yAxis.dataKey]} xScale={xScale} yScale={yScale} color={colorScale} offset='none'>
+        <BarStackHorizontal
+          data={data}
+          keys={barStackedSeriesKeys}
+          height={yMax}
+          y={d => d[config.runtime.yAxis.dataKey]}
+          xScale={xScale}
+          yScale={yScale}
+          color={colorScale}
+          offset='none'
+        >
           {barStacks =>
             barStacks.map(barStack =>
               updateBars(barStack.bars).map((bar, index) => {
-                const transparentBar = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(bar.key) === -1
-                const displayBar = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(bar.key) !== -1
+                const transparentBar =
+                  config.legend.behavior === 'highlight' &&
+                  seriesHighlight.length > 0 &&
+                  seriesHighlight.indexOf(bar.key) === -1
+                const displayBar =
+                  config.legend.behavior === 'highlight' ||
+                  seriesHighlight.length === 0 ||
+                  seriesHighlight.indexOf(bar.key) !== -1
                 config.barHeight = Number(config.barHeight)
                 const labelColor = getContrastColor('#000', colorScale(config.runtime.seriesLabels[bar.key]))
                 // tooltips
                 const xAxisValue = formatNumber(data[bar.index][bar.key], 'left')
-                const yAxisValue = config.runtime.yAxis.type === 'date' ? formatDate(parseDate(data[bar.index][config.runtime.originalXAxis.dataKey])) : data[bar.index][config.runtime.originalXAxis.dataKey]
-                const yAxisTooltip = config.runtime.yAxis.label ? `${config.runtime.yAxis.label}: ${yAxisValue}` : yAxisValue
+                const yAxisValue =
+                  config.runtime.yAxis.type === 'date'
+                    ? formatDate(parseDate(data[bar.index][config.runtime.originalXAxis.dataKey]))
+                    : data[bar.index][config.runtime.originalXAxis.dataKey]
+                const yAxisTooltip = config.runtime.yAxis.label
+                  ? `${config.runtime.yAxis.label}: ${yAxisValue}`
+                  : yAxisValue
                 const textWidth = getTextWidth(xAxisValue, `normal ${fontSize[config.fontSize]}px sans-serif`)
                 const additionalColTooltip = getAdditionalColumn(hoveredBar)
                 const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${xAxisValue}`
@@ -93,17 +113,21 @@ const BarChartStackedHorizontal = () => {
                         }
                       })}
 
-                      {orientation === 'horizontal' && visualizationSubType === 'stacked' && isLabelBelowBar && barStack.index === 0 && !config.yAxis.hideLabel && (
-                        <Text
-                          x={`${bar.x + (config.isLollipopChart ? 15 : 5)}`} // padding
-                          y={bar.y + bar.height * 1.2}
-                          fill={'#000000'}
-                          textAnchor='start'
-                          verticalAnchor='start'
-                        >
-                          {yAxisValue}
-                        </Text>
-                      )}
+                      {orientation === 'horizontal' &&
+                        visualizationSubType === 'stacked' &&
+                        isLabelBelowBar &&
+                        barStack.index === 0 &&
+                        !config.yAxis.hideLabel && (
+                          <Text
+                            x={`${bar.x + (config.isLollipopChart ? 15 : 5)}`} // padding
+                            y={bar.y + bar.height * 1.2}
+                            fill={'#000000'}
+                            textAnchor='start'
+                            verticalAnchor='start'
+                          >
+                            {yAxisValue}
+                          </Text>
+                        )}
 
                       {displayNumbersOnBar && textWidth < bar.width && (
                         <Text

--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -42,7 +42,7 @@ export const BarChartVertical = () => {
   } = useBarChart()
 
   // prettier-ignore
-  const { colorScale, config, dashboardConfig, tableData, formatDate, formatNumber, getXAxisData, getYAxisData, isNumber, parseDate, seriesHighlight, setSharedFilter, transformedData, brushConfig, getTextWidth } = useContext<ChartContext>(ConfigContext)
+  const { colorScale, config, dashboardConfig, tableData, formatDate, formatNumber, getXAxisData, getYAxisData, isNumber, parseDate, seriesHighlight, setSharedFilter, transformedData, brushConfig } = useContext<ChartContext>(ConfigContext)
   const { HighLightedBarUtils } = useHighlightedBars(config)
   let data = transformedData
   // check if user add suppression
@@ -168,7 +168,6 @@ export const BarChartVertical = () => {
                     defaultBarHeight,
                     config,
                     isNumber,
-                    getTextWidth,
                     barWidth,
                     isVertical: true,
                     yAxisValue

--- a/packages/chart/src/components/BarChart/helpers/index.ts
+++ b/packages/chart/src/components/BarChart/helpers/index.ts
@@ -1,3 +1,5 @@
+import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
+
 // Define an interface for the function's parameter
 interface BarConfigProps {
   defaultBarWidth?: number
@@ -5,7 +7,6 @@ interface BarConfigProps {
   bar?: { [key: string]: any }
   isNumber?: Function
   config: { [key: string]: any }
-  getTextWidth: (a: string, b: string) => string
   barWidth: number
   isVertical: boolean
 }
@@ -17,7 +18,6 @@ export const getBarConfig = ({
   defaultBarWidth,
   config,
   isNumber,
-  getTextWidth,
   barWidth,
   isVertical
 }: BarConfigProps) => {

--- a/packages/chart/src/components/BrushChart.tsx
+++ b/packages/chart/src/components/BrushChart.tsx
@@ -2,15 +2,16 @@ import { Group } from '@visx/group'
 import { useContext, useEffect, useRef, useState } from 'react'
 import ConfigContext from '../ConfigContext'
 import * as d3 from 'd3'
-import { invertValue } from '@cdc/core/helpers/scaling'
 import { Text } from '@visx/text'
+import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
+
 interface BrushChartProps {
   xMax: number
   yMax: number
 }
 
 const BrushChart = ({ xMax, yMax }: BrushChartProps) => {
-  const { tableData, config, setBrushConfig, getTextWidth, dashboardConfig, formatDate } = useContext(ConfigContext)
+  const { tableData, config, setBrushConfig, dashboardConfig, formatDate } = useContext(ConfigContext)
   const [brushState, setBrushState] = useState({ isBrushing: false, selection: [] })
   const [brushKey, setBrushKey] = useState(0)
   const sharedFilters = dashboardConfig?.dashboard?.sharedFilters ?? []

--- a/packages/chart/src/components/DeviationBar.jsx
+++ b/packages/chart/src/components/DeviationBar.jsx
@@ -6,13 +6,30 @@ import { Text } from '@visx/text'
 import ErrorBoundary from '@cdc/core/components/ErrorBoundary'
 import useIntersectionObserver from '../hooks/useIntersectionObserver'
 import { getContrastColor } from '@cdc/core/helpers/cove/accessibility'
+import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 
 export default function DeviationBar({ height, xScale }) {
-  const { transformedData: data, config, formatNumber, twoColorPalette, getTextWidth, updateConfig, parseDate, formatDate, currentViewport } = useContext(ConfigContext)
+  const {
+    transformedData: data,
+    config,
+    formatNumber,
+    twoColorPalette,
+    updateConfig,
+    parseDate,
+    formatDate,
+    currentViewport
+  } = useContext(ConfigContext)
   const { barStyle, tipRounding, roundingStyle, twoColor } = config
   const barRefs = useRef([])
   const [windowWidth, setWindowWidth] = useState(window.innerWidth)
-  const radius = roundingStyle === 'standard' ? '8px' : roundingStyle === 'shallow' ? '5px' : roundingStyle === 'finger' ? '15px' : '0px'
+  const radius =
+    roundingStyle === 'standard'
+      ? '8px'
+      : roundingStyle === 'shallow'
+      ? '5px'
+      : roundingStyle === 'finger'
+      ? '15px'
+      : '0px'
   const fontSize = { small: 16, medium: 18, large: 20 }
   const isRounded = config.barStyle === 'rounded'
   const target = Number(config.xAxis.target)
@@ -148,7 +165,10 @@ export default function DeviationBar({ height, xScale }) {
           config.heights.horizontal = totalheight
 
           // text,labels postiions
-          const textWidth = getTextWidth(formatNumber(barValue, 'left'), `normal ${fontSize[config.fontSize]}px sans-serif`)
+          const textWidth = getTextWidth(
+            formatNumber(barValue, 'left'),
+            `normal ${fontSize[config.fontSize]}px sans-serif`
+          )
           const textFits = textWidth < barWidth - 6
           const textX = barBaseX
           const textY = barY + barHeight / 2
@@ -167,7 +187,10 @@ export default function DeviationBar({ height, xScale }) {
           let textProps = getTextProps(config.isLollipopChart, textFits, lollipopShapeSize, fill)
           // tooltips
           const xAxisValue = formatNumber(barValue, 'left')
-          const yAxisValue = config.runtime.yAxis.type === 'date' ? formatDate(parseDate(data[index][config.runtime.originalXAxis.dataKey])) : data[index][config.runtime.originalXAxis.dataKey]
+          const yAxisValue =
+            config.runtime.yAxis.type === 'date'
+              ? formatDate(parseDate(data[index][config.runtime.originalXAxis.dataKey]))
+              : data[index][config.runtime.originalXAxis.dataKey]
           let yAxisTooltip = config.runtime.yAxis.label ? `${config.runtime.yAxis.label}: ${yAxisValue}` : yAxisValue
           let xAxisTooltip = config.runtime.xAxis.label ? `${config.runtime.xAxis.label}: ${xAxisValue}` : xAxisValue
           const tooltip = `<div>
@@ -190,7 +213,15 @@ export default function DeviationBar({ height, xScale }) {
                 data-tooltip-id={`cdc-open-viz-tooltip-${config.runtime.uniqueId}`}
                 tabIndex={-1}
               >
-                <div style={{ width: barWidth, height: barHeight, border: `${borderWidth}px solid #333`, backgroundColor: barColor[barPosition], ...borderRadius }}></div>
+                <div
+                  style={{
+                    width: barWidth,
+                    height: barHeight,
+                    border: `${borderWidth}px solid #333`,
+                    backgroundColor: barColor[barPosition],
+                    ...borderRadius
+                  }}
+                ></div>
               </foreignObject>
               {config.yAxis.displayNumbersOnBar && (
                 <Text verticalAnchor='middle' x={textX} y={textY} {...textProps[barPosition]}>
@@ -198,8 +229,25 @@ export default function DeviationBar({ height, xScale }) {
                 </Text>
               )}
 
-              {config.isLollipopChart && config.lollipopShape === 'circle' && <circle cx={circleX} cy={circleY} r={lollipopShapeSize / 2} fill={barColor[barPosition]} style={{ filter: 'unset', opacity: 1 }} />}
-              {config.isLollipopChart && config.lollipopShape === 'square' && <rect x={squareX} y={squareY} width={lollipopShapeSize} height={lollipopShapeSize} fill={barColor[barPosition]} style={{ opacity: 1, filter: 'unset' }}></rect>}
+              {config.isLollipopChart && config.lollipopShape === 'circle' && (
+                <circle
+                  cx={circleX}
+                  cy={circleY}
+                  r={lollipopShapeSize / 2}
+                  fill={barColor[barPosition]}
+                  style={{ filter: 'unset', opacity: 1 }}
+                />
+              )}
+              {config.isLollipopChart && config.lollipopShape === 'square' && (
+                <rect
+                  x={squareX}
+                  y={squareY}
+                  width={lollipopShapeSize}
+                  height={lollipopShapeSize}
+                  fill={barColor[barPosition]}
+                  style={{ opacity: 1, filter: 'unset' }}
+                ></rect>
+              )}
             </Group>
           )
         })}
@@ -209,7 +257,9 @@ export default function DeviationBar({ height, xScale }) {
           </Text>
         )}
 
-        {shouldShowTargetLine && <Line from={{ x: targetX, y: 0 }} to={{ x: targetX, y: height }} stroke='#333' strokeWidth={2} />}
+        {shouldShowTargetLine && (
+          <Line from={{ x: targetX, y: 0 }} to={{ x: targetX, y: height }} stroke='#333' strokeWidth={2} />
+        )}
       </Group>
       <foreignObject y={height / 2} ref={targetRef}></foreignObject>
     </ErrorBoundary>

--- a/packages/chart/src/components/Legend/Legend.Component.tsx
+++ b/packages/chart/src/components/Legend/Legend.Component.tsx
@@ -28,7 +28,6 @@ export interface LegendProps {
   seriesHighlight: string[]
   skipId: string
   dimensions: DimensionsType // for responsive width legend
-  getTextWidth: (text: string, font: string) => string
 }
 
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex, jsx-a11y/no-static-element-interactions */
@@ -43,8 +42,7 @@ const Legend: React.FC<LegendProps> = forwardRef(
       currentViewport,
       formatLabels,
       skipId = 'legend',
-      dimensions,
-      getTextWidth
+      dimensions
     },
     ref
   ) => {
@@ -77,7 +75,6 @@ const Legend: React.FC<LegendProps> = forwardRef(
         {legend.label && <h3>{parse(legend.label)}</h3>}
         {legend.description && <p>{parse(legend.description)}</p>}
         <LegendGradient
-          getTextWidth={getTextWidth}
           config={config}
           {...getGradientConfig(config, formatLabels, colorScale)}
           dimensions={dimensions}

--- a/packages/chart/src/components/Legend/Legend.tsx
+++ b/packages/chart/src/components/Legend/Legend.tsx
@@ -17,7 +17,6 @@ const Legend = forwardRef((props, ref) => {
     transformedData: data,
     currentViewport,
     dimensions,
-    getTextWidth,
   } = useContext(ConfigContext)
   if (!config.legend) return null
   // create fn to reverse labels while legend is Bottom.  Legend-right , legend-left works by default.
@@ -28,7 +27,6 @@ const Legend = forwardRef((props, ref) => {
     !['Box Plot'].includes(config.visualizationType) && (
       <Fragment>
         <LegendComponent
-          getTextWidth={getTextWidth}
           dimensions={dimensions}
           ref={ref}
           skipId={props.skipId || 'legend'}

--- a/packages/chart/src/components/PairedBarChart.jsx
+++ b/packages/chart/src/components/PairedBarChart.jsx
@@ -6,9 +6,10 @@ import { Text } from '@visx/text'
 
 import ConfigContext from '../ConfigContext'
 import { getContrastColor } from '@cdc/core/helpers/cove/accessibility'
+import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 
 const PairedBarChart = ({ width, height, originalWidth }) => {
-  const { config, colorScale, transformedData: data, formatNumber, seriesHighlight, getTextWidth } = useContext(ConfigContext)
+  const { config, colorScale, transformedData: data, formatNumber, seriesHighlight } = useContext(ConfigContext)
 
   if (!config || config?.series?.length < 2) return
 
@@ -79,14 +80,27 @@ const PairedBarChart = ({ width, height, originalWidth }) => {
 				}
 				`}
         </style>
-        <svg id='cdc-visualization__paired-bar-chart' width={originalWidth} height={height} viewBox={`0 0 ${width + Number(config.runtime.yAxis.size)} ${height}`} role='img' tabIndex={0}>
+        <svg
+          id='cdc-visualization__paired-bar-chart'
+          width={originalWidth}
+          height={height}
+          viewBox={`0 0 ${width + Number(config.runtime.yAxis.size)} ${height}`}
+          role='img'
+          tabIndex={0}
+        >
           <title>{`Paired bar chart graphic with the title ${config.title ? config.title : 'No Title Found'}`}</title>
           <Group top={0} left={Number(config.xAxis.size)}>
             {data
               .filter(item => config.series[0].dataKey === groupOne.dataKey)
               .map((d, index) => {
-                let transparentBar = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(config.series[0].dataKey) === -1
-                let displayBar = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(config.series[0].dataKey) !== -1
+                let transparentBar =
+                  config.legend.behavior === 'highlight' &&
+                  seriesHighlight.length > 0 &&
+                  seriesHighlight.indexOf(config.series[0].dataKey) === -1
+                let displayBar =
+                  config.legend.behavior === 'highlight' ||
+                  seriesHighlight.length === 0 ||
+                  seriesHighlight.indexOf(config.series[0].dataKey) !== -1
                 let barWidth = xScale(d[config.series[0].dataKey])
                 let barHeight = Number(config.barHeight) ? Number(config.barHeight) : 25
                 // update bar Y to give dynamic Y when user applyes BarSpace
@@ -95,7 +109,10 @@ const PairedBarChart = ({ width, height, originalWidth }) => {
                 const totalheight = (Number(config.barSpace) + barHeight + borderWidth) * data.length
                 config.heights.horizontal = totalheight
                 // check if text fits inside of the  bar including suffix/prefix,comma,fontSize ..etc
-                const textWidth = getTextWidth(formatNumber(d[groupOne.dataKey], 'left'), `normal ${fontSize[config.fontSize]}px sans-serif`)
+                const textWidth = getTextWidth(
+                  formatNumber(d[groupOne.dataKey], 'left'),
+                  `normal ${fontSize[config.fontSize]}px sans-serif`
+                )
                 const textFits = textWidth < barWidth - 5 // minus padding dx(5)
 
                 return (
@@ -119,7 +136,14 @@ const PairedBarChart = ({ width, height, originalWidth }) => {
                         tabIndex={-1}
                       />
                       {config.yAxis.displayNumbersOnBar && displayBar && (
-                        <Text textAnchor={textFits ? 'start' : 'end'} dx={textFits ? 5 : -5} verticalAnchor='middle' x={halfWidth - barWidth} y={y + config.barHeight / 2} fill={textFits ? groupOne.labelColor : '#000'}>
+                        <Text
+                          textAnchor={textFits ? 'start' : 'end'}
+                          dx={textFits ? 5 : -5}
+                          verticalAnchor='middle'
+                          x={halfWidth - barWidth}
+                          y={y + config.barHeight / 2}
+                          fill={textFits ? groupOne.labelColor : '#000'}
+                        >
                           {formatNumber(d[groupOne.dataKey], 'left')}
                         </Text>
                       )}
@@ -131,8 +155,14 @@ const PairedBarChart = ({ width, height, originalWidth }) => {
               .filter(item => config.series[1].dataKey === groupTwo.dataKey)
               .map((d, index) => {
                 let barWidth = xScale(d[config.series[1].dataKey])
-                let transparentBar = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(config.series[1].dataKey) === -1
-                let displayBar = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(config.series[1].dataKey) !== -1
+                let transparentBar =
+                  config.legend.behavior === 'highlight' &&
+                  seriesHighlight.length > 0 &&
+                  seriesHighlight.indexOf(config.series[1].dataKey) === -1
+                let displayBar =
+                  config.legend.behavior === 'highlight' ||
+                  seriesHighlight.length === 0 ||
+                  seriesHighlight.indexOf(config.series[1].dataKey) !== -1
                 let barHeight = config.barHeight ? Number(config.barHeight) : 25
                 // update bar Y to give dynamic Y when user applyes BarSpace
                 let y = 0
@@ -140,7 +170,10 @@ const PairedBarChart = ({ width, height, originalWidth }) => {
                 const totalheight = (Number(config.barSpace) + barHeight + borderWidth) * data.length
                 config.heights.horizontal = totalheight
                 // check if text fits inside of the  bar including suffix/prefix,comma,fontSize ..etc
-                const textWidth = getTextWidth(formatNumber(d[groupTwo.dataKey], 'left'), `normal ${fontSize[config.fontSize]}px sans-serif`)
+                const textWidth = getTextWidth(
+                  formatNumber(d[groupTwo.dataKey], 'left'),
+                  `normal ${fontSize[config.fontSize]}px sans-serif`
+                )
                 const isTextFits = textWidth < barWidth - 5 // minus padding dx(5)
 
                 return (
@@ -171,7 +204,14 @@ const PairedBarChart = ({ width, height, originalWidth }) => {
                         tabIndex={-1}
                       />
                       {config.yAxis.displayNumbersOnBar && displayBar && (
-                        <Text textAnchor={isTextFits ? 'end' : 'start'} dx={isTextFits ? -5 : 5} verticalAnchor='middle' x={halfWidth + barWidth} y={y + config.barHeight / 2} fill={isTextFits ? groupTwo.labelColor : '#000'}>
+                        <Text
+                          textAnchor={isTextFits ? 'end' : 'start'}
+                          dx={isTextFits ? -5 : 5}
+                          verticalAnchor='middle'
+                          x={halfWidth + barWidth}
+                          y={y + config.barHeight / 2}
+                          fill={isTextFits ? groupTwo.labelColor : '#000'}
+                        >
                           {formatNumber(d[groupTwo.dataKey], 'left')}
                         </Text>
                       )}

--- a/packages/chart/src/components/ZoomBrush.tsx
+++ b/packages/chart/src/components/ZoomBrush.tsx
@@ -7,6 +7,7 @@ import ConfigContext from '../ConfigContext'
 import { ScaleLinear, ScaleBand } from 'd3-scale'
 import { isDateScale } from '@cdc/core/helpers/cove/date'
 import ErrorBoundary from '@cdc/core/components/ErrorBoundary'
+import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 
 interface Props {
   xScaleBrush: ScaleLinear<number, number>
@@ -15,7 +16,7 @@ interface Props {
   yMax: number
 }
 const ZoomBrush: FC<Props> = props => {
-  const { tableData, config, parseDate, formatDate, setBrushConfig, getTextWidth, dashboardConfig } = useContext(ConfigContext)
+  const { tableData, config, parseDate, formatDate, setBrushConfig, dashboardConfig } = useContext(ConfigContext)
   const sharedFilters = dashboardConfig?.dashboard?.sharedFilters ?? []
   const isDashboardFilters = sharedFilters?.length > 0
   const { fontSize } = useBarChart()
@@ -175,7 +176,6 @@ const ZoomBrush: FC<Props> = props => {
             <BrushHandle
               left={Number(config.runtime.yAxis.size)}
               showTooltip={showTooltip}
-              getTextWidth={getTextWidth}
               pixelDistance={textProps.endPosition - textProps.startPosition}
               textProps={textProps}
               fontSize={fontSize[config.fontSize]}
@@ -202,7 +202,7 @@ const ZoomBrush: FC<Props> = props => {
 }
 
 const BrushHandle = props => {
-  const { x, isBrushActive, isBrushing, className, textProps, fontSize, showTooltip, left, getTextWidth } = props
+  const { x, isBrushActive, isBrushing, className, textProps, fontSize, showTooltip, left } = props
   const pathWidth = 8
   if (!isBrushActive) {
     return null
@@ -217,15 +217,34 @@ const BrushHandle = props => {
   return (
     <>
       {showTooltip && (
-        <Text x={(Number(textProps.xMax) - textWidth) / 2} dy={-12} pointerEvents='visiblePainted' fontSize={fontSize / 1.1}>
+        <Text
+          x={(Number(textProps.xMax) - textWidth) / 2}
+          dy={-12}
+          pointerEvents='visiblePainted'
+          fontSize={fontSize / 1.1}
+        >
           {tooltipText}
         </Text>
       )}
       <Group left={x + pathWidth / 2} top={-2}>
-        <Text pointerEvents='visiblePainted' dominantBaseline='hanging' x={isLeft ? 55 : -50} y={25} verticalAnchor='start' textAnchor={textAnchor} fontSize={fontSize / 1.4}>
+        <Text
+          pointerEvents='visiblePainted'
+          dominantBaseline='hanging'
+          x={isLeft ? 55 : -50}
+          y={25}
+          verticalAnchor='start'
+          textAnchor={textAnchor}
+          fontSize={fontSize / 1.4}
+        >
           {isLeft ? textProps.startValue : textProps.endValue}
         </Text>
-        <path cursor='ew-resize' d='M0.5,10A6,6 0 0 1 6.5,16V14A6,6 0 0 1 0.5,20ZM2.5,18V12M4.5,18V12' fill={'#297EF1'} strokeWidth='1' transform={transform}></path>
+        <path
+          cursor='ew-resize'
+          d='M0.5,10A6,6 0 0 1 6.5,16V14A6,6 0 0 1 0.5,20ZM2.5,18V12M4.5,18V12'
+          fill={'#297EF1'}
+          strokeWidth='1'
+          transform={transform}
+        ></path>
       </Group>
     </>
   )

--- a/packages/chart/src/types/ChartContext.ts
+++ b/packages/chart/src/types/ChartContext.ts
@@ -20,7 +20,6 @@ type SharedChartContext = {
   config: ChartConfig
   currentViewport?: 'lg' | 'md' | 'sm' | 'xs' | 'xxs'
   dashboardConfig?: DashboardConfig
-  getTextWidth?: (a: string, b: string) => string
   // process top level chart aria label for each chart type
   handleChartAriaLabels: (config: any) => string
   handleDragStateChange: (isDragging: any) => void

--- a/packages/core/components/Legend/Legend.Gradient.tsx
+++ b/packages/core/components/Legend/Legend.Gradient.tsx
@@ -3,6 +3,7 @@ import { Text } from '@visx/text'
 import { type ViewportSize, type MapConfig } from '@cdc/map/src/types/MapConfig'
 import { type ChartConfig } from '@cdc/chart/src/types/ChartConfig'
 import { getGradientLegendWidth } from '@cdc/core/helpers/getGradientLegendWidth'
+import { getTextWidth } from '../../helpers/getTextWidth'
 import { DimensionsType } from '../../types/Dimensions'
 
 type CombinedConfig = MapConfig | ChartConfig
@@ -13,17 +14,9 @@ interface GradientProps {
   config: CombinedConfig
   dimensions: DimensionsType
   currentViewport: ViewportSize
-  getTextWidth: (text: string, font: string) => string
 }
 
-const LegendGradient = ({
-  labels,
-  colors,
-  config,
-  dimensions,
-  currentViewport,
-  getTextWidth
-}: GradientProps): JSX.Element => {
+const LegendGradient = ({ labels, colors, config, dimensions, currentViewport }: GradientProps): JSX.Element => {
   let [width] = dimensions
 
   const legendWidth = getGradientLegendWidth(width, currentViewport)

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -30,7 +30,6 @@ import { publish } from '@cdc/core/helpers/events'
 import coveUpdateWorker from '@cdc/core/helpers/coveUpdateWorker'
 import { getQueryStringFilterValue } from '@cdc/core/helpers/queryStringUtils'
 import Title from '@cdc/core/components/ui/Title'
-import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 
 // Data
 import { countryCoordinates } from './data/country-coordinates'
@@ -1730,7 +1729,6 @@ const CdcMap = ({
     tooltipRef,
     topoData,
     setTopoData,
-    getTextWidth,
     mapId
   }
 

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -38,7 +38,6 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
     setRuntimeLegend,
     state,
     viewport,
-    getTextWidth,
     mapId
   } = useContext(ConfigContext)
 
@@ -278,7 +277,6 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
               dimensions={dimensions}
               currentViewport={currentViewport}
               config={state}
-              getTextWidth={getTextWidth}
             />
             <ul className={legendClasses.ul.join(' ') || ''} aria-label='Legend items'>
               {state.legend.style === 'gradient' ? '' : legendList()}

--- a/packages/map/src/types/MapContext.ts
+++ b/packages/map/src/types/MapContext.ts
@@ -55,5 +55,4 @@ export type MapContext = {
   runtimeData: Object[]
   tooltipId: string
   setTopoData: Function
-  getTextWidth: (text: string, font: string) => string | undefined
 }


### PR DESCRIPTION
## [DEV-9285](https://websupport-cdc.msappproxy.net/browse/DEV-9285)
Two things happening here:

### 1. Refactor top-suffix-only logic so it overflows if a space is present in the suffix.
So:
"5lbs": pushes to the left
"5lbs per meter":  overflows
"5 units": overflows

### 2. Remove getTextWidth from context and import instead

## Testing Steps

In the editor:
1. Create a Bar or Line chart
2. Open the "Left Value Axis" panel
3. Select the checkbox labeled "Only Show Prefix/Suffix" 
4. Add a Suffix without a space (i.e. something like 'lbs')
5. Observe that the suffix pushes the tick labels to the left, to the left
6. Add a suffix with a space (i.e. something like " units" or "lbs of something")
7. Observe that the suffix now overflows to the right instead

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<img width="634" alt="Screenshot 2024-10-21 at 12 19 07 PM" src="https://github.com/user-attachments/assets/670f91d4-f073-4c82-ab9f-d367a4fa4313">
<img width="656" alt="Screenshot 2024-10-21 at 12 19 01 PM" src="https://github.com/user-attachments/assets/6490bc89-019d-47ba-8619-e0655ff7c8cb">
