### PR TITLE
[DEV-9617] align legend shape and labels for circles and squares

### DIFF
--- a/packages/chart/src/components/Legend/Legend.Component.tsx
+++ b/packages/chart/src/components/Legend/Legend.Component.tsx
@@ -9,7 +9,7 @@ import { handleLineType } from '../../helpers/handleLineType'
 import { getMarginTop, getGradientConfig, getMarginBottom } from './helpers/index'
 import { Line } from '@visx/shape'
 import { Label } from '../../types/Label'
-import { ChartConfig } from '../../types/ChartConfig'
+import { ChartConfig, ViewportSize } from '../../types/ChartConfig'
 import { ColorScale } from '../../types/ChartContext'
 import { forwardRef, useState } from 'react'
 import LegendSuppression from './Legend.Suppression'
@@ -20,7 +20,7 @@ import { isLegendWrapViewport } from '@cdc/core/helpers/viewports'
 export interface LegendProps {
   colorScale: ColorScale
   config: ChartConfig
-  currentViewport: 'lg' | 'md' | 'sm' | 'xs' | 'xxs'
+  currentViewport: ViewportSize
   formatLabels: (labels: Label[]) => Label[]
   highlight: Function
   highlightReset: Function
@@ -129,7 +129,7 @@ const Legend: React.FC<LegendProps> = forwardRef(
                         }}
                         role='button'
                       >
-                        <div className='d-flex justify-content-center align-items-center'>
+                        <>
                           {config.visualizationType === 'Line' && config.legend.style === 'lines' ? (
                             <svg width={40} height={25}>
                               <Line
@@ -141,17 +141,14 @@ const Legend: React.FC<LegendProps> = forwardRef(
                               />
                             </svg>
                           ) : (
-                            <div className='d-flex flex-column mt-1'>
+                            <>
                               <LegendShape
                                 shape={config.legend.style === 'boxes' ? 'square' : 'circle'}
-                                viewport={currentViewport}
-                                margin='0'
                                 fill={label.value}
-                                display={true}
                               />
-                            </div>
+                            </>
                           )}
-                        </div>
+                        </>
 
                         <LegendLabel align='left' margin='0 0 0 4px'>
                           {label.text}

--- a/packages/chart/src/scss/main.scss
+++ b/packages/chart/src/scss/main.scss
@@ -213,7 +213,6 @@
 
     .legend-item {
       text-align: left;
-      align-items: flex-start !important;
       user-select: none;
       white-space: nowrap;
 

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -105,7 +105,7 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
 
     legendItems = formattedItems.map((item, idx) => {
       const handleListItemClass = () => {
-        let classes = ['legend-container__li']
+        let classes = ['legend-container__li', 'd-flex', 'align-items-center']
         if (item.disabled) classes.push('legend-container__li--disabled')
         if (item.special) classes.push('legend-container__li--special-class')
         return classes.join(' ')
@@ -126,11 +126,7 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
           }}
           tabIndex={0}
         >
-          <LegendShape
-            shape={state.legend.style === 'boxes' ? 'square' : 'circle'}
-            viewport={viewport}
-            fill={item.color}
-          />
+          <LegendShape shape={state.legend.style === 'boxes' ? 'square' : 'circle'} fill={item.color} />
           <span>{item.label}</span>
         </li>
       )


### PR DESCRIPTION
## [DEV-9617] align legend shape and labels for circles and squares
https://websupport-cdc.msappproxy.net/browse/DEV-9617

## Testing Steps
- [ ] Open a chart
- [ ] Ensure legend circles and text are aligned
- [ ] Under Legend > Change the legend style to square
- [ ] Ensure legend squares and text are aligned 

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)
<img width="292" alt="Screen Shot 2024-10-30 at 9 59 50 AM" src="https://github.com/user-attachments/assets/97f3e02f-2167-4cbc-ad60-1d31a9537308">
<img width="287" alt="Screen Shot 2024-10-30 at 9 59 57 AM" src="https://github.com/user-attachments/assets/311f6202-ff21-4a44-a589-7ec2e1b9528a">
<img width="342" alt="Screen Shot 2024-10-30 at 10 00 06 AM" src="https://github.com/user-attachments/assets/5749da3b-35bf-4126-94cd-e227011f8ea6">


## Additional Notes
Removes unused properties passed to LegendShape
