### PR TITLE
[DEV-9601] maps > update tooltip hovers on territory names

### DIFF
--- a/packages/map/src/components/UsaMap/components/HexIcon.tsx
+++ b/packages/map/src/components/UsaMap/components/HexIcon.tsx
@@ -30,7 +30,13 @@ const HexIcon: React.FC<HexIconProps> = props => {
     )
   }
   return (
-    <Group top={centroid[1] - 5} left={centroid[0] - iconSize} color={textColor} textAnchor='start' key={`hex--${item.key}-${item.value}-${index}`}>
+    <Group
+      top={centroid[1] - 5}
+      left={centroid[0] - iconSize}
+      color={textColor}
+      textAnchor='start'
+      key={`hex--${item.key}-${item.value}-${index}`}
+    >
       {item.shape === 'Arrow Down' && <AiOutlineArrowDown />}
       {item.shape === 'Arrow Up' && <AiOutlineArrowUp />}
       {item.shape === 'Arrow Right' && <AiOutlineArrowRight />}

--- a/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
+++ b/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { geoCentroid, geoPath } from 'd3-geo'
+import { geoCentroid } from 'd3-geo'
 import ConfigContext from './../../../../context'
 import { MapContext } from './../../../../types/MapContext'
 import HexIcon from '../HexIcon'
@@ -31,7 +31,19 @@ const nudges = {
 
 // todo: combine hexagonLabel & geoLabel functions
 // todo: move geoLabel functions outside of components for reusability
-const TerritoryHexagon = ({ label, text, stroke, strokeWidth, textColor, territory, territoryData, ...props }) => {
+const TerritoryHexagon = ({
+  dataTooltipHtml,
+  dataTooltipId,
+  handleShapeClick,
+  label,
+  stroke,
+  strokeWidth,
+  territory,
+  territoryData,
+  text,
+  textColor,
+  ...props
+}) => {
   const { state } = useContext<MapContext>(ConfigContext)
 
   const isHex = state.general.displayAsHex
@@ -115,7 +127,17 @@ const TerritoryHexagon = ({ label, text, stroke, strokeWidth, textColor, territo
       let y = state.hexMap.type === 'shapes' ? '30%' : '50%'
       return (
         <>
-          <Text fontSize={14} x={'50%'} y={y} style={{ fill: 'currentColor', stroke: 'initial', fontWeight: 400, opacity: 1, fillOpacity: 1 }} textAnchor='middle' verticalAnchor='middle'>
+          <Text
+            fontSize={14}
+            x={'50%'}
+            y={y}
+            style={{ fill: 'currentColor', stroke: 'initial', fontWeight: 400, opacity: 1, fillOpacity: 1 }}
+            textAnchor='middle'
+            verticalAnchor='middle'
+            onClick={handleShapeClick}
+            data-tooltip-id={dataTooltipId}
+            data-tooltip-html={dataTooltipHtml}
+          >
             {abbr.substring(3)}
           </Text>
           {state.general.displayAsHex && state.hexMap.type === 'shapes' && getArrowDirection(territoryData, geo, true)}
@@ -127,21 +149,44 @@ const TerritoryHexagon = ({ label, text, stroke, strokeWidth, textColor, territo
 
     return (
       <g>
-        <line x1={centroid[0]} y1={centroid[1]} x2={centroid[0] + dx} y2={centroid[1] + dy} stroke='rgba(0,0,0,.5)' strokeWidth={1} />
-        <text x={4} strokeWidth='0' fontSize={13} style={{ fill: '#202020' }} alignmentBaseline='middle' transform={`translate(${centroid[0] + dx}, ${centroid[1] + dy})`}>
+        <line
+          x1={centroid[0]}
+          y1={centroid[1]}
+          x2={centroid[0] + dx}
+          y2={centroid[1] + dy}
+          stroke='rgba(0,0,0,.5)'
+          strokeWidth={1}
+        />
+        <text
+          x={4}
+          strokeWidth='0'
+          fontSize={13}
+          style={{ fill: '#202020' }}
+          alignmentBaseline='middle'
+          transform={`translate(${centroid[0] + dx}, ${centroid[1] + dy})`}
+          onClick={handleShapeClick}
+          data-tooltip-id={dataTooltipId}
+          data-tooltip-html={dataTooltipHtml}
+        >
           {abbr.substring(3)}
         </text>
       </g>
     )
   }
 
-  return territoryData && (
-    <svg viewBox='0 0 45 51' className='territory-wrapper--hex'>
-      <g {...props}>
-        <polygon stroke={stroke} strokeWidth={strokeWidth} points='22 0 44 12.702 44 38.105 22 50.807 0 38.105 0 12.702' />
-        {state.general.displayAsHex && hexagonLabel(territoryData, stroke, false)}
-      </g>
-    </svg>
+  return (
+    territoryData && (
+      <svg viewBox='0 0 45 51' className='territory-wrapper--hex'>
+        <g {...props} data-tooltip-html={dataTooltipHtml} data-tooltip-id={dataTooltipId} onClick={handleShapeClick}>
+          <polygon
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            points='22 0 44 12.702 44 38.105 22 50.807 0 38.105 0 12.702'
+          />
+          {state.general.displayAsHex && hexagonLabel(territoryData, stroke, false)}
+        </g>
+      </svg>
+    )
   )
 }
 

--- a/packages/map/src/components/UsaMap/components/Territory/Territory.Rectangle.tsx
+++ b/packages/map/src/components/UsaMap/components/Territory/Territory.Rectangle.tsx
@@ -4,21 +4,50 @@ import ConfigContext from './../../../../context'
 import { type MapContext } from '../../../../types/MapContext'
 import { patternSizes } from './../../helpers/patternSizes'
 import { getContrastColor } from '@cdc/core/helpers/cove/accessibility'
+import { type TerritoryShape } from './TerritoryShape'
 
-const TerritoryRectangle = ({ label, text, stroke, strokeWidth, textColor, hasPattern, territory, ...props }) => {
+const TerritoryRectangle: React.FC<TerritoryShape> = ({
+  dataTooltipId,
+  dataTooltipHtml,
+  handleShapeClick,
+  hasPattern,
+  label,
+  stroke,
+  strokeWidth,
+  territory,
+  text,
+  textColor,
+  ...props
+}) => {
   const { state, supportedTerritories } = useContext<MapContext>(ConfigContext)
   const { territoryData, ...otherProps } = props
+  const rectanglePath =
+    'M40,0.5 C41.2426407,0.5 42.3676407,1.00367966 43.1819805,1.81801948 C43.9963203,2.63235931 44.5,3.75735931 44.5,5 L44.5,5 L44.5,23 C44.5,24.2426407 43.9963203,25.3676407 43.1819805,26.1819805 C42.3676407,26.9963203 41.2426407,27.5 40,27.5 L40,27.5 L5,27.5 C3.75735931,27.5 2.63235931,26.9963203 1.81801948,26.1819805 C1.00367966,25.3676407 0.5,24.2426407 0.5,23 L0.5,23 L0.5,5 C0.5,3.75735931 1.00367966,2.63235931 1.81801948,1.81801948 C2.63235931,1.00367966 3.75735931,0.5 5,0.5 L5,0.5 Z'
 
   return (
     <svg viewBox='0 0 45 28' key={territory} className={territory}>
-      <g {...otherProps} strokeLinejoin='round' tabIndex={-1}>
-        <path
-          stroke={stroke}
-          strokeWidth={strokeWidth}
-          d='M40,0.5 C41.2426407,0.5 42.3676407,1.00367966 43.1819805,1.81801948 C43.9963203,2.63235931 44.5,3.75735931 44.5,5 L44.5,5 L44.5,23 C44.5,24.2426407 43.9963203,25.3676407 43.1819805,26.1819805 C42.3676407,26.9963203 41.2426407,27.5 40,27.5 L40,27.5 L5,27.5 C3.75735931,27.5 2.63235931,26.9963203 1.81801948,26.1819805 C1.00367966,25.3676407 0.5,24.2426407 0.5,23 L0.5,23 L0.5,5 C0.5,3.75735931 1.00367966,2.63235931 1.81801948,1.81801948 C2.63235931,1.00367966 3.75735931,0.5 5,0.5 L5,0.5 Z'
-          {...otherProps}
-        />
-        <text textAnchor='middle' dominantBaseline='middle' x='50%' y='54%' fill={text} style={{ stroke: textColor, strokeWidth: 1 }} className='territory-text' paintOrder='stroke'>
+      <g
+        {...otherProps}
+        strokeLinejoin='round'
+        tabIndex={-1}
+        onClick={handleShapeClick}
+        data-tooltip-id={dataTooltipId}
+        data-tooltip-html={dataTooltipHtml}
+      >
+        <path stroke={stroke} strokeWidth={strokeWidth} d={rectanglePath} {...otherProps} />
+        <text
+          textAnchor='middle'
+          dominantBaseline='middle'
+          x='50%'
+          y='54%'
+          fill={text}
+          style={{ stroke: textColor, strokeWidth: 1 }}
+          className='territory-text'
+          paintOrder='stroke'
+          onClick={handleShapeClick}
+          data-tooltip-id={dataTooltipId}
+          data-tooltip-html={dataTooltipHtml}
+        >
           {label}
         </text>
 
@@ -31,18 +60,62 @@ const TerritoryRectangle = ({ label, text, stroke, strokeWidth, textColor, hasPa
 
           return (
             <>
-              {patternData?.pattern === 'waves' && <PatternWaves id={`territory-${patternData?.dataKey}--${patternIndex}`} height={patternSizes[patternData?.size] ?? 10} width={patternSizes[patternData?.size] ?? 10} fill={patternColor} complement />}
-              {patternData?.pattern === 'circles' && <PatternCircles id={`territory-${patternData?.dataKey}--${patternIndex}`} height={patternSizes[patternData?.size] ?? 10} width={patternSizes[patternData?.size] ?? 10} fill={patternColor} complement />}
-              {patternData?.pattern === 'lines' && <PatternLines id={`territory-${patternData?.dataKey}--${patternIndex}`} height={patternSizes[patternData?.size] ?? 6} width={patternSizes[patternData?.size] ?? 6} stroke={patternColor} strokeWidth={1} orientation={['diagonalRightToLeft']} />}
+              {patternData?.pattern === 'waves' && (
+                <PatternWaves
+                  id={`territory-${patternData?.dataKey}--${patternIndex}`}
+                  height={patternSizes[patternData?.size] ?? 10}
+                  width={patternSizes[patternData?.size] ?? 10}
+                  fill={patternColor}
+                  complement
+                />
+              )}
+              {patternData?.pattern === 'circles' && (
+                <PatternCircles
+                  id={`territory-${patternData?.dataKey}--${patternIndex}`}
+                  height={patternSizes[patternData?.size] ?? 10}
+                  width={patternSizes[patternData?.size] ?? 10}
+                  fill={patternColor}
+                  complement
+                />
+              )}
+              {patternData?.pattern === 'lines' && (
+                <PatternLines
+                  id={`territory-${patternData?.dataKey}--${patternIndex}`}
+                  height={patternSizes[patternData?.size] ?? 6}
+                  width={patternSizes[patternData?.size] ?? 6}
+                  stroke={patternColor}
+                  strokeWidth={1}
+                  orientation={['diagonalRightToLeft']}
+                />
+              )}
               <path
                 stroke={stroke}
                 strokeWidth={strokeWidth}
-                d='M40,0.5 C41.2426407,0.5 42.3676407,1.00367966 43.1819805,1.81801948 C43.9963203,2.63235931 44.5,3.75735931 44.5,5 L44.5,5 L44.5,23 C44.5,24.2426407 43.9963203,25.3676407 43.1819805,26.1819805 C42.3676407,26.9963203 41.2426407,27.5 40,27.5 L40,27.5 L5,27.5 C3.75735931,27.5 2.63235931,26.9963203 1.81801948,26.1819805 C1.00367966,25.3676407 0.5,24.2426407 0.5,23 L0.5,23 L0.5,5 C0.5,3.75735931 1.00367966,2.63235931 1.81801948,1.81801948 C2.63235931,1.00367966 3.75735931,0.5 5,0.5 L5,0.5 Z'
+                d={rectanglePath}
                 fill={`url(#territory-${patternData?.dataKey}--${patternIndex})`}
                 color={patternData ? 'white' : textColor}
-                className={[`territory-pattern-${patternData.dataKey}`, `territory-pattern-${patternData.dataKey}--${patternData.dataValue}`].join(' ')}
+                className={[
+                  `territory-pattern-${patternData.dataKey}`,
+                  `territory-pattern-${patternData.dataKey}--${patternData.dataValue}`
+                ].join(' ')}
               />
-              <text textAnchor='middle' dominantBaseline='middle' x='50%' y='54%' fill={text} style={{ fill: patternData ? 'white' : 'black', stroke: patternData ? 'black' : textColor, strokeWidth: patternData ? 6 : 0 }} className='territory-text' paint-order='stroke'>
+              <text
+                textAnchor='middle'
+                dominantBaseline='middle'
+                x='50%'
+                y='54%'
+                fill={text}
+                style={{
+                  fill: patternData ? 'white' : 'black',
+                  stroke: patternData ? 'black' : textColor,
+                  strokeWidth: patternData ? 6 : 0
+                }}
+                className='territory-text'
+                paint-order='stroke'
+                onClick={handleShapeClick}
+                data-tooltip-id={dataTooltipId}
+                data-tooltip-html={dataTooltipHtml}
+              >
                 {label}
               </text>
             </>

--- a/packages/map/src/components/UsaMap/components/Territory/TerritoryShape.ts
+++ b/packages/map/src/components/UsaMap/components/Territory/TerritoryShape.ts
@@ -1,0 +1,13 @@
+export type TerritoryShape = {
+  handleShapeClick: () => void
+  dataTooltipHtml: string
+  dataTooltipId: string
+  hasPattern: boolean
+  label: string
+  stroke: string
+  strokeWidth: number
+  territory: string
+  territoryData: object
+  text: string
+  textColor: string
+}

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -195,9 +195,9 @@ const UsaMap = () => {
           text={styles.color}
           strokeWidth={1.5}
           textColor={textColor}
-          onClick={() => geoClickHandler(territory, territoryData)}
-          data-tooltip-id={`tooltip__${tooltipId}`}
-          data-tooltip-html={toolTip}
+          handleShapeClick={() => geoClickHandler(territory, territoryData)}
+          dataTooltipId={`tooltip__${tooltipId}`}
+          dataTooltipHtml={toolTip}
           territory={territory}
           territoryData={territoryData}
           tabIndex={-1}

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -48,7 +48,7 @@ export type ViewportSize = 'xxs' | 'xs' | 'sm' | 'md' | 'lg'
 export type LegendShapeItem = {
   column: string
   key: string
-  operator: string
+  operator: '=' | '≠' | '<' | '>' | '<=' | '>='
   shape: string
   value: string
 }


### PR DESCRIPTION
## [DEV-9601] maps > update tooltip hovers on territory names

- Hex Territories > add tooltip to text
- Rectangle Territories > add tooltip to text
- Update props on UsaMap.State.tsx for Shapes
- Add TerritoryShape.ts file


## Testing Steps
- [ ] Run `yarn storybook
- [ ] Open `http://localhost:6006/?path=/story/components-templates-map--equal-number-map`
- [ ] Hover over the territory letters and make sure the tooltip continues to show

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes
- Resolved LegendShapeItem TS Issue
- Added Territory Shape TS file

<!-- Add any additional notes about this PR -->
