### PR TITLE
Enhancement: Dev-9529 Download Data CSV link on stand alone table

### DIFF
--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -83,7 +83,7 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
           </Tooltip>
         }
       />
-      {config.type !== 'table' && (
+      {config.type !== 'table' ? (
         <CheckBox
           value={config.table.show}
           fieldName='show'
@@ -107,6 +107,15 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
               </Tooltip.Content>
             </Tooltip>
           }
+        />
+      ) : (
+        <CheckBox
+          value={config.general?.showDownloadButton}
+          fieldName='showDownloadButton'
+          label='Show Download CSV link'
+          section='general'
+          updateField={updateField}
+          className='column-heading'
         />
       )}
 
@@ -249,15 +258,14 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
           updateField={updateField}
         />
       )}
-      {config.type !== 'table' && (
-        <CheckBox
-          value={config.table.showDownloadLinkBelow}
-          fieldName='showDownloadLinkBelow'
-          label='Show Download Link Below Table'
-          section='table'
-          updateField={updateField}
-        />
-      )}
+
+      <CheckBox
+        value={config.table.showDownloadLinkBelow}
+        fieldName='showDownloadLinkBelow'
+        label='Show Download Link Below Table'
+        section='table'
+        updateField={updateField}
+      />
       <label>
         <span className='edit-label column-heading'>Table Cell Min Width</span>
         <input


### PR DESCRIPTION
## Enhancement: Dev-9529 Download Data CSV link on stand alone table
[https://websupport.cdc.gov/browse/DEV-9529](https://websupport.cdc.gov/browse/DEV-9529)

The stand-alone table has the functionality to download the table data with the "Download Data (CSV)" link.

## Testing Steps

Scenario: Upload [dev-9529-config.json](https://github.com/user-attachments/files/17575095/dev-9529-config.json), click Configuration, click the tools icon on the Table visualization

Expected: The Table editor is open with a table with some data

1. Open Data Table section
2. Check the checkbox next to Show download CSV link
Expected: Above the table to the right the Download Data (CSV) link is showing

3. Check the checkbox next to Show Download Link Below Table
Expected: The Download Data (CSV) link in now below the Table

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
