### PR TITLE
fix [dev-9566] table columns sizing

### DIFF
--- a/packages/core/components/DataTable/components/SortIcon/sort-icon.css
+++ b/packages/core/components/DataTable/components/SortIcon/sort-icon.css
@@ -1,21 +1,21 @@
 /* format the white triangle sort icon in data table headers */
 .sort-icon {
   fill: white;
-  width: 15px;
-  height: 20px;
-  float: right;
   position: relative;
+  margin: 0 0.5rem !important;
   :is(svg) {
     position: absolute;
     fill: rgba(255, 255, 255, 0.5);
     &.active {
       fill: white;
     }
+    width: 1rem;
+    height: 1rem;
   }
   .up {
-    top: 0;
+    bottom: 0.5rem;
   }
   .down {
-    bottom: 0;
+    top: 0.5rem;
   }
 }

--- a/packages/core/components/DataTable/data-table.css
+++ b/packages/core/components/DataTable/data-table.css
@@ -1,3 +1,8 @@
+.table {
+  width: unset;
+  min-width: 100%;
+}
+
 .collapsed + .table-container {
   border-bottom: none;
 }
@@ -40,13 +45,10 @@ table.horizontal {
 
 table.data-table {
   margin-bottom: 0;
-  min-width: 100%;
   background: #fff;
   position: relative;
   border: none;
-  overflow-x: auto;
   border-collapse: collapse;
-  overflow: auto;
   appearance: none;
   table-layout: fixed;
   * {
@@ -105,12 +107,6 @@ table.data-table {
     }
   }
 
-  tbody {
-    tr {
-      width: 100%;
-    }
-  }
-
   tr {
     &.row-group {
       background-color: var(--tertiary) !important;
@@ -128,8 +124,6 @@ table.data-table {
     padding: 0.3em 0.7em;
     border-right: 1px solid rgba(0, 0, 0, 0.1);
     white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
     &:last-child {
       border-right: 0 !important;
     }
@@ -138,18 +132,9 @@ table.data-table {
       font-size: var(--font-small) + 0.2em;
     }
   }
-  tr {
-    & > * {
-      width: 100%;
-    }
-  }
-  th {
-    flex-grow: 1;
-  }
 
   td {
     position: relative;
-    flex-grow: 1;
     svg {
       margin-left: 1rem;
     }


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

Table columns were collapsing with asterisks to the right when on mobile, this fixes that an makes it scroll instead of collapsing. 

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
