### PR TITLE
[DEV-9182] Align image button to the right

### DIFF
--- a/packages/core/styles/_button-section.scss
+++ b/packages/core/styles/_button-section.scss
@@ -2,8 +2,8 @@
 .download-buttons {
   display: flex;
   justify-content: flex-end;
-  margin: 0 1em; // align w/ data table
-  margin-left: auto;
+  margin: 0 0 0 auto;
+
   .btn:not(:last-child) {
     margin-right: 10px;
   }

--- a/packages/core/styles/_button-section.scss
+++ b/packages/core/styles/_button-section.scss
@@ -3,7 +3,7 @@
   display: flex;
   justify-content: flex-end;
   margin: 0 1em; // align w/ data table
-
+  margin-left: auto;
   .btn:not(:last-child) {
     margin-right: 10px;
   }


### PR DESCRIPTION
## [Replace With Ticket Number]
Open Data table panel ==>click "Show Download Image" the button has to be always on the right side of chart.
We had bug that it is on the left sometimes.
<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
