### PR TITLE
[DEV-6966] Fix chart font

### DIFF
--- a/packages/core/components/DataTable/data-table.css
+++ b/packages/core/components/DataTable/data-table.css
@@ -13,7 +13,7 @@
   border-bottom: 1px solid var(--lightGray);
 }
 
-div.data-table-heading {
+.cdc-open-viz-module div.data-table-heading {
   position: relative;
   background: rgba(0, 0, 0, 0.05);
   padding: 0.5em 0.7em;

--- a/packages/core/styles/_reset.scss
+++ b/packages/core/styles/_reset.scss
@@ -1,6 +1,7 @@
 .cdc-open-viz-module {
   margin: 0;
-  font: 1em/1.6 system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Droid Sans, Helvetica Neue, Fira Sans, sans-serif;
+  font: 1em/1.6 system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Droid Sans,
+    Helvetica Neue, Fira Sans, sans-serif;
   font-weight: 400;
   font-style: normal;
   text-rendering: optimizeLegibility;
@@ -18,6 +19,7 @@
   }
 }
 .cdc-open-viz-module {
+  div,
   span,
   applet,
   object,


### PR DESCRIPTION
## [DEV-6966]

The chart font was unintentionally changed from `sans-serif` to `system-ui` during the table refactor.

This fixes it by restoring `div` to `_reset.scss` (was removed in https://github.com/CDCgov/cdc-open-viz/commit/8c74a5483e112d5afec764925c52a5fba59711e3) and updating affected table styles.

## Testing Steps

Open a chart and see that the font on axis labels is `sans-serif`, not `system-ui`.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
