### PR TITLE
[DEV-9187] Fixes Chart Annotations

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -88,7 +88,7 @@ interface CdcChartProps {
   setSharedFilterValue?: (value: any) => void
   dashboardConfig?: DashboardConfig
 }
-export default function CdcChart({
+const CdcChart = ({
   configUrl,
   config: configObj,
   isEditor = false,
@@ -101,9 +101,10 @@ export default function CdcChart({
   setSharedFilter,
   setSharedFilterValue,
   dashboardConfig
-}: CdcChartProps) {
+}: CdcChartProps) => {
   const transform = new DataTransform()
   const [loading, setLoading] = useState(true)
+  const svgRef = useRef(null)
   const [colorScale, setColorScale] = useState(null)
   const [config, setConfig] = useState<ChartConfig>({} as ChartConfig)
   const [stateData, setStateData] = useState(_.cloneDeep(configObj?.data) || [])
@@ -134,7 +135,6 @@ export default function CdcChart({
   const handleDragStateChange = isDragging => {
     setIsDraggingAnnotation(isDragging)
   }
-
   if (isDebug) console.log('Chart config, isEditor', config, isEditor)
 
   // Destructure items from config for more readable JSX
@@ -692,7 +692,7 @@ export default function CdcChart({
     setContainer(node)
   }, []) // eslint-disable-line
 
-  function isEmpty(obj) {
+  const isEmpty = obj => {
     return Object.keys(obj).length === 0
   }
 
@@ -1361,14 +1361,16 @@ export default function CdcChart({
                     {!['Spark Line', 'Line', 'Sankey', 'Pie', 'Sankey'].includes(config.visualizationType) && (
                       <div ref={parentRef} style={{ width: `100%` }}>
                         <ParentSize>
-                          {parent => <LinearChart parentWidth={parent.width} parentHeight={parent.height} />}
+                          {parent => (
+                            <LinearChart ref={svgRef} parentWidth={parent.width} parentHeight={parent.height} />
+                          )}
                         </ParentSize>
                       </div>
                     )}
 
                     {config.visualizationType === 'Pie' && (
                       <ParentSize className='justify-content-center d-flex' style={{ width: `100%` }}>
-                        {parent => <PieChart parentWidth={parent.width} parentHeight={parent.height} />}
+                        {parent => <PieChart ref={svgRef} parentWidth={parent.width} parentHeight={parent.height} />}
                       </ParentSize>
                     )}
                     {/* Line Chart */}
@@ -1376,13 +1378,17 @@ export default function CdcChart({
                       (checkLineToBarGraph() ? (
                         <div ref={parentRef} style={{ width: `100%` }}>
                           <ParentSize>
-                            {parent => <LinearChart parentWidth={parent.width} parentHeight={parent.height} />}
+                            {parent => (
+                              <LinearChart ref={svgRef} parentWidth={parent.width} parentHeight={parent.height} />
+                            )}
                           </ParentSize>
                         </div>
                       ) : (
                         <div ref={parentRef} style={{ width: `100%` }}>
                           <ParentSize>
-                            {parent => <LinearChart parentWidth={parent.width} parentHeight={parent.height} />}
+                            {parent => (
+                              <LinearChart ref={svgRef} parentWidth={parent.width} parentHeight={parent.height} />
+                            )}
                           </ParentSize>
                         </div>
                       ))}
@@ -1436,7 +1442,6 @@ export default function CdcChart({
                 {description && config.visualizationType !== 'Spark Line' && (
                   <div className={getChartSubTextClasses().join('')}>{parse(description)}</div>
                 )}
-                {false && <Annotation.List />}
 
                 {/* buttons */}
                 <MediaControls.Section classes={['download-buttons']}>
@@ -1563,6 +1568,7 @@ export default function CdcChart({
     setSeriesHighlight,
     setSharedFilter,
     setSharedFilterValue,
+    svgRef,
     tableData: filteredData || excludedData, // do not clean table data
     transformedData: clean(filteredData || excludedData), // do this right before passing to components
     twoColorPalette,
@@ -1585,3 +1591,5 @@ export default function CdcChart({
     </ConfigContext.Provider>
   )
 }
+
+export default CdcChart

--- a/packages/chart/src/components/Annotations/components/AnnotationDraggable.tsx
+++ b/packages/chart/src/components/Annotations/components/AnnotationDraggable.tsx
@@ -32,11 +32,8 @@ const Annotations = ({ xScale, yScale, xScaleAnnotation, xMax, svgRef, onDragSta
   // prettier-ignore
   const {
     config,
-    currentViewport,
     dimensions,
-    isDraggingAnnotation,
     isEditor,
-    isLegendBottom,
     updateConfig
   } = useContext(ConfigContext)
 

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Annotate.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Annotate.tsx
@@ -12,27 +12,7 @@ import { type PanelProps } from './../PanelProps'
 import './../panels.scss'
 
 const PanelAnnotate: React.FC<PanelProps> = props => {
-  const { updateConfig, config, unfilteredData, dimensions, isDraggingAnnotation } = useContext(ConfigContext)
-
-  const getColumns = (filter = true) => {
-    const columns = {}
-    unfilteredData.forEach(row => {
-      Object.keys(row).forEach(columnName => (columns[columnName] = true))
-    })
-
-    if (filter) {
-      Object.keys(columns).forEach(key => {
-        if (
-          (config.series && config.series.filter(series => series.dataKey === key).length > 0) ||
-          (config.confidenceKeys && Object.keys(config.confidenceKeys).includes(key))
-        ) {
-          delete columns[key]
-        }
-      })
-    }
-
-    return Object.keys(columns)
-  }
+  const { updateConfig, config, svgRef } = useContext(ConfigContext)
 
   const handleAnnotationUpdate = (value, property, index) => {
     const svgContainer = document.querySelector('.chart-container  > svg')?.getBoundingClientRect()
@@ -48,8 +28,11 @@ const PanelAnnotate: React.FC<PanelProps> = props => {
   }
 
   const handleAddAnnotation = () => {
-    const svgContainer = document.querySelector('.chart-container > svg')?.getBoundingClientRect()
-    const newSvgDims = [svgContainer?.width, svgContainer?.height]
+    // check if svg is animated svg or standard svg
+    const newSvgDims = [
+      svgRef?.current?.width?.baseVal?.value || svgRef?.current?.width,
+      svgRef?.current?.height?.baseVal?.value || svgRef?.current?.height
+    ]
 
     const newAnnotation = {
       text: 'New Annotation',

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import React, { forwardRef, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 // Libraries
 import { AxisLeft, AxisBottom, AxisRight, AxisTop } from '@visx/axis'
@@ -50,7 +50,7 @@ const BOTTOM_LABEL_PADDING = 9
 const X_TICK_LABEL_PADDING = 3
 const DEFAULT_TICK_LENGTH = 8
 
-const LinearChart: React.FC<LinearChartProps> = ({ parentHeight, parentWidth }) => {
+const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, parentWidth }, svgRef) => {
   // prettier-ignore
   const {
     brushConfig,
@@ -101,7 +101,6 @@ const LinearChart: React.FC<LinearChartProps> = ({ parentHeight, parentWidth }) 
   // REFS
   const axisBottomRef = useRef(null)
   const forestPlotRightLabelRef = useRef(null)
-  const svgRef = useRef(null)
   const suffixRef = useRef(null)
   const topYLabelRef = useRef(null)
   const triggerRef = useRef()
@@ -1538,6 +1537,6 @@ const LinearChart: React.FC<LinearChartProps> = ({ parentHeight, parentWidth }) 
       </div>
     </ErrorBoundary>
   )
-}
+})
 
 export default LinearChart

--- a/packages/chart/src/types/ChartContext.ts
+++ b/packages/chart/src/types/ChartContext.ts
@@ -37,6 +37,7 @@ type SharedChartContext = {
   parentRef?: React.RefObject<HTMLDivElement>
   setBrushConfig: Function
   setLegendIsolateValues?: Function
+  svgRef?: React.RefObject<SVGSVGElement>
 }
 
 // Line Chart Specific Context


### PR DESCRIPTION
## DEV-9187
- Moves svgRef state to CdcChart
- Forwards ref from the rendered svg element to CdcChart so that it can be passed to additional components
- Annotation Panel now uses svgRef to calculate adding the annotations width/height placements

## Testing Steps
- Open a bar, line, or area chart. 
- Click add annotation
- The annotation should appear in the middle of the chart when added

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
