### PR TITLE
[DEV-9274] Work on tooltip accessibility

### DIFF
--- a/packages/core/helpers/cove/accessibility.ts
+++ b/packages/core/helpers/cove/accessibility.ts
@@ -34,3 +34,10 @@ export const getColorContrast = (color1: string, color2: string) => {
   if (!chroma.valid(color1) || !chroma.valid(color2)) return false
   return chroma.contrast(color1, color2)
 }
+
+export const handleDismissTooltip = (e, tooltipShowHandler) => {
+  if (e.key === 'Escape') {
+    tooltipShowHandler(false)
+  }
+  return
+}

--- a/packages/map/examples/default-usa-regions.json
+++ b/packages/map/examples/default-usa-regions.json
@@ -1,118 +1,268 @@
 {
-	"data": [
-		{
-			"Current Week Positivity": "20",
-			"State": "REGION 1",
-			"Change": "0.2"
-		},
-		{
-			"Current Week Positivity": "27",
-			"State": "region 2",
-			"Change": "-0.5"
-		},
-		{
-			"Current Week Positivity": "26",
-			"State": "region 3",
-			"Change": "-.08"
-		},
-		{
-			"Current Week Positivity": "30",
-			"State": "region 4",
-			"Change": "0.8"
-		},
-		{
-			"Current Week Positivity": "14",
-			"State": "region 5",
-			"Change": "0.5"
-		},
-		{
-			"Current Week Positivity": "25",
-			"State": "region 6",
-			"Change": "0.05"
-		},
-		{
-			"Current Week Positivity": "0",
-			"State": "region 7",
-			"Change": "0"
-		},
-		{
-			"Current Week Positivity": "14",
-			"State": "region 8",
-			"Change": "-1.2"
-		},
-		{
-			"Current Week Positivity": "28",
-			"State": "region 9",
-			"Change": "1.5"
-		},
-		{
-			"Current Week Positivity": "12",
-			"State": "region 10",
-			"Change": "0.5"
-		}
-	],
-
-	"dataFileSourceType": "file",
-	"dataDescription": {
-		"horizontal": true
-	},
-	"newViz": true,
-	"type": "map",
-	"general": {
-		"geoType": "us-region",
-		"geoBorderColor": "darkGray",
-		"headerColor": "theme-blue",
-		"showTitle": true,
-		"showSidebar": true,
-		"showDownloadButton": true,
-		"showDownloadMediaButton": false,
-		"displayAsHex": false,
-		"displayStateLabels": false,
-		"territoriesLabel": "Territories",
-		"language": "en",
-		"hasRegions": false,
-		"expandDataTable": true,
-		"fullBorder": false,
-		"type": "data",
-		"title": "Default US Map"
-	},
-
-	"geoType": "us-region",
-	"geoBorderColor": "darkGray",
-	"headerColor": "theme-blue",
-	"showTitle": true,
-	"showSidebar": true,
-	"showDownloadButton": true,
-	"showDownloadMediaButton": false,
-	"displayAsHex": false,
-	"displayStateLabels": false,
-	"territoriesLabel": "Territories",
-	"language": "en",
-	"hasRegions": false,
-	"expandDataTable": true,
-	"fullBorder": false,
-	"color": "pinkpurple",
-	"columns": {
-		"geo": { "name": "State", "label": "Location", "tooltip": false, "dataTable": true },
-		"primary": { "dataTable": true, "tooltip": true, "prefix": "", "suffix": "", "name": "Current Week Positivity", "label": "" },
-		"navigate": { "name": "Current Week Positivity" }
-	},
-	"legend": {
-		"descriptions": {},
-		"specialClasses": [],
-		"unified": false,
-		"singleColumn": false,
-		"dynamicDescription": false,
-		"type": "category",
-		"numberOfItems": 10,
-		"position": "side",
-		"title": "Legend"
-	},
-	"filters": [],
-	"dataTable": { "title": "Data Table", "forceDisplay": true },
-	"tooltips": {
-		"appearanceType": "hover",
-		"linkLabel": "Learn More",
-		"capitalizeLabels": true
-	}
+  "annotations": [],
+  "general": {
+    "geoType": "us-region",
+    "type": "data",
+    "noStateFoundMessage": "Map Unavailable",
+    "annotationDropdownText": "Annotations",
+    "geoBorderColor": "darkGray",
+    "headerColor": "theme-blue",
+    "title": "",
+    "showTitle": true,
+    "showSidebar": true,
+    "showDownloadButton": true,
+    "showDownloadMediaButton": false,
+    "displayAsHex": false,
+    "displayStateLabels": false,
+    "territoriesLabel": "Territories",
+    "territoriesAlwaysShow": false,
+    "language": "en",
+    "geoLabelOverride": "",
+    "hasRegions": false,
+    "fullBorder": false,
+    "convertFipsCodes": true,
+    "palette": {
+      "isReversed": false
+    },
+    "allowMapZoom": true,
+    "hideGeoColumnInTooltip": false,
+    "hidePrimaryColumnInTooltip": false,
+    "statePicked": {
+      "fipsCode": "01",
+      "stateName": "Alabama"
+    },
+    "expandDataTable": false
+  },
+  "type": "map",
+  "color": "pinkpurple",
+  "columns": {
+    "geo": {
+      "name": "State",
+      "label": "Location",
+      "tooltip": false,
+      "dataTable": true
+    },
+    "primary": {
+      "dataTable": true,
+      "tooltip": true,
+      "prefix": "",
+      "suffix": "",
+      "name": "Current Week Positivity",
+      "label": "",
+      "roundToPlace": 0
+    },
+    "navigate": {
+      "name": ""
+    },
+    "latitude": {
+      "name": ""
+    },
+    "longitude": {
+      "name": ""
+    }
+  },
+  "legend": {
+    "descriptions": {},
+    "specialClasses": [],
+    "unified": false,
+    "singleColumn": false,
+    "singleRow": false,
+    "verticalSorted": false,
+    "showSpecialClassesLast": false,
+    "dynamicDescription": false,
+    "type": "equalnumber",
+    "numberOfItems": 3,
+    "position": "side",
+    "title": "",
+    "style": "circles",
+    "subStyle": "linear blocks",
+    "tickRotation": "",
+    "singleColumnLegend": false,
+    "hideBorder": false
+  },
+  "filters": [],
+  "table": {
+    "wrapColumns": false,
+    "label": "Data Table",
+    "expanded": false,
+    "limitHeight": false,
+    "height": "",
+    "caption": "",
+    "showDownloadUrl": false,
+    "showDataTableLink": true,
+    "showDownloadLinkBelow": true,
+    "showFullGeoNameInCSV": false,
+    "forceDisplay": true,
+    "download": true,
+    "indexLabel": ""
+  },
+  "tooltips": {
+    "appearanceType": "hover",
+    "linkLabel": "Learn More",
+    "capitalizeLabels": true,
+    "opacity": 90
+  },
+  "runtime": {
+    "editorErrorMessage": []
+  },
+  "visual": {
+    "minBubbleSize": 1,
+    "maxBubbleSize": 20,
+    "extraBubbleBorder": false,
+    "cityStyle": "circle",
+    "cityStyleLabel": "",
+    "showBubbleZeros": false,
+    "additionalCityStyles": [],
+    "geoCodeCircleSize": 8
+  },
+  "mapPosition": {
+    "coordinates": [
+      0,
+      30
+    ],
+    "zoom": 1
+  },
+  "map": {
+    "layers": [],
+    "patterns": []
+  },
+  "hexMap": {
+    "type": "",
+    "shapeGroups": [
+      {
+        "legendTitle": "",
+        "legendDescription": "",
+        "items": [
+          {
+            "key": "",
+            "shape": "Arrow Up",
+            "column": "",
+            "operator": "=",
+            "value": ""
+          }
+        ]
+      }
+    ]
+  },
+  "filterBehavior": "Filter Change",
+  "datasets": {},
+  "isResponsiveTicks": false,
+  "barThickness": "0.37",
+  "xAxis": {
+    "type": "categorical",
+    "size": 75,
+    "maxTickRotation": 45,
+    "labelOffset": 0
+  },
+  "data": [
+    {
+      "Current Week Positivity": "20",
+      "State": "REGION 1",
+      "Change": "0.2"
+    },
+    {
+      "Current Week Positivity": "27",
+      "State": "region 2",
+      "Change": "-0.5"
+    },
+    {
+      "Current Week Positivity": "26",
+      "State": "region 3",
+      "Change": "-.08"
+    },
+    {
+      "Current Week Positivity": "30",
+      "State": "region 4",
+      "Change": "0.8"
+    },
+    {
+      "Current Week Positivity": "14",
+      "State": "region 5",
+      "Change": "0.5"
+    },
+    {
+      "Current Week Positivity": "25",
+      "State": "region 6",
+      "Change": "0.05"
+    },
+    {
+      "Current Week Positivity": "0",
+      "State": "region 7",
+      "Change": "0"
+    },
+    {
+      "Current Week Positivity": "14",
+      "State": "region 8",
+      "Change": "-1.2"
+    },
+    {
+      "Current Week Positivity": "28",
+      "State": "region 9",
+      "Change": "1.5"
+    },
+    {
+      "Current Week Positivity": "12",
+      "State": "region 10",
+      "Change": "0.5"
+    }
+  ],
+  "dataFileName": "valid-region-data.json",
+  "dataFileSourceType": "file",
+  "formattedData": [
+    {
+      "Current Week Positivity": "20",
+      "State": "REGION 1",
+      "Change": "0.2"
+    },
+    {
+      "Current Week Positivity": "27",
+      "State": "region 2",
+      "Change": "-0.5"
+    },
+    {
+      "Current Week Positivity": "26",
+      "State": "region 3",
+      "Change": "-.08"
+    },
+    {
+      "Current Week Positivity": "30",
+      "State": "region 4",
+      "Change": "0.8"
+    },
+    {
+      "Current Week Positivity": "14",
+      "State": "region 5",
+      "Change": "0.5"
+    },
+    {
+      "Current Week Positivity": "25",
+      "State": "region 6",
+      "Change": "0.05"
+    },
+    {
+      "Current Week Positivity": "0",
+      "State": "region 7",
+      "Change": "0"
+    },
+    {
+      "Current Week Positivity": "14",
+      "State": "region 8",
+      "Change": "-1.2"
+    },
+    {
+      "Current Week Positivity": "28",
+      "State": "region 9",
+      "Change": "1.5"
+    },
+    {
+      "Current Week Positivity": "12",
+      "State": "region 10",
+      "Change": "0.5"
+    }
+  ],
+  "dataDescription": {
+    "horizontal": false,
+    "series": false
+  },
+  "version": "4.24.10"
 }

--- a/packages/map/index.html
+++ b/packages/map/index.html
@@ -23,13 +23,13 @@
   <body>
     <!-- DEFAULT EXAMPLES -->
     <!-- <div class="react-container" data-config="/examples/annotation/usa-map.json"></div> -->
-    <div class="react-container" data-config="/examples/hex-colors.json"></div>
+    <!-- <div class="react-container" data-config="/examples/hex-colors.json"></div> -->
     <!-- <div class="react-container" data-config="/examples/private/map.json"></div> -->
     <!-- <div class="react-container" data-config="/examples/private/zika-issue.json"></div> -->
     <!-- <div class="react-container react-container--maps" data-config="/examples/annotation/index.json">/</div> -->
 
     <!-- <div class="react-container react-container--maps" data-config="/examples/private/tooltip-issue.json"></div> -->
-    <!-- <div class="react-container react-container--maps" data-config="/examples/test.json"></div> -->
+    <div class="react-container react-container--maps" data-config="/examples/default-county.json"></div>
     <!-- <div class="react-container react-container--maps" data-config="/examples/default-patterns.json"></div> -->
     <!-- <div class="react-container react-container--maps" data-config="/examples/test.json"></div> -->
     <!-- <div class="react-container react-container--maps" data-config="/examples/private/map-text-wrap.json"></div> -->

--- a/packages/map/index.html
+++ b/packages/map/index.html
@@ -29,7 +29,7 @@
     <!-- <div class="react-container react-container--maps" data-config="/examples/annotation/index.json">/</div> -->
 
     <!-- <div class="react-container react-container--maps" data-config="/examples/private/tooltip-issue.json"></div> -->
-    <div class="react-container react-container--maps" data-config="/examples/default-county.json"></div>
+    <!-- <div class="react-container react-container--maps" data-config="/examples/default-world.json"></div> -->
     <!-- <div class="react-container react-container--maps" data-config="/examples/default-patterns.json"></div> -->
     <!-- <div class="react-container react-container--maps" data-config="/examples/test.json"></div> -->
     <!-- <div class="react-container react-container--maps" data-config="/examples/private/map-text-wrap.json"></div> -->

--- a/packages/map/index.html
+++ b/packages/map/index.html
@@ -23,7 +23,7 @@
   <body>
     <!-- DEFAULT EXAMPLES -->
     <!-- <div class="react-container" data-config="/examples/annotation/usa-map.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/hex-colors.json"></div> -->
+    <div class="react-container" data-config="/examples/hex-colors.json"></div>
     <!-- <div class="react-container" data-config="/examples/private/map.json"></div> -->
     <!-- <div class="react-container" data-config="/examples/private/zika-issue.json"></div> -->
     <!-- <div class="react-container react-container--maps" data-config="/examples/annotation/index.json">/</div> -->

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -136,6 +136,7 @@ const CdcMap = ({
   const [liveRegionMessage, setLiveRegionMessage] = useState('')
 
   const legendRef = useRef(null)
+  const liveRegionRef = useRef(null)
   const tooltipRef = useRef(null)
   const legendId = useId()
   // create random tooltipId
@@ -1729,7 +1730,7 @@ const CdcMap = ({
     supportedTerritories,
     titleCase,
     tooltipId,
-    tooltipRef,
+    liveRegionRef,
     topoData,
     liveRegionMessage,
     setLiveRegionMessage,
@@ -1967,14 +1968,7 @@ const CdcMap = ({
               display: 'none' // can't use d-none here
             }}
           ></div>
-          <div
-            id='tooltip'
-            role='tooltip'
-            aria-live='assertive'
-            ref={tooltipRef}
-            tabIndex={-1}
-            style={{ position: 'absolute', backgroundColor: 'white', border: '1px solid black', padding: '5px' }}
-          >
+          <div role='tooltip' aria-live='assertive' ref={liveRegionRef} tabIndex={-1} className='sr-only'>
             {liveRegionMessage}
           </div>
         </Layout.Responsive>

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -123,7 +123,6 @@ const CdcMap = ({
   const [runtimeData, setRuntimeData] = useState({ init: true })
   const [stateToShow, setStateToShow] = useState(null)
   const [modal, setModal] = useState(null)
-  const [accessibleStatus, setAccessibleStatus] = useState('')
   const [filteredCountryCode, setFilteredCountryCode] = useState()
   const [position, setPosition] = useState(state.mapPosition)
   const [coveLoadedHasRan, setCoveLoadedHasRan] = useState(false)
@@ -133,7 +132,6 @@ const CdcMap = ({
   const [requiredColumns, setRequiredColumns] = useState(null) // Simple state so we know if we need more information before parsing the map
   const [projection, setProjection] = useState(null)
   const [showTooltip, setShowTooltip] = useState(true)
-  const [liveRegionMessage, setLiveRegionMessage] = useState('')
 
   const legendRef = useRef(null)
   const liveRegionRef = useRef(null)
@@ -1672,6 +1670,7 @@ const CdcMap = ({
 
   // Props passed to all map types
   const mapProps = {
+    tooltipRef,
     applyLegendToRow,
     applyTooltipsToGeo,
     capitalize: state.tooltips?.capitalizeLabels,
@@ -1706,7 +1705,6 @@ const CdcMap = ({
     runtimeFilters,
     runtimeLegend,
     scale,
-    setAccessibleStatus,
     setFilteredCountryCode,
     setParentConfig: setConfig,
     setPosition,
@@ -1732,8 +1730,6 @@ const CdcMap = ({
     tooltipId,
     liveRegionRef,
     topoData,
-    liveRegionMessage,
-    setLiveRegionMessage,
     translate,
     type: general.type,
     viewport: currentViewport
@@ -1942,10 +1938,6 @@ const CdcMap = ({
             </section>
           )}
 
-          <div aria-live='assertive' className='cdcdataviz-sr-only'>
-            {accessibleStatus}
-          </div>
-
           {showTooltip &&
             !isDraggingAnnotation &&
             !window.matchMedia('(any-hover: none)').matches &&
@@ -1969,7 +1961,7 @@ const CdcMap = ({
             }}
           ></div>
           <div role='tooltip' aria-live='assertive' ref={liveRegionRef} tabIndex={-1} className='sr-only'>
-            {liveRegionMessage}
+            {liveRegionRef.current?.textContent || ''}
           </div>
         </Layout.Responsive>
       </Layout.VisualizationWrapper>

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -132,6 +132,8 @@ const CdcMap = ({
   const [dimensions, setDimensions] = useState<DimensionsType>([0, 0])
   const [requiredColumns, setRequiredColumns] = useState(null) // Simple state so we know if we need more information before parsing the map
   const [projection, setProjection] = useState(null)
+  const [showTooltip, setShowTooltip] = useState(true)
+  const [liveRegionMessage, setLiveRegionMessage] = useState('')
 
   const legendRef = useRef(null)
   const tooltipRef = useRef(null)
@@ -1669,16 +1671,6 @@ const CdcMap = ({
 
   // Props passed to all map types
   const mapProps = {
-    projection,
-    setProjection,
-    stateToShow,
-    setStateToShow,
-    setScale,
-    setTranslate,
-    scale,
-    translate,
-    isDraggingAnnotation,
-    handleDragStateChange,
     applyLegendToRow,
     applyTooltipsToGeo,
     capitalize: state.tooltips?.capitalizeLabels,
@@ -1695,41 +1687,55 @@ const CdcMap = ({
     generateColorsArray,
     generateRuntimeData,
     geoClickHandler,
+    handleDragStateChange,
     handleMapAriaLabels,
     hasZoom: state.general.allowMapZoom,
     innerContainerRef,
     isDashboard,
     isDebug,
+    isDraggingAnnotation,
     isEditor,
     loadConfig,
+    mapId,
     navigationHandler,
     position,
+    projection,
     resetLegendToggles,
+    runtimeData,
     runtimeFilters,
     runtimeLegend,
-    runtimeData,
+    scale,
     setAccessibleStatus,
     setFilteredCountryCode,
     setParentConfig: setConfig,
     setPosition,
+    setProjection,
     setRuntimeData,
     setRuntimeFilters,
     setRuntimeLegend,
+    setScale,
     setSharedFilterValue,
+    setShowTooltip,
     setState,
+    setStateToShow,
+    setTopoData,
+    setTranslate,
+    showTooltip,
     state,
+    stateToShow,
     supportedCities,
     supportedCounties,
     supportedCountries,
     supportedTerritories,
     titleCase,
-    type: general.type,
-    viewport: currentViewport,
     tooltipId,
     tooltipRef,
     topoData,
-    setTopoData,
-    mapId
+    liveRegionMessage,
+    setLiveRegionMessage,
+    translate,
+    type: general.type,
+    viewport: currentViewport
   }
 
   if (!mapProps.data || !state.data) return <></>
@@ -1939,7 +1945,8 @@ const CdcMap = ({
             {accessibleStatus}
           </div>
 
-          {!isDraggingAnnotation &&
+          {showTooltip &&
+            !isDraggingAnnotation &&
             !window.matchMedia('(any-hover: none)').matches &&
             'hover' === tooltips.appearanceType && (
               <ReactTooltip
@@ -1960,6 +1967,16 @@ const CdcMap = ({
               display: 'none' // can't use d-none here
             }}
           ></div>
+          <div
+            id='tooltip'
+            role='tooltip'
+            aria-live='assertive'
+            ref={tooltipRef}
+            tabIndex={-1}
+            style={{ position: 'absolute', backgroundColor: 'white', border: '1px solid black', padding: '5px' }}
+          >
+            {liveRegionMessage}
+          </div>
         </Layout.Responsive>
       </Layout.VisualizationWrapper>
     </ConfigContext.Provider>

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -1949,17 +1949,19 @@ const CdcMap = ({
                 style={{ background: `rgba(255,255,255, ${state.tooltips.opacity / 100})`, color: 'black' }}
               />
             )}
-          <div
-            ref={tooltipRef}
-            id={`tooltip__${tooltipId}-canvas`}
-            className='tooltip'
-            style={{
-              background: `rgba(255,255,255,${state.tooltips.opacity / 100})`,
-              position: 'absolute',
-              whiteSpace: 'nowrap',
-              display: 'none' // can't use d-none here
-            }}
-          ></div>
+          {showTooltip && (
+            <div
+              ref={tooltipRef}
+              id={`tooltip__${tooltipId}-canvas`}
+              className='tooltip'
+              style={{
+                background: `rgba(255,255,255,${state.tooltips.opacity / 100})`,
+                position: 'absolute',
+                whiteSpace: 'nowrap',
+                display: 'none' // can't use d-none here
+              }}
+            ></div>
+          )}
           <div role='tooltip' aria-live='assertive' ref={liveRegionRef} tabIndex={-1} className='sr-only'>
             {liveRegionRef.current?.textContent || ''}
           </div>

--- a/packages/map/src/components/BubbleList.tsx
+++ b/packages/map/src/components/BubbleList.tsx
@@ -3,19 +3,33 @@ import { scaleLinear } from 'd3-scale'
 import { countryCoordinates } from '../data/country-coordinates'
 import stateCoordinates from '../data/state-coordinates'
 import ConfigContext from '../context'
+import { handleDismissTooltip } from '@cdc/core/helpers/cove/accessibility'
 
-export const BubbleList = ({ data: dataImport, state, projection, applyLegendToRow, applyTooltipsToGeo, handleCircleClick, runtimeData, displayGeoName }) => {
+export const BubbleList = ({
+  data: dataImport,
+  state,
+  projection,
+  applyLegendToRow,
+  applyTooltipsToGeo,
+  handleCircleClick,
+  runtimeData,
+  displayGeoName
+}) => {
   const maxDataValue = Math.max(...dataImport.map(d => d[state.columns.primary.name]))
-  const { tooltipId } = useContext(ConfigContext)
+  const { tooltipId, liveRegionRef, setShowTooltip } = useContext(ConfigContext)
 
   const hasBubblesWithZeroOnMap = state.visual.showBubbleZeros ? 0 : 1
   // sort runtime data. Smaller bubbles should appear on top.
-  const sortedRuntimeData = Object.values(runtimeData).sort((a, b) => (a[state.columns.primary.name] < b[state.columns.primary.name] ? 1 : -1))
+  const sortedRuntimeData = Object.values(runtimeData).sort((a, b) =>
+    a[state.columns.primary.name] < b[state.columns.primary.name] ? 1 : -1
+  )
   if (!sortedRuntimeData) return
 
   const clickTolerance = 10
   // Set bubble sizes
-  var size = scaleLinear().domain([hasBubblesWithZeroOnMap, maxDataValue]).range([state.visual.minBubbleSize, state.visual.maxBubbleSize])
+  var size = scaleLinear()
+    .domain([hasBubblesWithZeroOnMap, maxDataValue])
+    .range([state.visual.minBubbleSize, state.visual.maxBubbleSize])
 
   // Start looping through the countries to create the bubbles.
   if (state.general.geoType === 'world') {
@@ -31,7 +45,11 @@ export const BubbleList = ({ data: dataImport, state, projection, applyLegendToR
         const legendColors = applyLegendToRow(country)
 
         let primaryKey = state.columns.primary.name
-        if ((Math.floor(Number(country[primaryKey])) === 0 || country[primaryKey] === '') && !state.visual.showBubbleZeros) return
+        if (
+          (Math.floor(Number(country[primaryKey])) === 0 || country[primaryKey] === '') &&
+          !state.visual.showBubbleZeros
+        )
+          return
 
         let transform = `translate(${projection([coordinates[1], coordinates[0]])})`
 
@@ -42,6 +60,15 @@ export const BubbleList = ({ data: dataImport, state, projection, applyLegendToR
         const circle = (
           <>
             <circle
+              onKeyDown={e => {
+                handleDismissTooltip(e, setShowTooltip)
+                liveRegionRef.current.textContent = 'Dismissing tooltip'
+              }}
+              onMouseMove={setShowTooltip(true)}
+              onMouseEnter={() => {
+                setShowTooltip(true)
+                liveRegionRef.current.textContent = `Hovering on ${countryName}`
+              }}
               tabIndex={-1}
               key={`circle-${countryName.replace(' ', '')}`}
               className={`bubble country--${countryName}`}
@@ -57,7 +84,14 @@ export const BubbleList = ({ data: dataImport, state, projection, applyLegendToR
                 pointerY = e.clientY
               }}
               onPointerUp={e => {
-                if (pointerX && pointerY && e.clientX > pointerX - clickTolerance && e.clientX < pointerX + clickTolerance && e.clientY > pointerY - clickTolerance && e.clientY < pointerY + clickTolerance) {
+                if (
+                  pointerX &&
+                  pointerY &&
+                  e.clientX > pointerX - clickTolerance &&
+                  e.clientX < pointerX + clickTolerance &&
+                  e.clientY > pointerY - clickTolerance &&
+                  e.clientY < pointerY + clickTolerance
+                ) {
                   handleCircleClick(country)
                   pointerX = undefined
                   pointerY = undefined
@@ -85,7 +119,14 @@ export const BubbleList = ({ data: dataImport, state, projection, applyLegendToR
                   pointerY = e.clientY
                 }}
                 onPointerUp={e => {
-                  if (pointerX && pointerY && e.clientX > pointerX - clickTolerance && e.clientX < pointerX + clickTolerance && e.clientY > pointerY - clickTolerance && e.clientY < pointerY + clickTolerance) {
+                  if (
+                    pointerX &&
+                    pointerY &&
+                    e.clientX > pointerX - clickTolerance &&
+                    e.clientX < pointerX + clickTolerance &&
+                    e.clientY > pointerY - clickTolerance &&
+                    e.clientY < pointerY + clickTolerance
+                  ) {
                     handleCircleClick(country)
                     pointerX = undefined
                     pointerY = undefined
@@ -120,7 +161,8 @@ export const BubbleList = ({ data: dataImport, state, projection, applyLegendToR
         if (item[primaryKey] === null) item[primaryKey] = ''
 
         // Return if hiding zeros on the map
-        if ((Math.floor(Number(item[primaryKey])) === 0 || item[primaryKey] === '') && !state.visual.showBubbleZeros) return
+        if ((Math.floor(Number(item[primaryKey])) === 0 || item[primaryKey] === '') && !state.visual.showBubbleZeros)
+          return
 
         if (!stateData) return true
         let longitude = Number(stateData.Longitude)
@@ -156,7 +198,14 @@ export const BubbleList = ({ data: dataImport, state, projection, applyLegendToR
                 pointerY = e.clientY
               }}
               onPointerUp={e => {
-                if (pointerX && pointerY && e.clientX > pointerX - clickTolerance && e.clientX < pointerX + clickTolerance && e.clientY > pointerY - clickTolerance && e.clientY < pointerY + clickTolerance) {
+                if (
+                  pointerX &&
+                  pointerY &&
+                  e.clientX > pointerX - clickTolerance &&
+                  e.clientX < pointerX + clickTolerance &&
+                  e.clientY > pointerY - clickTolerance &&
+                  e.clientY < pointerY + clickTolerance
+                ) {
                   handleCircleClick(state)
                   pointerX = undefined
                   pointerY = undefined
@@ -184,7 +233,14 @@ export const BubbleList = ({ data: dataImport, state, projection, applyLegendToR
                   pointerY = e.clientY
                 }}
                 onPointerUp={e => {
-                  if (pointerX && pointerY && e.clientX > pointerX - clickTolerance && e.clientX < pointerX + clickTolerance && e.clientY > pointerY - clickTolerance && e.clientY < pointerY + clickTolerance) {
+                  if (
+                    pointerX &&
+                    pointerY &&
+                    e.clientX > pointerX - clickTolerance &&
+                    e.clientX < pointerX + clickTolerance &&
+                    e.clientY > pointerY - clickTolerance &&
+                    e.clientY < pointerY + clickTolerance
+                  ) {
                     handleCircleClick(state)
                     pointerX = undefined
                     pointerY = undefined

--- a/packages/map/src/components/CityList.tsx
+++ b/packages/map/src/components/CityList.tsx
@@ -7,6 +7,7 @@ import { GlyphStar, GlyphTriangle, GlyphDiamond, GlyphSquare, GlyphCircle } from
 import { getFilterControllingStatePicked } from './UsaMap/helpers/map'
 
 import ConfigContext from '../context'
+import { handleDismissTooltip } from '@cdc/core/helpers/cove/accessibility'
 
 const CityList = ({
   data,
@@ -18,7 +19,9 @@ const CityList = ({
   setSharedFilterValue,
   isFilterValueSupported,
   tooltipId,
-  projection
+  projection,
+  liveRegionRef,
+  setShowTooltip
 }) => {
   const [citiesData, setCitiesData] = useState({})
   const { scale, state, topoData, runtimeData, position } = useContext(ConfigContext)
@@ -192,12 +195,64 @@ const CityList = ({
     }
 
     const cityStyleShapes = {
-      circle: <GlyphCircle {...shapeProps} />,
+      circle: (
+        <GlyphCircle
+          {...shapeProps}
+          onKeyDown={e => {
+            handleDismissTooltip(e, setShowTooltip)
+            liveRegionRef.current.textContent = 'Dismissing tooltip'
+          }}
+          onMouseMove={setShowTooltip(true)}
+          onMouseEnter={() => {
+            setShowTooltip(true)
+            liveRegionRef.current.textContent = `Hovering on ${stateName}`
+          }}
+        />
+      ),
       pin: pin,
-      square: <GlyphSquare {...shapeProps} />,
-      diamond: <GlyphDiamond {...shapeProps} />,
+      square: (
+        <GlyphSquare
+          {...shapeProps}
+          onKeyDown={e => {
+            handleDismissTooltip(e, setShowTooltip)
+            liveRegionRef.current.textContent = 'Dismissing tooltip'
+          }}
+          onMouseMove={setShowTooltip(true)}
+          onMouseEnter={() => {
+            setShowTooltip(true)
+            liveRegionRef.current.textContent = `Hovering on ${stateName}`
+          }}
+        />
+      ),
+      diamond: (
+        <GlyphDiamond
+          {...shapeProps}
+          onKeyDown={e => {
+            handleDismissTooltip(e, setShowTooltip)
+            liveRegionRef.current.textContent = 'Dismissing tooltip'
+          }}
+          onMouseMove={setShowTooltip(true)}
+          onMouseEnter={() => {
+            setShowTooltip(true)
+            liveRegionRef.current.textContent = `Hovering on ${stateName}`
+          }}
+        />
+      ),
       star: <GlyphStar {...shapeProps} />,
-      triangle: <GlyphTriangle {...shapeProps} />
+      triangle: (
+        <GlyphTriangle
+          {...shapeProps}
+          onKeyDown={e => {
+            handleDismissTooltip(e, setShowTooltip)
+            liveRegionRef.current.textContent = 'Dismissing tooltip'
+          }}
+          onMouseMove={setShowTooltip(true)}
+          onMouseEnter={() => {
+            setShowTooltip(true)
+            liveRegionRef.current.textContent = `Hovering on ${stateName}`
+          }}
+        />
+      )
     }
 
     const { additionalCityStyles } = state.visual || []

--- a/packages/map/src/components/CityList.tsx
+++ b/packages/map/src/components/CityList.tsx
@@ -195,64 +195,12 @@ const CityList = ({
     }
 
     const cityStyleShapes = {
-      circle: (
-        <GlyphCircle
-          {...shapeProps}
-          onKeyDown={e => {
-            handleDismissTooltip(e, setShowTooltip)
-            liveRegionRef.current.textContent = 'Dismissing tooltip'
-          }}
-          onMouseMove={setShowTooltip(true)}
-          onMouseEnter={() => {
-            setShowTooltip(true)
-            liveRegionRef.current.textContent = `Hovering on ${stateName}`
-          }}
-        />
-      ),
+      circle: <GlyphCircle {...shapeProps} />,
       pin: pin,
-      square: (
-        <GlyphSquare
-          {...shapeProps}
-          onKeyDown={e => {
-            handleDismissTooltip(e, setShowTooltip)
-            liveRegionRef.current.textContent = 'Dismissing tooltip'
-          }}
-          onMouseMove={setShowTooltip(true)}
-          onMouseEnter={() => {
-            setShowTooltip(true)
-            liveRegionRef.current.textContent = `Hovering on ${stateName}`
-          }}
-        />
-      ),
-      diamond: (
-        <GlyphDiamond
-          {...shapeProps}
-          onKeyDown={e => {
-            handleDismissTooltip(e, setShowTooltip)
-            liveRegionRef.current.textContent = 'Dismissing tooltip'
-          }}
-          onMouseMove={setShowTooltip(true)}
-          onMouseEnter={() => {
-            setShowTooltip(true)
-            liveRegionRef.current.textContent = `Hovering on ${stateName}`
-          }}
-        />
-      ),
+      square: <GlyphSquare {...shapeProps} />,
+      diamond: <GlyphDiamond {...shapeProps} />,
       star: <GlyphStar {...shapeProps} />,
-      triangle: (
-        <GlyphTriangle
-          {...shapeProps}
-          onKeyDown={e => {
-            handleDismissTooltip(e, setShowTooltip)
-            liveRegionRef.current.textContent = 'Dismissing tooltip'
-          }}
-          onMouseMove={setShowTooltip(true)}
-          onMouseEnter={() => {
-            setShowTooltip(true)
-            liveRegionRef.current.textContent = `Hovering on ${stateName}`
-          }}
-        />
-      )
+      triangle: <GlyphTriangle {...shapeProps} />
     }
 
     const { additionalCityStyles } = state.visual || []

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -29,12 +29,11 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
   const { skipId, currentViewport, dimensions } = props
 
   const {
-    // prettier-ignore
+    liveRegionRef,
     displayDataAsText,
     resetLegendToggles,
     runtimeFilters,
     runtimeLegend,
-    setAccessibleStatus,
     setRuntimeLegend,
     state,
     viewport,
@@ -59,9 +58,9 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
 
     setRuntimeLegend(newLegend)
 
-    setAccessibleStatus(
-      `Disabled legend item ${legendLabel ?? ''}. Please reference the data table to see updated values.`
-    )
+    liveRegionRef.current.textContent = `Disabled legend item ${
+      legendLabel ?? ''
+    }. Please reference the data table to see updated values.`
   }
   const getFormattedLegendItems = () => {
     return runtimeLegend.map((entry, idx) => {
@@ -212,7 +211,7 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
       e.preventDefault()
     }
     resetLegendToggles()
-    setAccessibleStatus('Legend has been reset, please reference the data table to see updated values.')
+    liveRegionRef.current.textContent = 'Legend has been reset, please reference the data table to see updated values.'
     if (legend) {
       legend.focus()
     }

--- a/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
+++ b/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
@@ -33,7 +33,7 @@ const nudges = {
 // todo: combine hexagonLabel & geoLabel functions
 // todo: move geoLabel functions outside of components for reusability
 const TerritoryHexagon = ({ label, text, stroke, strokeWidth, textColor, territory, territoryData, ...props }) => {
-  const { state, setShowTooltip, setLiveRegionMessage } = useContext<MapContext>(ConfigContext)
+  const { state, setShowTooltip, liveRegionRef } = useContext<MapContext>(ConfigContext)
 
   const isHex = state.general.displayAsHex
 
@@ -164,12 +164,12 @@ const TerritoryHexagon = ({ label, text, stroke, strokeWidth, textColor, territo
           {...props}
           onKeyDown={e => {
             handleDismissTooltip(e, setShowTooltip)
-            setLiveRegionMessage('Dismissing tooltip')
+            liveRegionRef.current.textContent = 'Dismissing tooltip'
           }}
           onMouseMove={setShowTooltip(true)}
           onMouseEnter={() => {
             setShowTooltip(true)
-            setLiveRegionMessage(`Hovering on ${territoryData[state.columns.geo.name]}`)
+            liveRegionRef.current.textContent = `Hovering on ${territoryData[state.columns.geo.name]}`
           }}
         >
           <polygon

--- a/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
+++ b/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
@@ -5,6 +5,7 @@ import { MapContext } from './../../../../types/MapContext'
 import HexIcon from '../HexIcon'
 import { Text } from '@visx/text'
 import { getContrastColor } from '@cdc/core/helpers/cove/accessibility'
+import { handleDismissTooltip } from '@cdc/core/helpers/cove/accessibility'
 
 const offsets = {
   'US-VT': [50, -8],
@@ -32,7 +33,7 @@ const nudges = {
 // todo: combine hexagonLabel & geoLabel functions
 // todo: move geoLabel functions outside of components for reusability
 const TerritoryHexagon = ({ label, text, stroke, strokeWidth, textColor, territory, territoryData, ...props }) => {
-  const { state } = useContext<MapContext>(ConfigContext)
+  const { state, setShowTooltip, setLiveRegionMessage } = useContext<MapContext>(ConfigContext)
 
   const isHex = state.general.displayAsHex
 
@@ -115,7 +116,14 @@ const TerritoryHexagon = ({ label, text, stroke, strokeWidth, textColor, territo
       let y = state.hexMap.type === 'shapes' ? '30%' : '50%'
       return (
         <>
-          <Text fontSize={14} x={'50%'} y={y} style={{ fill: 'currentColor', stroke: 'initial', fontWeight: 400, opacity: 1, fillOpacity: 1 }} textAnchor='middle' verticalAnchor='middle'>
+          <Text
+            fontSize={14}
+            x={'50%'}
+            y={y}
+            style={{ fill: 'currentColor', stroke: 'initial', fontWeight: 400, opacity: 1, fillOpacity: 1 }}
+            textAnchor='middle'
+            verticalAnchor='middle'
+          >
             {abbr.substring(3)}
           </Text>
           {state.general.displayAsHex && state.hexMap.type === 'shapes' && getArrowDirection(territoryData, geo, true)}
@@ -127,21 +135,52 @@ const TerritoryHexagon = ({ label, text, stroke, strokeWidth, textColor, territo
 
     return (
       <g>
-        <line x1={centroid[0]} y1={centroid[1]} x2={centroid[0] + dx} y2={centroid[1] + dy} stroke='rgba(0,0,0,.5)' strokeWidth={1} />
-        <text x={4} strokeWidth='0' fontSize={13} style={{ fill: '#202020' }} alignmentBaseline='middle' transform={`translate(${centroid[0] + dx}, ${centroid[1] + dy})`}>
+        <line
+          x1={centroid[0]}
+          y1={centroid[1]}
+          x2={centroid[0] + dx}
+          y2={centroid[1] + dy}
+          stroke='rgba(0,0,0,.5)'
+          strokeWidth={1}
+        />
+        <text
+          x={4}
+          strokeWidth='0'
+          fontSize={13}
+          style={{ fill: '#202020' }}
+          alignmentBaseline='middle'
+          transform={`translate(${centroid[0] + dx}, ${centroid[1] + dy})`}
+        >
           {abbr.substring(3)}
         </text>
       </g>
     )
   }
 
-  return territoryData && (
-    <svg viewBox='0 0 45 51' className='territory-wrapper--hex'>
-      <g {...props}>
-        <polygon stroke={stroke} strokeWidth={strokeWidth} points='22 0 44 12.702 44 38.105 22 50.807 0 38.105 0 12.702' />
-        {state.general.displayAsHex && hexagonLabel(territoryData, stroke, false)}
-      </g>
-    </svg>
+  return (
+    territoryData && (
+      <svg viewBox='0 0 45 51' className='territory-wrapper--hex'>
+        <g
+          {...props}
+          onKeyDown={e => {
+            handleDismissTooltip(e, setShowTooltip)
+            setLiveRegionMessage('Dismissing tooltip')
+          }}
+          onMouseMove={setShowTooltip(true)}
+          onMouseEnter={() => {
+            setShowTooltip(true)
+            setLiveRegionMessage(`Hovering on ${territoryData[state.columns.geo.name]}`)
+          }}
+        >
+          <polygon
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            points='22 0 44 12.702 44 38.105 22 50.807 0 38.105 0 12.702'
+          />
+          {state.general.displayAsHex && hexagonLabel(territoryData, stroke, false)}
+        </g>
+      </svg>
+    )
   )
 }
 

--- a/packages/map/src/components/UsaMap/components/Territory/Territory.Rectangle.tsx
+++ b/packages/map/src/components/UsaMap/components/Territory/Territory.Rectangle.tsx
@@ -6,7 +6,7 @@ import { patternSizes } from './../../helpers/patternSizes'
 import { getContrastColor, handleDismissTooltip } from '@cdc/core/helpers/cove/accessibility'
 
 const TerritoryRectangle = ({ label, text, stroke, strokeWidth, textColor, hasPattern, territory, ...props }) => {
-  const { state, supportedTerritories, setShowTooltip, setLiveRegionMessage } = useContext<MapContext>(ConfigContext)
+  const { state, supportedTerritories, setShowTooltip, liveRegionRef } = useContext<MapContext>(ConfigContext)
   const { territoryData, ...otherProps } = props
 
   return (
@@ -17,12 +17,12 @@ const TerritoryRectangle = ({ label, text, stroke, strokeWidth, textColor, hasPa
         tabIndex={-1}
         onKeyDown={e => {
           handleDismissTooltip(e, setShowTooltip)
-          setLiveRegionMessage('Dismissing tooltip')
+          liveRegionRef.current.textContent = 'Dismissing tooltip'
         }}
         onMouseMove={setShowTooltip(true)}
         onMouseEnter={() => {
           setShowTooltip(true)
-          setLiveRegionMessage(`Hovering on ${territoryData[state.columns.geo.name]}`)
+          liveRegionRef.current.textContent = `Hovering on ${territoryData[state.columns.geo.name]}`
         }}
       >
         <path

--- a/packages/map/src/components/UsaMap/components/Territory/Territory.Rectangle.tsx
+++ b/packages/map/src/components/UsaMap/components/Territory/Territory.Rectangle.tsx
@@ -3,22 +3,44 @@ import { PatternLines, PatternCircles, PatternWaves } from '@visx/pattern'
 import ConfigContext from './../../../../context'
 import { type MapContext } from '../../../../types/MapContext'
 import { patternSizes } from './../../helpers/patternSizes'
-import { getContrastColor } from '@cdc/core/helpers/cove/accessibility'
+import { getContrastColor, handleDismissTooltip } from '@cdc/core/helpers/cove/accessibility'
 
 const TerritoryRectangle = ({ label, text, stroke, strokeWidth, textColor, hasPattern, territory, ...props }) => {
-  const { state, supportedTerritories } = useContext<MapContext>(ConfigContext)
+  const { state, supportedTerritories, setShowTooltip, setLiveRegionMessage } = useContext<MapContext>(ConfigContext)
   const { territoryData, ...otherProps } = props
 
   return (
     <svg viewBox='0 0 45 28' key={territory} className={territory}>
-      <g {...otherProps} strokeLinejoin='round' tabIndex={-1}>
+      <g
+        {...otherProps}
+        strokeLinejoin='round'
+        tabIndex={-1}
+        onKeyDown={e => {
+          handleDismissTooltip(e, setShowTooltip)
+          setLiveRegionMessage('Dismissing tooltip')
+        }}
+        onMouseMove={setShowTooltip(true)}
+        onMouseEnter={() => {
+          setShowTooltip(true)
+          setLiveRegionMessage(`Hovering on ${territoryData[state.columns.geo.name]}`)
+        }}
+      >
         <path
           stroke={stroke}
           strokeWidth={strokeWidth}
           d='M40,0.5 C41.2426407,0.5 42.3676407,1.00367966 43.1819805,1.81801948 C43.9963203,2.63235931 44.5,3.75735931 44.5,5 L44.5,5 L44.5,23 C44.5,24.2426407 43.9963203,25.3676407 43.1819805,26.1819805 C42.3676407,26.9963203 41.2426407,27.5 40,27.5 L40,27.5 L5,27.5 C3.75735931,27.5 2.63235931,26.9963203 1.81801948,26.1819805 C1.00367966,25.3676407 0.5,24.2426407 0.5,23 L0.5,23 L0.5,5 C0.5,3.75735931 1.00367966,2.63235931 1.81801948,1.81801948 C2.63235931,1.00367966 3.75735931,0.5 5,0.5 L5,0.5 Z'
           {...otherProps}
         />
-        <text textAnchor='middle' dominantBaseline='middle' x='50%' y='54%' fill={text} style={{ stroke: textColor, strokeWidth: 1 }} className='territory-text' paintOrder='stroke'>
+        <text
+          textAnchor='middle'
+          dominantBaseline='middle'
+          x='50%'
+          y='54%'
+          fill={text}
+          style={{ stroke: textColor, strokeWidth: 1 }}
+          className='territory-text'
+          paintOrder='stroke'
+        >
           {label}
         </text>
 
@@ -31,18 +53,59 @@ const TerritoryRectangle = ({ label, text, stroke, strokeWidth, textColor, hasPa
 
           return (
             <>
-              {patternData?.pattern === 'waves' && <PatternWaves id={`territory-${patternData?.dataKey}--${patternIndex}`} height={patternSizes[patternData?.size] ?? 10} width={patternSizes[patternData?.size] ?? 10} fill={patternColor} complement />}
-              {patternData?.pattern === 'circles' && <PatternCircles id={`territory-${patternData?.dataKey}--${patternIndex}`} height={patternSizes[patternData?.size] ?? 10} width={patternSizes[patternData?.size] ?? 10} fill={patternColor} complement />}
-              {patternData?.pattern === 'lines' && <PatternLines id={`territory-${patternData?.dataKey}--${patternIndex}`} height={patternSizes[patternData?.size] ?? 6} width={patternSizes[patternData?.size] ?? 6} stroke={patternColor} strokeWidth={1} orientation={['diagonalRightToLeft']} />}
+              {patternData?.pattern === 'waves' && (
+                <PatternWaves
+                  id={`territory-${patternData?.dataKey}--${patternIndex}`}
+                  height={patternSizes[patternData?.size] ?? 10}
+                  width={patternSizes[patternData?.size] ?? 10}
+                  fill={patternColor}
+                  complement
+                />
+              )}
+              {patternData?.pattern === 'circles' && (
+                <PatternCircles
+                  id={`territory-${patternData?.dataKey}--${patternIndex}`}
+                  height={patternSizes[patternData?.size] ?? 10}
+                  width={patternSizes[patternData?.size] ?? 10}
+                  fill={patternColor}
+                  complement
+                />
+              )}
+              {patternData?.pattern === 'lines' && (
+                <PatternLines
+                  id={`territory-${patternData?.dataKey}--${patternIndex}`}
+                  height={patternSizes[patternData?.size] ?? 6}
+                  width={patternSizes[patternData?.size] ?? 6}
+                  stroke={patternColor}
+                  strokeWidth={1}
+                  orientation={['diagonalRightToLeft']}
+                />
+              )}
               <path
                 stroke={stroke}
                 strokeWidth={strokeWidth}
                 d='M40,0.5 C41.2426407,0.5 42.3676407,1.00367966 43.1819805,1.81801948 C43.9963203,2.63235931 44.5,3.75735931 44.5,5 L44.5,5 L44.5,23 C44.5,24.2426407 43.9963203,25.3676407 43.1819805,26.1819805 C42.3676407,26.9963203 41.2426407,27.5 40,27.5 L40,27.5 L5,27.5 C3.75735931,27.5 2.63235931,26.9963203 1.81801948,26.1819805 C1.00367966,25.3676407 0.5,24.2426407 0.5,23 L0.5,23 L0.5,5 C0.5,3.75735931 1.00367966,2.63235931 1.81801948,1.81801948 C2.63235931,1.00367966 3.75735931,0.5 5,0.5 L5,0.5 Z'
                 fill={`url(#territory-${patternData?.dataKey}--${patternIndex})`}
                 color={patternData ? 'white' : textColor}
-                className={[`territory-pattern-${patternData.dataKey}`, `territory-pattern-${patternData.dataKey}--${patternData.dataValue}`].join(' ')}
+                className={[
+                  `territory-pattern-${patternData.dataKey}`,
+                  `territory-pattern-${patternData.dataKey}--${patternData.dataValue}`
+                ].join(' ')}
               />
-              <text textAnchor='middle' dominantBaseline='middle' x='50%' y='54%' fill={text} style={{ fill: patternData ? 'white' : 'black', stroke: patternData ? 'black' : textColor, strokeWidth: patternData ? 6 : 0 }} className='territory-text' paint-order='stroke'>
+              <text
+                textAnchor='middle'
+                dominantBaseline='middle'
+                x='50%'
+                y='54%'
+                fill={text}
+                style={{
+                  fill: patternData ? 'white' : 'black',
+                  stroke: patternData ? 'black' : textColor,
+                  strokeWidth: patternData ? 6 : 0
+                }}
+                className='territory-text'
+                paint-order='stroke'
+              >
                 {label}
               </text>
             </>

--- a/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
@@ -320,11 +320,6 @@ const CountyMap = props => {
     const context = canvas.getContext('2d')
     const path = geoPath(topoData.projection, context)
 
-    const handleKeyDown = e => {
-      handleDismissTooltip(e, setShowTooltip)
-      liveRegionRef.current.textContent = 'Dismissing tooltip'
-    }
-
     const handleMouseMove = () => {
       setShowTooltip(true)
     }
@@ -393,7 +388,6 @@ const CountyMap = props => {
             context.fill()
             context.stroke()
           }
-          canvas.addEventListener('keydown', handleKeyDown)
           canvas.addEventListener('mousemove', handleMouseMove)
           canvas.addEventListener('mouseenter', handleMouseEnter(county.id))
 
@@ -631,7 +625,12 @@ const CountyMap = props => {
           tooltipRef.current.style.display = 'none'
           tooltipRef.current.setAttribute('data-index', null)
         }}
+        onKeyDown={e => {
+          handleDismissTooltip(e, setShowTooltip)
+          liveRegionRef.current.textContent = 'Dismissing tooltip'
+        }}
         onClick={canvasClick}
+        tabIndex={0}
         className='county-map-canvas'
       ></canvas>
 

--- a/packages/map/src/components/UsaMap/components/UsaMap.Region.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.Region.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, memo, useContext } from 'react'
 import { getContrastColor } from '@cdc/core/helpers/cove/accessibility'
+import { handleDismissTooltip } from '@cdc/core/helpers/cove/accessibility'
 
 // 3rd party
 import { geoCentroid } from 'd3-geo'
@@ -40,9 +41,11 @@ const UsaRegionMap = props => {
     displayGeoName,
     geoClickHandler,
     handleMapAriaLabels,
+    liveRegionRef,
+    setShowTooltip,
     state,
     supportedTerritories,
-    tooltipId
+    tooltipId,
   } = useContext(ConfigContext)
 
   // "Choose State" options
@@ -97,7 +100,10 @@ const UsaRegionMap = props => {
       let needsPointer = false
 
       // If we need to add a pointer cursor
-      if ((state.columns.navigate && territoryData[state.columns.navigate.name]) || state.tooltips.appearanceType === 'click') {
+      if (
+        (state.columns.navigate && territoryData[state.columns.navigate.name]) ||
+        state.tooltips.appearanceType === 'click'
+      ) {
         needsPointer = true
       }
 
@@ -113,7 +119,19 @@ const UsaRegionMap = props => {
         }
       }
 
-      return <Shape key={label} label={label} css={styles} text={styles.color} stroke={geoStrokeColor} strokeWidth={1.5} onClick={() => geoClickHandler(territory, territoryData)} data-tooltip-id={`tooltip__${tooltipId}`} data-tooltip-html={toolTip} />
+      return (
+        <Shape
+          key={label}
+          label={label}
+          css={styles}
+          text={styles.color}
+          stroke={geoStrokeColor}
+          strokeWidth={1.5}
+          onClick={() => geoClickHandler(territory, territoryData)}
+          data-tooltip-id={`tooltip__${tooltipId}`}
+          data-tooltip-html={toolTip}
+        />
+      )
     }
   })
 
@@ -130,8 +148,22 @@ const UsaRegionMap = props => {
 
     return (
       <g>
-        <line x1={centroid[0]} y1={centroid[1]} x2={centroid[0] + dx} y2={centroid[1] + dy} stroke='rgba(0,0,0,.5)' strokeWidth={1} />
-        <text x={4} strokeWidth='0' fontSize={13} style={{ fill: '#202020' }} alignmentBaseline='middle' transform={`translate(${centroid[0] + dx}, ${centroid[1] + dy})`}>
+        <line
+          x1={centroid[0]}
+          y1={centroid[1]}
+          x2={centroid[0] + dx}
+          y2={centroid[1] + dy}
+          stroke='rgba(0,0,0,.5)'
+          strokeWidth={1}
+        />
+        <text
+          x={4}
+          strokeWidth='0'
+          fontSize={13}
+          style={{ fill: '#202020' }}
+          alignmentBaseline='middle'
+          transform={`translate(${centroid[0] + dx}, ${centroid[1] + dy})`}
+        >
           {abbr.substring(3)}
         </text>
       </g>
@@ -183,7 +215,10 @@ const UsaRegionMap = props => {
         }
 
         // When to add pointer cursor
-        if ((state.columns.navigate && geoData[state.columns.navigate.name]) || state.tooltips.appearanceType === 'click') {
+        if (
+          (state.columns.navigate && geoData[state.columns.navigate.name]) ||
+          state.tooltips.appearanceType === 'click'
+        ) {
           styles.cursor = 'pointer'
         }
 
@@ -203,7 +238,24 @@ const UsaRegionMap = props => {
         const circleRadius = 15
 
         return (
-          <g key={key} className='geo-group' style={styles} onClick={() => geoClickHandler(geoDisplayName, geoData)} data-tooltip-id={`tooltip__${tooltipId}`} data-tooltip-html={toolTip} tabIndex={-1}>
+          <g
+            key={key}
+            className='geo-group'
+            style={styles}
+            onClick={() => geoClickHandler(geoDisplayName, geoData)}
+            data-tooltip-id={`tooltip__${tooltipId}`}
+            data-tooltip-html={toolTip}
+            tabIndex={-1}
+            onKeyDown={e => {
+              handleDismissTooltip(e, setShowTooltip)
+              liveRegionRef.current.textContent = 'Dismissing tooltip'
+            }}
+            onMouseMove={setShowTooltip(true)}
+            onMouseEnter={() => {
+              setShowTooltip(true)
+              liveRegionRef.current.textContent = `Hovering on ${geoDisplayName}`
+            }}
+          >
             <path tabIndex={-1} className='single-geo' stroke={geoStrokeColor} strokeWidth={1.3} d={path} />
             <g id={`region-${index + 1}-label`}>
               <circle fill='#fff' stroke='#999' cx={circleRadius} cy={circleRadius} r={circleRadius} />

--- a/packages/map/src/components/UsaMap/components/UsaMap.Region.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.Region.tsx
@@ -246,10 +246,6 @@ const UsaRegionMap = props => {
             data-tooltip-id={`tooltip__${tooltipId}`}
             data-tooltip-html={toolTip}
             tabIndex={-1}
-            onKeyDown={e => {
-              handleDismissTooltip(e, setShowTooltip)
-              liveRegionRef.current.textContent = 'Dismissing tooltip'
-            }}
             onMouseMove={setShowTooltip(true)}
             onMouseEnter={() => {
               setShowTooltip(true)
@@ -301,7 +297,16 @@ const UsaRegionMap = props => {
 
   return (
     <ErrorBoundary component='UsaRegionMap'>
-      <svg viewBox='0 0 880 500' role='img' aria-label={handleMapAriaLabels(state)}>
+      <svg
+        viewBox='0 0 880 500'
+        role='img'
+        tabIndex={0}
+        aria-label={handleMapAriaLabels(state)}
+        onKeyDown={e => {
+          handleDismissTooltip(e, setShowTooltip)
+          liveRegionRef.current.textContent = 'Dismissing tooltip'
+        }}
+      >
         <Mercator data={focusedStates} scale={620} translate={[1500, 735]}>
           {({ features, projection }) => constructGeoJsx(features, projection)}
         </Mercator>

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -16,6 +16,7 @@ import { geoAlbersUsa } from 'd3-composite-projections'
 import { PatternLines, PatternCircles, PatternWaves } from '@visx/pattern'
 import HexIcon from './HexIcon'
 import { patternSizes } from '../helpers/patternSizes'
+import { handleDismissTooltip } from '@cdc/core/helpers/cove/accessibility'
 import Annotation from '../../Annotation'
 
 import Territory from './Territory'
@@ -59,16 +60,17 @@ const UsaMap = () => {
       data,
       displayGeoName,
       geoClickHandler,
-      handleCircleClick,
+      handleDragStateChange,
       handleMapAriaLabels,
+      mapId,
       setSharedFilterValue,
+      setShowTooltip,
+      showTooltip,
+      setLiveRegionMessage,
       state,
       supportedTerritories,
       titleCase,
       tooltipId,
-      handleDragStateChange,
-      setState,
-      mapId
     } = useContext<MapContext>(ConfigContext)
 
   let isFilterValueSupported = false
@@ -395,7 +397,20 @@ const UsaMap = () => {
         }
 
         return (
-          <g data-name={geoName} key={key} tabIndex={-1}>
+          <g
+            data-name={geoName}
+            key={key}
+            tabIndex={-1}
+            onKeyDown={e => {
+              handleDismissTooltip(e, setShowTooltip)
+              setLiveRegionMessage('Dismissing tooltip')
+            }}
+            onMouseMove={setShowTooltip(true)}
+            onMouseEnter={() => {
+              setShowTooltip(true)
+              setLiveRegionMessage(`Hovering on ${geoDisplayName}`)
+            }}
+          >
             <g
               className='geo-group'
               style={styles}

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -24,7 +24,7 @@ import Territory from './Territory'
 import useMapLayers from '../../../hooks/useMapLayers'
 import ConfigContext from '../../../context'
 import { MapContext } from '../../../types/MapContext'
-import { checkColorContrast, getContrastColor, getColorContrast } from '@cdc/core/helpers/cove/accessibility'
+import { checkColorContrast, getContrastColor } from '@cdc/core/helpers/cove/accessibility'
 
 const { features: unitedStates } = feature(topoJSON, topoJSON.objects.states)
 const { features: unitedStatesHex } = feature(hexTopoJSON, hexTopoJSON.objects.states)
@@ -71,6 +71,7 @@ const UsaMap = () => {
       supportedTerritories,
       titleCase,
       tooltipId,
+      liveRegionRef
     } = useContext<MapContext>(ConfigContext)
 
   let isFilterValueSupported = false
@@ -403,12 +404,12 @@ const UsaMap = () => {
             tabIndex={-1}
             onKeyDown={e => {
               handleDismissTooltip(e, setShowTooltip)
-              setLiveRegionMessage('Dismissing tooltip')
+              liveRegionRef.current.textContent = 'Dismissing tooltip'
             }}
             onMouseMove={setShowTooltip(true)}
             onMouseEnter={() => {
               setShowTooltip(true)
-              setLiveRegionMessage(`Hovering on ${geoDisplayName}`)
+              liveRegionRef.current.textContent = `Hovering on ${geoDisplayName}`
             }}
           >
             <g

--- a/packages/map/src/components/WorldMap/WorldMap.tsx
+++ b/packages/map/src/components/WorldMap/WorldMap.tsx
@@ -1,6 +1,7 @@
 import { memo, useContext } from 'react'
 
 import ErrorBoundary from '@cdc/core/components/ErrorBoundary'
+import { handleDismissTooltip } from '@cdc/core/helpers/cove/accessibility'
 import { geoMercator } from 'd3-geo'
 import { Mercator } from '@visx/geo'
 import { feature } from 'topojson-client'
@@ -27,6 +28,7 @@ const WorldMap = () => {
     geoClickHandler,
     handleMapAriaLabels,
     hasZoom,
+    liveRegionRef,
     position,
     setFilteredCountryCode,
     setPosition,
@@ -37,7 +39,8 @@ const WorldMap = () => {
     titleCase,
     tooltipId,
     setScale,
-    setTranslate
+    setTranslate,
+    setShowTooltip
   } = useContext(ConfigContext)
 
   // TODO Refactor - state should be set together here to avoid rerenders
@@ -77,7 +80,12 @@ const WorldMap = () => {
     const geosJsx = geographies.map(({ feature: geo, path }, i) => {
       // If the geo.properties.state value is found in the data use that, otherwise fall back to geo.properties.iso
       const dataHasStateName = state.data.some(d => d[state.columns.geo.name] === geo.properties.state)
-      const geoKey = geo.properties.state && data[geo.properties.state] ? geo.properties.state : geo.properties.name ? geo.properties.name : geo.properties.iso
+      const geoKey =
+        geo.properties.state && data[geo.properties.state]
+          ? geo.properties.state
+          : geo.properties.name
+          ? geo.properties.name
+          : geo.properties.iso
 
       const additionalData = {
         name: geo.properties.name
@@ -98,7 +106,8 @@ const WorldMap = () => {
         legendColors = applyLegendToRow(geoData)
       }
 
-      const geoStrokeColor = state.general.geoBorderColor === 'darkGray' ? 'rgba(0, 0, 0, 0.2)' : 'rgba(255,255,255,0.7)'
+      const geoStrokeColor =
+        state.general.geoBorderColor === 'darkGray' ? 'rgba(0, 0, 0, 0.2)' : 'rgba(255,255,255,0.7)'
 
       let styles: Record<string, string | Record<string, string>> = {
         fill: '#E6E6E6',
@@ -124,7 +133,10 @@ const WorldMap = () => {
         }
 
         // When to add pointer cursor
-        if ((state.columns.navigate && geoData[state.columns.navigate.name]) || state.tooltips.appearanceType === 'click') {
+        if (
+          (state.columns.navigate && geoData[state.columns.navigate.name]) ||
+          state.tooltips.appearanceType === 'click'
+        ) {
           styles.cursor = 'pointer'
         }
 
@@ -142,16 +154,49 @@ const WorldMap = () => {
             data-tooltip-id={`tooltip__${tooltipId}`}
             data-tooltip-html={toolTip}
             tabIndex={-1}
+            onKeyDown={e => {
+              handleDismissTooltip(e, setShowTooltip)
+              liveRegionRef.current.textContent = 'Dismissing tooltip'
+            }}
+            onMouseMove={setShowTooltip(true)}
+            onMouseEnter={() => {
+              setShowTooltip(true)
+              liveRegionRef.current.textContent = `Hovering on ${geoDisplayName}`
+            }}
           />
         )
       }
 
       // Default return state, just geo with no additional information
-      return <Geo additionaldata={JSON.stringify(additionalData)} geodata={JSON.stringify(geoData)} state={state} key={i + '-geo'} stroke={geoStrokeColor} strokeWidth={strokeWidth} style={styles} path={path} />
+      return (
+        <Geo
+          additionaldata={JSON.stringify(additionalData)}
+          geodata={JSON.stringify(geoData)}
+          state={state}
+          key={i + '-geo'}
+          stroke={geoStrokeColor}
+          strokeWidth={strokeWidth}
+          style={styles}
+          path={path}
+        />
+      )
     })
 
     // Cities
-    geosJsx.push(<CityList applyLegendToRow={applyLegendToRow} applyTooltipsToGeo={applyTooltipsToGeo} data={data} displayGeoName={displayGeoName} geoClickHandler={geoClickHandler} key='cities' projection={projection} state={state} titleCase={titleCase} tooltipId={tooltipId} />)
+    geosJsx.push(
+      <CityList
+        applyLegendToRow={applyLegendToRow}
+        applyTooltipsToGeo={applyTooltipsToGeo}
+        data={data}
+        displayGeoName={displayGeoName}
+        geoClickHandler={geoClickHandler}
+        key='cities'
+        projection={projection}
+        state={state}
+        titleCase={titleCase}
+        tooltipId={tooltipId}
+      />
+    )
 
     // Bubbles
     if (state.general.type === 'bubble') {
@@ -166,7 +211,9 @@ const WorldMap = () => {
           applyTooltipsToGeo={applyTooltipsToGeo}
           displayGeoName={displayGeoName}
           tooltipId={tooltipId}
-          handleCircleClick={country => handleCircleClick(country, state, setState, setRuntimeData, generateRuntimeData)}
+          handleCircleClick={country =>
+            handleCircleClick(country, state, setState, setRuntimeData, generateRuntimeData)
+          }
         />
       )
     }
@@ -178,19 +225,42 @@ const WorldMap = () => {
     <ErrorBoundary component='WorldMap'>
       {hasZoom ? (
         <svg viewBox='0 0 880 500' role='img' aria-label={handleMapAriaLabels(state)}>
-          <rect height={500} width={880} onClick={() => handleReset(state, setState, setRuntimeData, generateRuntimeData)} fill='white' />
-          <ZoomableGroup zoom={position.zoom} center={position.coordinates} onMoveEnd={handleMoveEnd} maxZoom={4} projection={projection} width={880} height={500}>
+          <rect
+            height={500}
+            width={880}
+            onClick={() => handleReset(state, setState, setRuntimeData, generateRuntimeData)}
+            fill='white'
+          />
+          <ZoomableGroup
+            zoom={position.zoom}
+            center={position.coordinates}
+            onMoveEnd={handleMoveEnd}
+            maxZoom={4}
+            projection={projection}
+            width={880}
+            height={500}
+          >
             <Mercator data={world}>{({ features }) => constructGeoJsx(features)}</Mercator>
           </ZoomableGroup>
         </svg>
       ) : (
         <svg viewBox='0 0 880 500'>
-          <ZoomableGroup zoom={1} center={position.coordinates} onMoveEnd={handleMoveEnd} maxZoom={0} projection={projection} width={880} height={500}>
+          <ZoomableGroup
+            zoom={1}
+            center={position.coordinates}
+            onMoveEnd={handleMoveEnd}
+            maxZoom={0}
+            projection={projection}
+            width={880}
+            height={500}
+          >
             <Mercator data={world}>{({ features }) => constructGeoJsx(features)}</Mercator>
           </ZoomableGroup>
         </svg>
       )}
-      {(state.general.type === 'data' || (state.general.type === 'world-geocode' && hasZoom) || (state.general.type === 'bubble' && hasZoom)) && (
+      {(state.general.type === 'data' ||
+        (state.general.type === 'world-geocode' && hasZoom) ||
+        (state.general.type === 'bubble' && hasZoom)) && (
         <ZoomControls
           // prettier-ignore
           generateRuntimeData={generateRuntimeData}

--- a/packages/map/src/context.ts
+++ b/packages/map/src/context.ts
@@ -27,7 +27,6 @@ type MapContext = {
   resetLegendToggles
   runtimeFilters
   runtimeLegend
-  setAccessibleStatus
   setFilteredCountryCode
   setParentConfig
   setPosition

--- a/packages/map/src/context.ts
+++ b/packages/map/src/context.ts
@@ -45,6 +45,7 @@ type MapContext = {
   titleCase
   tooltipId: string
   viewport
+  setShowTooltip: Function
 }
 
 const ConfigContext = createContext({} as MapContext)

--- a/packages/map/src/context.ts
+++ b/packages/map/src/context.ts
@@ -21,6 +21,8 @@ type MapContext = {
   isDashboard
   isDebug
   isEditor
+  // div that has aria-live region set to assertive
+  liveRegionRef: React.RefObject<HTMLDivElement>
   loadConfig
   navigationHandler
   position

--- a/packages/map/src/types/MapContext.ts
+++ b/packages/map/src/types/MapContext.ts
@@ -29,7 +29,6 @@ export type MapContext = {
   resetLegendToggles
   runtimeFilters
   runtimeLegend
-  setAccessibleStatus
   setFilteredCountryCode
   setParentConfig
   setPosition


### PR DESCRIPTION
- Verified states are in order for tabbing
- Adds a live region for reading aloud hovers on US State Maps
- Adds the ability to dismmiss React Tooltips on USA Maps using the escape key
- Updates Territory Rectangles and Hexagons to use the assertive live region

## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
