### PR TITLE
[DEV-9561] Fix top bottom legend default border

### DIFF
--- a/packages/core/helpers/useDataVizClasses.ts
+++ b/packages/core/helpers/useDataVizClasses.ts
@@ -67,16 +67,20 @@ export default function useDataVizClasses(config, viewport = null) {
     if (legend?.style === 'gradient') ulClasses.push('patterns-only')
     return ulClasses
   }
-  const hasBorder = legend?.hideBorder ? 'no-border' : ''
+  const hasSideBorder = legend.position === 'side' && legend?.hideSideBorder ? 'no-side-border' : ''
+  const hasTopBottomBorder = legend?.hideTopBottomBorder && legend.position !== 'side' ? 'no-top-bottom-border' : ''
   const legendOuterClasses = [
     `${legend?.position}`,
     `${getListPosition()}`,
     `cdcdataviz-sr-focusable`,
     `${viewport}`,
-    `${hasBorder}`
+    `${hasSideBorder}`,
+    `${hasTopBottomBorder}`
   ]
 
-  const usePadding = !legend?.hideBorder
+  const usePadding =
+    (legend.position === 'side' && !legend?.hideSideBorder) ||
+    (legend.position !== 'side' && !legend?.hideTopBottomBorder)
 
   const legendClasses = {
     aside: legendOuterClasses,

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -402,12 +402,21 @@ const EditorPanel = ({ columnsRequiredChecker }) => {
           }
         })
         break
-      case 'legendBorder':
+      case 'legendBorderSide':
         setState({
           ...state,
           legend: {
             ...state.legend,
-            hideBorder: value
+            hideSideBorder: value
+          }
+        })
+        break
+      case 'legendBorderTopBottom':
+        setState({
+          ...state,
+          legend: {
+            ...state.legend,
+            hideTopBottomBorder: value
           }
         })
         break
@@ -2604,13 +2613,13 @@ const EditorPanel = ({ columnsRequiredChecker }) => {
                     ></input>
                   </label>
                 )}
-                {
+                {legend.position === 'side' && (
                   <label className='checkbox'>
                     <input
                       type='checkbox'
-                      checked={legend.hideBorder}
+                      checked={legend.hideSideBorder}
                       onChange={event => {
-                        handleEditorChanges('legendBorder', event.target.checked)
+                        handleEditorChanges('legendBorderSide', event.target.checked)
                       }}
                     />
                     <span className='edit-label column-heading'>Hide Legend Box</span>
@@ -2626,7 +2635,30 @@ const EditorPanel = ({ columnsRequiredChecker }) => {
                       </Tooltip.Content>
                     </Tooltip>
                   </label>
-                }
+                )}
+                {legend.position !== 'side' && (
+                  <label className='checkbox'>
+                    <input
+                      type='checkbox'
+                      checked={legend.hideTopBottomBorder}
+                      onChange={event => {
+                        handleEditorChanges('legendBorderTopBottom', event.target.checked)
+                      }}
+                    />
+                    <span className='edit-label column-heading'>Hide Legend Box</span>
+                    <Tooltip style={{ textTransform: 'none' }}>
+                      <Tooltip.Target>
+                        <Icon
+                          display='question'
+                          style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
+                        />
+                      </Tooltip.Target>
+                      <Tooltip.Content>
+                        <p> Default option for top and bottom legends is ‘No Box.’</p>
+                      </Tooltip.Content>
+                    </Tooltip>
+                  </label>
+                )}
                 {'side' === legend.position && (
                   <label className='checkbox'>
                     <input

--- a/packages/map/src/components/Legend/components/index.scss
+++ b/packages/map/src/components/Legend/components/index.scss
@@ -52,7 +52,11 @@
           flex-wrap: wrap;
         }
       }
-      &.no-border {
+      &.no-side-border {
+        border: none;
+      }
+
+      &.no-top-bottom-border {
         border: none;
       }
 

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -73,7 +73,8 @@ export default {
     subStyle: 'linear blocks',
     tickRotation: '',
     singleColumnLegend: false,
-    hideBorder: false
+    hideSideBorder: false,
+    hideTopBottomBorder: true
   },
   filters: [],
   table: {

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -130,7 +130,8 @@ export type MapConfig = Visualization & {
     style: 'circles' | 'boxes' | 'gradient'
     subStyle: 'linear blocks' | 'smooth'
     tickRotation: string
-    hideBorder: false
+    hideSideBorder: boolean
+    hideTopBottomBorder: boolean
     singleColumnLegend: false
   }
   table: {


### PR DESCRIPTION
## [Replace With Ticket Number]
Fixed legend border when legend changes from side to top/bottom the border around legend should be turn of by default.
there is a checkbox "Hide Legend Box" which controls it.
<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
