### PR TITLE
fix [dev-9648] pivot tables adding additional rows

### DIFF
--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -22,6 +22,7 @@ import { Column } from '../../types/Column'
 import { pivotData } from '../../helpers/pivotData'
 import { isLegendWrapViewport } from '@cdc/core/helpers/viewports'
 import './data-table.css'
+import _ from 'lodash'
 
 export type DataTableProps = {
   applyLegendToRow?: Function
@@ -73,9 +74,14 @@ const DataTable = (props: DataTableProps) => {
   const runtimeData = useMemo(() => {
     const data = removeNullColumns(parentRuntimeData)
     if (config.table.pivot) {
+      const excludeColumns = Object.values(config.columns || {})
+        .filter(column => column.dataTable === false)
+        .map(col => col.name)
       const { columnName, valueColumns } = config.table.pivot
       if (columnName && valueColumns) {
-        return pivotData(data, columnName, valueColumns)
+        // remove excluded columns so that they aren't included in the pivot calculation
+        const _data = data.map(row => _.omit(row, excludeColumns))
+        return pivotData(_data, columnName, valueColumns)
       }
     }
     return data

--- a/packages/dashboard/src/_stories/_mock/group-pivot-filter.json
+++ b/packages/dashboard/src/_stories/_mock/group-pivot-filter.json
@@ -30,7 +30,12 @@
           "valueColumns": ["age", "color"]
         }
       },
-      "columns": {},
+      "columns": {
+        "other": {
+          "name": "other",
+          "dataTable": false
+        }
+      },
       "dataFormat": {},
       "visualizationType": "table",
       "dataDescription": {
@@ -59,10 +64,10 @@
   "datasets": {
     "valid-data-chart.csv": {
       "data": [
-        { "name": "John", "age": 25, "color": "blue", "city": "New York" },
-        { "name": "Jane", "age": 27, "color": "red", "city": "New York" },
-        { "name": "Jane", "age": 30, "color": "yellow", "city": "San Francisco" },
-        { "name": "John", "age": 31, "color": "green", "city": "San Francisco" }
+        { "name": "John", "age": 25, "color": "blue", "other": "no", "city": "New York" },
+        { "name": "Jane", "age": 27, "color": "red", "other": "yes", "city": "New York" },
+        { "name": "Jane", "age": 30, "color": "yellow", "other": "no", "city": "San Francisco" },
+        { "name": "John", "age": 31, "color": "green", "other": "yes", "city": "San Francisco" }
       ],
       "dataFileSize": 178,
       "dataFileName": "valid-data-chart.csv",


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: Running storybook navigate to the Pages/Dashboard/Group Pivot Filter story.

Expected: You should see groupings in blue with New York and San Fransciso, Each grouping should have two rows under them. There should be 3 columns total. Selecting from the multiselect filter will toggle the respective column.

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
