### PR TITLE
[DEV-9632] Add custom color palette for scatter plots

### DIFF
--- a/packages/chart/examples/feature/scatterplot/scatterplot.json
+++ b/packages/chart/examples/feature/scatterplot/scatterplot.json
@@ -4,6 +4,18 @@
   "chartMessage": {
     "noData": "No Data Available"
   },
+  "customColors": [
+    "red",
+    "orange",
+    "yellow",
+    "green",
+    "blue",
+    "purple",
+    "pink",
+    "brown",
+    "gray",
+    "black"
+  ],
   "title": "",
   "showTitle": true,
   "showDownloadMediaButton": false,

--- a/packages/chart/src/_stories/Chart.CustomColors.stories.tsx
+++ b/packages/chart/src/_stories/Chart.CustomColors.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import Chart from '../CdcChart'
+import scatterPlotCustomColorConfig from './../../examples/feature/scatterplot/scatterplot.json'
+
+const meta: Meta<typeof Chart> = {
+  title: 'Components/Templates/Chart/Custom Colors',
+  component: Chart
+}
+
+type Story = StoryObj<typeof Chart>
+
+export const ScatterPlot: Story = {
+  args: {
+    config: scatterPlotCustomColorConfig,
+    isEditor: false
+  }
+}
+
+export default meta

--- a/packages/chart/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/packages/chart/src/components/ScatterPlot/ScatterPlot.jsx
@@ -4,7 +4,14 @@ import { Group } from '@visx/group'
 import { formatNumber as formatColNumber } from '@cdc/core/helpers/cove/number'
 
 const ScatterPlot = ({ xScale, yScale }) => {
-  const { transformedData: data, config, tableData, formatNumber, seriesHighlight, colorPalettes } = useContext(ConfigContext)
+  const {
+    transformedData: data,
+    config,
+    tableData,
+    formatNumber,
+    seriesHighlight,
+    colorPalettes
+  } = useContext(ConfigContext)
 
   // TODO: copied from line chart should probably be a constant somewhere.
   const circleRadii = 4.5
@@ -23,10 +30,19 @@ const ScatterPlot = ({ xScale, yScale }) => {
       }
     ])
   const handleTooltip = (item, s, dataIndex) => `<div>
-    ${config.legend.showLegendValuesTooltip && config.runtime.seriesLabels && hasMultipleSeries ? `${config.runtime.seriesLabels[s] || ''}<br/>` : ''}
+    ${
+      config.legend.showLegendValuesTooltip && config.runtime.seriesLabels && hasMultipleSeries
+        ? `${config.runtime.seriesLabels[s] || ''}<br/>`
+        : ''
+    }
     ${config.xAxis.label}: ${formatNumber(item[config.xAxis.dataKey], 'bottom')} <br/>
     ${config.yAxis.label}: ${formatNumber(item[s], 'left')}<br/>
-   ${additionalColumns.map(([label, name, options]) => `${label} : ${formatColNumber(tableData[dataIndex][name], 'left', false, config, options)}<br/>`).join('')}
+   ${additionalColumns
+     .map(
+       ([label, name, options]) =>
+         `${label} : ${formatColNumber(tableData[dataIndex][name], 'left', false, config, options)}<br/>`
+     )
+     .join('')}
 </div>`
 
   return (
@@ -36,7 +52,7 @@ const ScatterPlot = ({ xScale, yScale }) => {
         return config.runtime.seriesKeys.map((s, index) => {
           const transparentArea = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(s) === -1
           const displayArea = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(s) !== -1
-          const seriesColor = config.palette ? colorPalettes[config.palette][index] : '#000'
+          const seriesColor = config?.customColors ? config.customColors[index] : config.palette ? colorPalettes[config.palette][index] : '#000'
 
           let pointStyles = {
             filter: 'unset',


### PR DESCRIPTION
## [DEV-9632]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
1. run `yarn storybook`
2. Open `http://localhost:6006/?path=/story/components-templates-chart-custom-colors--scatter-plot`
3. Verify the circles on the chart are red and orange

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes
The only additions are line 55 in scatter plot and the testing files. The rest is formatting from prettier since this is an older file. I used the /example file as mock data to reduce file size on the repo. 
<!-- Add any additional notes about this PR -->
