### PR TITLE
FIX: DEV-9346 Nested Dropdown: not populating filter options (Viz level)

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -73,6 +73,7 @@ import SkipTo from '@cdc/core/components/elements/SkipTo'
 import { filterVizData } from '@cdc/core/helpers/filterVizData'
 import LegendWrapper from './components/LegendWrapper'
 import _ from 'lodash'
+import { addValuesToFilters } from '@cdc/core/helpers/addValuesToFilters'
 
 interface CdcChartProps {
   configUrl?: string
@@ -290,14 +291,6 @@ const CdcChart = ({
       }
     }
     let newConfig = { ...defaults, ...response }
-    if (newConfig.filters) {
-      newConfig.filters.forEach((filter, index) => {
-        const queryStringFilterValue = getQueryStringFilterValue(filter)
-        if (queryStringFilterValue) {
-          newConfig.filters[index].active = queryStringFilterValue
-        }
-      })
-    }
 
     if (newConfig.visualizationType === 'Box Plot') {
       newConfig.legend.hide = true
@@ -373,28 +366,8 @@ const CdcChart = ({
     // After data is grabbed, loop through and generate filter column values if there are any
     let currentData: any[] = []
     if (newConfig.filters) {
-      newConfig.filters.forEach((filter, index) => {
-        const filterValues =
-          filter.filterStyle === 'nested-dropdown'
-            ? filter.values
-            : filter.orderedValues ||
-              generateValuesForFilter(filter.columnName, newExcludedData).sort(
-                filter.order === 'desc' ? sortDesc : sortAsc
-              )
-
-        newConfig.filters[index].values = filterValues
-        // Initial filter should be active
-
-        const includes = (arr: any[], val: any): boolean => (arr || []).map(val => String(val)).includes(String(val))
-        newConfig.filters[index].active =
-          !newConfig.filters[index].active || !includes(filterValues, newConfig.filters[index].active)
-            ? filterValues[0]
-            : newConfig.filters[index].active
-        newConfig.filters[index].filterStyle = newConfig.filters[index].filterStyle
-          ? newConfig.filters[index].filterStyle
-          : 'dropdown'
-      })
-      currentData = filterVizData(newConfig.filters, newExcludedData)
+      const filtersWithValues = addValuesToFilters(newConfig.filters, newExcludedData)
+      currentData = filterVizData(filtersWithValues, newExcludedData)
       setFilteredData(currentData)
     }
 

--- a/packages/core/components/EditorPanel/VizFilterEditor/NestedDropdownEditor.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/NestedDropdownEditor.tsx
@@ -3,6 +3,7 @@ import { SubGrouping, VizFilter, OrderBy } from '../../../types/VizFilter'
 import { filterOrderOptions, handleSorting } from '../../Filters'
 import FilterOrder from './components/FilterOrder'
 import { Visualization } from '../../../types/Visualization'
+import { useMemo } from 'react'
 
 type NestedDropdownEditorProps = {
   config: Visualization
@@ -121,6 +122,25 @@ const NestedDropdownEditor: React.FC<NestedDropdownEditorProps> = ({
 
   const columnNameOptions = dataColumns.filter(columnName => !listOfUsedColumnNames.includes(columnName))
 
+  const useParameters = useMemo(() => {
+    const filter = config.filters[filterIndex]
+    return !!(filter.setByQueryParameter && filter.subGrouping.setByQueryParameter)
+  }, [config, filterIndex])
+
+  const handleParametersCheckboxClick = e => {
+    const updatedFilters = config.filters
+    const { checked } = e.target
+    const groupColumnName = checked ? filter.columnName : ''
+    const subGroupColumnName = checked ? subGrouping.columnName : ''
+    updatedFilters[filterIndex] = {
+      ...config.filters[filterIndex],
+      setByQueryParameter: groupColumnName,
+      subGrouping: { ...subGrouping, setByQueryParameter: subGroupColumnName }
+    }
+
+    updateField(null, null, 'filters', updatedFilters)
+  }
+
   return (
     <div className='nesteddropdown-editor'>
       <label>
@@ -175,15 +195,13 @@ const NestedDropdownEditor: React.FC<NestedDropdownEditorProps> = ({
       <label>
         <input
           type='checkbox'
-          checked={!!filter.setByQueryParameter}
+          checked={useParameters}
           aria-label='Create query parameters'
-          onChange={e => {
-            updateGroupingFilterProp('setByQueryParameter', filter.columnName)
-            updateSubGroupingFilterProperty({ ...subGrouping, setByQueryParameter: subGrouping.columnName })
-          }}
+          disabled={!filter.columnName || !subGrouping?.columnName}
+          onChange={e => handleParametersCheckboxClick(e)}
         />
         <span> Create query parameters</span>
-        {!!filter.setByQueryParameter && (
+        {useParameters && (
           <>
             <span className='edit-label column-heading mt-2'>
               Grouping: Default Value Set By Query String Parameter

--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -113,6 +113,14 @@ export const useFilters = props => {
         queryParams[newFilter.setByQueryParameter] = newFilter.active
         updateQueryString(queryParams)
       }
+      if (
+        newFilter?.subGrouping.setByQueryParameter &&
+        queryParams[newFilter?.subGrouping.setByQueryParameter] !== newFilter?.subGrouping.active
+      ) {
+        queryParams[newFilter?.subGrouping.setByQueryParameter] = newFilter.subGrouping.active
+        updateQueryString(queryParams)
+      }
+      setFilteredData(newFilters[index])
     }
 
     if (!visualizationConfig.dynamicSeries) {

--- a/packages/core/helpers/addValuesToFilters.ts
+++ b/packages/core/helpers/addValuesToFilters.ts
@@ -122,7 +122,12 @@ export const addValuesToFilters = (filters: VizFilter[], data: any[] | MapData):
       }
     }
     if (filterCopy.subGrouping) {
-      const queryStringFilterValue = getQueryStringFilterValue(filterCopy.subGrouping)
+      const groupName = filterCopy.active as string
+      const subGroupingFilter = {
+        ...filterCopy.subGrouping,
+        values: filterCopy.subGrouping.valuesLookup[groupName].values
+      }
+      const queryStringFilterValue = getQueryStringFilterValue(subGroupingFilter)
       const groupActive = filterCopy.active || filterCopy.values[0]
       const defaultValue = filterCopy.subGrouping.valuesLookup[groupActive as string].values[0]
       // if the value doesn't exist in the subGrouping then return the default


### PR DESCRIPTION


## DEV-9346 Nested Dropdown: not populating filter options (Viz level)
[https://websupport.cdc.gov/browse/DEV-9346](https://websupport.cdc.gov/browse/DEV-9346)

When a nested dropdown option is selected and parameters are used, the URL will change showing the newly selected option. 

Also, when parameters are used, using the URL with parameters will selected the nested dropdown option and display the correct chart on the screen  

## Testing Steps

Scenario: Upload [dev-9346-nested-dropdown-using-parameters.json](https://github.com/user-attachments/files/17509307/dev-9346-nested-dropdown-using-parameters.json), Click on Dashboard Preview 

Expected: There is a bar chart with a nested dropdown filter.  

1. Click on the Nested Dropdown and select Age Group 3 - Overall
2. Once loaded, copy the URL
3. Click on the Nested Dropdown and select Age Group - 50-64 years
4. Replace current URL with the copied URL from step 2 
5. Go to that URL

Expected: The Chart from step 3 will show Age Group - 50-64 years has 6 bars. After navigating the the URL in step 2 there will be 1 single bar and the nested dropdown will read "Age Group 3 - Overall"

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings