### PR TITLE
[DEV-9555] Fix initial height of horizontal bar charts in editor

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -410,7 +410,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     const legendIsLeftOrRight =
       legend?.position !== 'top' && legend?.position !== 'bottom' && !isLegendWrapViewport(currentViewport)
     legendRef.current.style.transform = legendIsLeftOrRight ? `translateY(${topLabelOnGridlineHeight}px)` : 'none'
-  }, [axisBottomRef.current, config, bottomLabelStart, brush, currentViewport, topYLabelRef.current])
+  }, [axisBottomRef.current, config, bottomLabelStart, brush, currentViewport, topYLabelRef.current, initialHeight])
 
   const chartHasTooltipGuides = () => {
     const { visualizationType } = config


### PR DESCRIPTION
## [DEV-9555]

See the ticket; the height of horizontal bar charts is initially wrong when created in the editor, and doesn't correct itself until another option is toggled.

## Testing Steps

1. Run the editor locally
2. Create a bar chart with the sample data set, change orientation to horizontal
3. Click "I'm done"
4. See that the chart is the correct height and isn't cut off by the data table on this branch

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
