### PR TITLE
[DEV-9293a] Update tooltips for null values

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.General.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.General.tsx
@@ -271,10 +271,7 @@ const PanelGeneral: FC<PanelProps> = props => {
               updateField={updateField}
             />
             <CheckBox
-              display={
-                config.visualizationSubType === 'stacked' &&
-                (config.visualizationType === 'Bar' || config.visualizationType === 'Combo')
-              }
+              display={config.visualizationType === 'Bar' || config.visualizationType === 'Combo'}
               tooltip={
                 <Tooltip style={{ textTransform: 'none' }}>
                   <Tooltip.Target>

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -58,10 +58,7 @@ export const useTooltip = props => {
     const showMissingDataValue = config.general.showMissingDataLabel && (!value || value === 'null')
     let formattedValue = seriesKey === config.xAxis.dataKey ? value : formatNumber(value, getAxisPosition(seriesKey))
 
-    formattedValue =
-      showMissingDataValue && (config.visualizationSubType === 'stacked' ? !config.general.hideNullValue : true)
-        ? 'N/A'
-        : formattedValue
+    formattedValue = showMissingDataValue ? 'N/A' : formattedValue
 
     return formattedValue
   }
@@ -198,8 +195,16 @@ export const useTooltip = props => {
             )
             ?.flatMap(seriesKey => {
               const value = resolvedScaleValues[0]?.[seriesKey]
+              console.log(value, 'value')
               const formattedValue = getFormattedValue(seriesKey, value, config, getAxisPosition)
-              return [[seriesKey, formattedValue, getAxisPosition(seriesKey)]]
+              if (
+                (value === null || value === undefined || value === '' || formattedValue === 'N/A') &&
+                config.general.hideNullValue
+              ) {
+                return []
+              } else {
+                return [[seriesKey, formattedValue, getAxisPosition(seriesKey)]]
+              }
             })
         )
       }


### PR DESCRIPTION
## [Replace With Ticket Number]
Updated tooltips for bar charts to not to shows null or undefined values when user hovers. To test it we need null or missing data in dataset and then in General Panel checkox "Remove Null values from hover". it removes nulls.
<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
