### PR TITLE
refactor [BlurStrokeText] make blur stroke default 8

### DIFF
--- a/packages/core/components/BlurStrokeText.tsx
+++ b/packages/core/components/BlurStrokeText.tsx
@@ -15,7 +15,7 @@ export interface BlurStrokeTextProps extends React.ComponentProps<typeof Text> {
 export const BlurStrokeText: React.FC<BlurStrokeTextProps> = ({
   blurRadius = 1,
   stroke = 'white',
-  strokeWidth = 4.5,
+  strokeWidth = 8,
   strokeMiterLimit = 2,
   disableStroke = false,
   disableBlur = false,


### PR DESCRIPTION
No ticket

## Testing Steps

Make a chart with overlapping Y-Axis labes (i.e. "Only show top prefix/suffix" or "Labels above gridlines") and observe larger stroke

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)
<img width="793" alt="Screenshot 2024-10-24 at 3 53 02 PM" src="https://github.com/user-attachments/assets/ba66aec9-3672-4a85-afc9-c12907bfda77">
<img width="902" alt="Screenshot 2024-10-24 at 3 53 10 PM" src="https://github.com/user-attachments/assets/9f0565c6-4e16-447f-9705-84548680c899">