### PR TITLE
[DEV-9564] Filters > Hide Intro Text

### DIFF
--- a/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
@@ -67,7 +67,12 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
 
   const addNewFilter = () => {
     const filters = config.filters ? [...config.filters] : []
-    const newVizFilter: VizFilter = { values: [], filterStyle: 'dropdown', id: Date.now() } as VizFilter
+    const newVizFilter: VizFilter = {
+      values: [],
+      filterStyle: 'dropdown',
+      id: Date.now(),
+      showDropdown: true
+    } as VizFilter
     filters.push(newVizFilter)
     updateField(null, null, 'filters', filters)
   }

--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -502,7 +502,7 @@ const Filters = (props: FilterProps) => {
   return (
     <section className={getClasses().join(' ')}>
       <p className='filters-section__intro-text'>
-        {filters?.some(filter => filter.active && filter.columnName) ? filterConstants.introText : ''}{' '}
+        {filters?.some(filter => filter.showDropdown) ? filterConstants.introText : ''}{' '}
         {visualizationConfig.filterBehavior === 'Apply Button' && filterConstants.applyText}
       </p>
       <div className='d-flex flex-wrap filters-section__wrapper'>


### PR DESCRIPTION
## [DEV-9564] Filters > Hide Intro Text
- When a filter is hidden from view stop showing the intro text
- It doesn't seem like the active or columnName properties should hold any weight with intro text being displayed
- Update `addNewFilter` handler to add the showDropdown property 

## Testing Steps
- [ ] Open a chart
- [ ] Add a filter, you should see text above the filter that reads "Make a selection.."
- [ ] Under the filters accordion > uncheck the toggle for showing the filter
- [ ] "Make a Selection..." text should be hidden

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
