### PR TITLE
Feat [DEV 9552] Wrap legend label

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -652,7 +652,6 @@ const CdcChart = ({
   const resizeObserver = new ResizeObserver(entries => {
     for (let entry of entries) {
       let { width, height } = entry.contentRect
-      let svgMarginWidth = 30
       let editorWidth = 350
 
       width = isEditor ? width - editorWidth : width
@@ -665,7 +664,7 @@ const CdcChart = ({
         width = width - 2.5
       }
 
-      width = width - svgMarginWidth
+      width = width
 
       setDimensions([width, height])
     }

--- a/packages/chart/src/_stories/Chart.Legend.Gradient.stories.tsx
+++ b/packages/chart/src/_stories/Chart.Legend.Gradient.stories.tsx
@@ -12,9 +12,15 @@ const meta: Meta<typeof Chart> = {
 
 type Story = StoryObj<typeof Chart>
 
-export const Legend_Gradient: Story = {
+export const Legend_Gradient_Smooth: Story = {
   args: {
     config: chartGradientConfig
+  }
+}
+
+export const Legend_Gradient_Linear_Blocks: Story = {
+  args: {
+    config: editConfigKeys(chartGradientConfig, [{ path: ['legend', 'subStyle'], value: 'linear blocks' }])
   }
 }
 

--- a/packages/chart/src/_stories/Chart.Legend.Gradient.stories.tsx
+++ b/packages/chart/src/_stories/Chart.Legend.Gradient.stories.tsx
@@ -51,5 +51,18 @@ export const Legend_Gradient_With_Text: Story = {
     ])
   }
 }
+export const Legend_Gradient_Wrapping_Label: Story = {
+  args: {
+    config: JSON.parse(
+      JSON.stringify(
+        editConfigKeys(chartGradientConfig, [
+          { path: ['legend', 'title'], value: 'Title' },
+          { path: ['legend', 'description'], value: 'Description' },
+          { path: ['legend', 'hideBorder'], value: false }
+        ])
+      ).replace(/Data 1/g, 'This is a long string that should wrap')
+    )
+  }
+}
 
 export default meta

--- a/packages/chart/src/components/Legend/Legend.Component.tsx
+++ b/packages/chart/src/components/Legend/Legend.Component.tsx
@@ -80,7 +80,7 @@ const Legend: React.FC<LegendProps> = forwardRef(
           config={config}
           {...getGradientConfig(config, formatLabels, colorScale)}
           dimensions={dimensions}
-          parentPaddingToSubtract={LEGEND_PADDING}
+          parentPaddingToSubtract={legend.hideBorder ? 0 : LEGEND_PADDING}
         />
 
         <LegendOrdinal scale={colorScale} itemDirection='row' labelMargin='0 20px 0 0' shapeMargin='0 10px 0'>

--- a/packages/core/components/Layout/components/Visualization/visualizations.scss
+++ b/packages/core/components/Layout/components/Visualization/visualizations.scss
@@ -1,6 +1,6 @@
 .cdc-open-viz-module {
   .cdc-chart-inner-container .cove-component__content {
-    padding: 25px 15px !important;
+    padding: 25px 0px !important;
   }
   &.isEditor {
     overflow: auto;

--- a/packages/core/components/Legend/Legend.Gradient.tsx
+++ b/packages/core/components/Legend/Legend.Gradient.tsx
@@ -7,6 +7,7 @@ import { DimensionsType } from '../../types/Dimensions'
 
 const MARGIN = 1
 const BORDER_SIZE = 1
+const MOBILE_BREAKPOINT = 576
 
 type CombinedConfig = MapConfig | ChartConfig
 
@@ -25,10 +26,15 @@ const LegendGradient = ({
   dimensions,
   parentPaddingToSubtract = 0
 }: GradientProps): JSX.Element => {
+  const { uid, legend, type } = config
+  const { tickRotation, position, style, subStyle } = legend
+
+  const isLinearBlocks = subStyle === 'linear blocks'
   let [width] = dimensions
 
+  const smallScreen = width <= MOBILE_BREAKPOINT
   const legendWidth = Number(width) - parentPaddingToSubtract - MARGIN * 2 - BORDER_SIZE * 2
-  const uniqueID = `${config.uid}-${Date.now()}`
+  const uniqueID = `${uid}-${Date.now()}`
 
   const numTicks = colors?.length
 
@@ -38,7 +44,7 @@ const LegendGradient = ({
 
   // configure tick witch and angle
   const textWidth = getTextWidth(longestLabel, `normal 14px sans-serif`)
-  const rotationAngle = Number(config.legend.tickRotation) || 0
+  const rotationAngle = Number(tickRotation) || 0
   // Convert the angle from degrees to radians
   const angleInRadians = rotationAngle * (Math.PI / 180)
   const newHeight = height + Number(textWidth) * Math.sin(angleInRadians)
@@ -59,14 +65,14 @@ const LegendGradient = ({
 
     return (
       <Group top={MARGIN}>
-        {!lastTick && <line x1={xPositionX} x2={xPositionX} y1={30} y2={boxHeight} stroke='black' />}
+        {!lastTick && !isLinearBlocks && <line x1={xPositionX} x2={xPositionX} y1={30} y2={boxHeight} stroke='black' />}
         <Text
-          angle={-config.legend.tickRotation}
+          angle={-tickRotation}
           x={xPositionX}
           y={boxHeight}
           dy={10}
           dx={-segmentWidth / 2}
-          fontSize='14'
+          fontSize={smallScreen ? '12' : '14'}
           textAnchor={textAnchor}
           verticalAnchor={verticalAnchor}
           width={segmentWidth}
@@ -76,17 +82,14 @@ const LegendGradient = ({
       </Group>
     )
   })
-  if ((config.type === 'map' && config.legend.position === 'side') || !config.legend.position) {
+  if ((type === 'map' && position === 'side') || !position) {
     return
   }
-  if (
-    config.type === 'chart' &&
-    (config.legend.position === 'left' || config.legend.position === 'right' || !config.legend.position)
-  ) {
+  if (type === 'chart' && (position === 'left' || position === 'right' || !position)) {
     return
   }
 
-  if (config.legend.style === 'gradient') {
+  if (style === 'gradient') {
     return (
       <svg style={{ overflow: 'visible', width: '100%', marginTop: 10 }} height={newHeight}>
         {/* background border*/}
@@ -96,7 +99,7 @@ const LegendGradient = ({
           {stops}
         </linearGradient>
 
-        {config.legend.subStyle === 'smooth' && (
+        {subStyle === 'smooth' && (
           <rect
             x={MARGIN}
             y={MARGIN}
@@ -106,7 +109,7 @@ const LegendGradient = ({
           />
         )}
 
-        {config.legend.subStyle === 'linear blocks' &&
+        {subStyle === 'linear blocks' &&
           colors.map((color, index) => {
             const segmentWidth = legendWidth / numTicks
             const xPosition = index * segmentWidth + MARGIN

--- a/packages/core/components/Legend/Legend.Gradient.tsx
+++ b/packages/core/components/Legend/Legend.Gradient.tsx
@@ -69,6 +69,7 @@ const LegendGradient = ({
           fontSize='14'
           textAnchor={textAnchor}
           verticalAnchor={verticalAnchor}
+          width={segmentWidth}
         >
           {key}
         </Text>

--- a/packages/core/types/Legend.ts
+++ b/packages/core/types/Legend.ts
@@ -10,7 +10,7 @@ export type Legend = {
   hideSuppressedLabels: boolean
   highlightOnHover: boolean
   label: string
-  position: 'left' | 'bottom' | 'top' | 'right'
+  position: 'left' | 'bottom' | 'top' | 'right' | 'side'
   reverseLabelOrder: boolean
   singleRow: boolean
   type: string

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -78,8 +78,6 @@ import useTooltip from './hooks/useTooltip'
 import { isSolrCsv, isSolrJson } from '@cdc/core/helpers/isSolr'
 import SkipTo from '@cdc/core/components/elements/SkipTo'
 
-const CONTAINER_WIDTH_PADDING = 50
-
 // Data props
 const stateKeys = Object.keys(supportedStates)
 const territoryKeys = Object.keys(supportedTerritories)
@@ -1835,7 +1833,7 @@ const CdcMap = ({
                     closeModal(e)
                   }
                 }}
-                style={{ padding: `15px ${CONTAINER_WIDTH_PADDING / 2}px`, margin: '0px' }}
+                style={{ padding: '15px 0px', margin: '0px' }}
               >
                 {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
                 <section className='outline-none geography-container w-100' ref={mapSvg} tabIndex='0'>
@@ -1855,12 +1853,7 @@ const CdcMap = ({
                 </section>
 
                 {general.showSidebar && 'navigation' !== general.type && (
-                  <Legend
-                    dimensions={dimensions}
-                    ref={legendRef}
-                    skipId={tabId}
-                    containerWidthPadding={CONTAINER_WIDTH_PADDING}
-                  />
+                  <Legend dimensions={dimensions} ref={legendRef} skipId={tabId} containerWidthPadding={0} />
                 )}
               </div>
 


### PR DESCRIPTION
## [DEV-9652](https://websupport-cdc.msappproxy.net/browse/DEV-9652)

Allow long legend labels to wrap

## Testing Steps
1. Create or view a chart with long data labels (Storybook: "Legend Gradient Wrapping Label")
2. Observe that the label wraps

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots

<img width="585" alt="Screenshot 2024-11-05 at 10 20 06 AM" src="https://github.com/user-attachments/assets/5906feff-507b-4d30-9338-c6705bac34e6">
