### PR TITLE
Fix: DEV-9643 Issue with deleting tab within multi tabs

### DIFF
--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -105,8 +105,14 @@ const reducer = (state: DashboardState, action: DashboardActions): DashboardStat
       _.remove(newMultiDashboards, (_, index) => {
         return index === action.payload
       })
+      const config = {
+        ...state.config,
+        multiDashboards: newMultiDashboards,
+        ...newMultiDashboards[0],
+        activeDashboard: 0
+      }
       if (newMultiDashboards.length === 0) return { ...state, config: _.omit(state.config, 'multiDashboards') }
-      return applyMultiDashboards(state, newMultiDashboards)
+      return applyMultiDashboards({ ...state, config }, newMultiDashboards)
     }
     case 'RENAME_DASHBOARD_TAB': {
       const newMultiDashboards = state.config.multiDashboards.map(dashboard => {


### PR DESCRIPTION
## Fix: DEV-9643 Issue with deleting tab within multi tabs
[https://websupport.cdc.gov/projects/DEV/issues/DEV-9643](https://websupport.cdc.gov/projects/DEV/issues/DEV-9643)


## Testing Steps

Scenario: Upload [dev-9643-config.json](https://github.com/user-attachments/files/17558934/dev-9643-config.json) and open the Configuration tab. There are 4 dashboard tabs at the top: Dashboard, Compare Years, Compare Locations, All Locations

1. Hover over Dashboard and click the "X"
Expectations: The "Dashboard" dashboard will be deleted and the new first dashboard "Compare Years" will be showing.

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings