### PR TITLE
[DEV-9553] Chart > Legend Updates

### DIFF
--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -3671,38 +3671,6 @@ const EditorPanel = () => {
                     updateField={updateField}
                   />
 
-                  {/* <fieldset className="checkbox-group">
-                    <CheckBox value={config.legend.dynamicLegend} section="legend" fieldName="dynamicLegend" label="Dynamic Legend" updateField={updateField}/>
-                    {config.legend.dynamicLegend && (
-                      <>
-                        <TextField value={config.legend.dynamicLegendDefaultText} section="legend" fieldName="dynamicLegendDefaultText" label="Dynamic Legend Default Text" updateField={updateField} />
-                        <TextField value={config.legend.dynamicLegendItemLimit} type="number" min="0" section="legend" fieldName="dynamicLegendItemLimit" label={'Dynamic Legend Limit'} className="number-narrow" updateField={updateField}/>
-                        <TextField value={config.legend.dynamicLegendItemLimitMessage} section="legend" fieldName="dynamicLegendItemLimitMessage" label="Dynamic Legend Item Limit Message" updateField={updateField} />
-                        <TextField value={config.legend.dynamicLegendChartMessage} section="legend" fieldName="dynamicLegendChartMessage" label="Dynamic Legend Chart Message" updateField={updateField} />
-                      </>
-                    )}
-                  </fieldset> */}
-
-                  <CheckBox
-                    value={config.legend.hide ? true : false}
-                    section='legend'
-                    fieldName='hide'
-                    label='Hide Legend'
-                    updateField={updateField}
-                    tooltip={
-                      <Tooltip style={{ textTransform: 'none' }}>
-                        <Tooltip.Target>
-                          <Icon
-                            display='question'
-                            style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
-                          />
-                        </Tooltip.Target>
-                        <Tooltip.Content>
-                          <p>With a single-series chart, consider hiding the legend to reduce visual clutter.</p>
-                        </Tooltip.Content>
-                      </Tooltip>
-                    }
-                  />
                   <CheckBox
                     display={config.preliminaryData?.some(pd => pd.label && pd.type === 'suppression' && pd.value)}
                     value={config.legend.hideSuppressedLabels}

--- a/packages/chart/src/components/Legend/Legend.Component.tsx
+++ b/packages/chart/src/components/Legend/Legend.Component.tsx
@@ -2,7 +2,7 @@ import parse from 'html-react-parser'
 import { LegendOrdinal, LegendItem, LegendLabel } from '@visx/legend'
 import LegendShape from '@cdc/core/components/LegendShape'
 import Button from '@cdc/core/components/elements/Button'
-import useLegendClasses from '../../hooks/useLegendClasses'
+import { getLegendClasses } from './helpers/getLegendClasses'
 import { useHighlightedBars } from '../../hooks/useHighlightedBars'
 import { handleLineType } from '../../helpers/handleLineType'
 
@@ -48,7 +48,7 @@ const Legend: React.FC<LegendProps> = forwardRef(
     },
     ref
   ) => {
-    const { innerClasses, containerClasses } = useLegendClasses(config)
+    const { innerClasses, containerClasses } = getLegendClasses(config)
     const { runtime, legend } = config
 
     const [hasSuppression, setHasSuppression] = useState(false)

--- a/packages/chart/src/components/Legend/helpers/getLegendClasses.ts
+++ b/packages/chart/src/components/Legend/helpers/getLegendClasses.ts
@@ -40,11 +40,11 @@ export const getLegendClasses = (config: ChartConfig) => {
 
   // Configure border classes
   if (hideBorder.side && (['right', 'left'].includes(position) || !position)) {
-    containerClasses.push('no-border')
+    containerClasses.push('border-0')
   }
 
   if (hideBorder.topBottom && ['top', 'bottom'].includes(position)) {
-    containerClasses.push('no-border')
+    containerClasses.push('border-0')
   }
 
   if (hideBorder.topBottom && ['top'].includes(position)) {

--- a/packages/chart/src/components/Legend/helpers/getLegendClasses.ts
+++ b/packages/chart/src/components/Legend/helpers/getLegendClasses.ts
@@ -1,6 +1,6 @@
-import { ChartConfig } from '../types/ChartConfig'
+import { ChartConfig } from './../../../types/ChartConfig'
 
-const useLegendClasses = (config: ChartConfig) => {
+export const getLegendClasses = (config: ChartConfig) => {
   const { position, singleRow, reverseLabelOrder, verticalSorted, hideBorder } = config.legend
   const containerClasses = ['legend-container']
   const innerClasses = ['legend-container__inner']
@@ -56,4 +56,4 @@ const useLegendClasses = (config: ChartConfig) => {
     innerClasses
   }
 }
-export default useLegendClasses
+export default getLegendClasses

--- a/packages/chart/src/components/Legend/tests/getLegendClasses.test.ts
+++ b/packages/chart/src/components/Legend/tests/getLegendClasses.test.ts
@@ -15,6 +15,7 @@ describe('getLegendClasses', () => {
     }
     const result = getLegendClasses(config)
     expect(result.containerClasses).toContain('left')
+    // Left Position Charts can't have single row...
     expect(result.innerClasses).not.toContain('single-row')
   })
 
@@ -30,6 +31,7 @@ describe('getLegendClasses', () => {
     }
     const result = getLegendClasses(config)
     expect(result.containerClasses).toContain('right')
+    // Right Position Charts can't have single row...
     expect(result.innerClasses).not.toContain('single-row')
   })
 

--- a/packages/chart/src/components/Legend/tests/getLegendClasses.test.ts
+++ b/packages/chart/src/components/Legend/tests/getLegendClasses.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { getLegendClasses } from './../helpers/getLegendClasses'
+import { ChartConfig } from '../../../types/ChartConfig'
+
+describe('getLegendClasses', () => {
+  it('should return correct classes for left position', () => {
+    const config: ChartConfig = {
+      legend: {
+        position: 'left',
+        singleRow: false,
+        reverseLabelOrder: false,
+        verticalSorted: false,
+        hideBorder: { side: false, topBottom: false }
+      }
+    }
+    const result = getLegendClasses(config)
+    expect(result.containerClasses).toContain('left')
+    expect(result.innerClasses).not.toContain('single-row')
+  })
+
+  it('should return correct classes for right position', () => {
+    const config: ChartConfig = {
+      legend: {
+        position: 'right',
+        singleRow: false,
+        reverseLabelOrder: false,
+        verticalSorted: false,
+        hideBorder: { side: false, topBottom: false }
+      }
+    }
+    const result = getLegendClasses(config)
+    expect(result.containerClasses).toContain('right')
+    expect(result.innerClasses).not.toContain('single-row')
+  })
+
+  it('should return correct classes for bottom position with single row', () => {
+    const config: ChartConfig = {
+      legend: {
+        position: 'bottom',
+        singleRow: true,
+        reverseLabelOrder: false,
+        verticalSorted: false,
+        hideBorder: { side: false, topBottom: false }
+      }
+    }
+    const result = getLegendClasses(config)
+    expect(result.containerClasses).toContain('bottom')
+    expect(result.innerClasses).toContain('double-column')
+    expect(result.innerClasses).toContain('bottom')
+    expect(result.innerClasses).toContain('single-row')
+  })
+
+  it('should return correct classes for top position with vertical sorting', () => {
+    const config: ChartConfig = {
+      legend: {
+        position: 'top',
+        singleRow: false,
+        reverseLabelOrder: false,
+        verticalSorted: true,
+        hideBorder: { side: false, topBottom: false }
+      }
+    }
+    const result = getLegendClasses(config)
+    expect(result.containerClasses).toContain('top')
+    expect(result.innerClasses).toContain('double-column')
+    expect(result.innerClasses).toContain('top')
+    expect(result.innerClasses).toContain('vertical-sorted')
+  })
+
+  it('should return correct classes for reverse label order', () => {
+    const config: ChartConfig = {
+      legend: {
+        position: 'bottom',
+        singleRow: false,
+        reverseLabelOrder: true,
+        verticalSorted: false,
+        hideBorder: { side: false, topBottom: false }
+      }
+    }
+    const result = getLegendClasses(config)
+    expect(result.innerClasses).toContain('d-flex')
+    expect(result.innerClasses).toContain('flex-column-reverse')
+  })
+
+  it('should return correct classes for hide border side', () => {
+    const config: ChartConfig = {
+      legend: {
+        position: 'left',
+        singleRow: false,
+        reverseLabelOrder: false,
+        verticalSorted: false,
+        hideBorder: { side: true, topBottom: false }
+      }
+    }
+    const result = getLegendClasses(config)
+    expect(result.containerClasses).toContain('no-border')
+  })
+
+  it('should return correct classes for hide border topBottom', () => {
+    const config: ChartConfig = {
+      legend: {
+        position: 'top',
+        singleRow: false,
+        reverseLabelOrder: false,
+        verticalSorted: false,
+        hideBorder: { side: false, topBottom: true }
+      }
+    }
+    const result = getLegendClasses(config)
+    expect(result.containerClasses).toContain('no-border')
+    expect(result.containerClasses).toContain('p-0')
+  })
+})

--- a/packages/chart/src/components/Legend/tests/getLegendClasses.test.ts
+++ b/packages/chart/src/components/Legend/tests/getLegendClasses.test.ts
@@ -93,7 +93,7 @@ describe('getLegendClasses', () => {
       }
     }
     const result = getLegendClasses(config)
-    expect(result.containerClasses).toContain('no-border')
+    expect(result.containerClasses).toContain('border-0')
   })
 
   it('should return correct classes for hide border topBottom', () => {
@@ -107,7 +107,7 @@ describe('getLegendClasses', () => {
       }
     }
     const result = getLegendClasses(config)
-    expect(result.containerClasses).toContain('no-border')
+    expect(result.containerClasses).toContain('border-0')
     expect(result.containerClasses).toContain('p-0')
   })
 })

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -171,7 +171,8 @@ export default {
     hideBorder: {
       side: false,
       topBottom: true
-    }
+    },
+    position: 'right'
   },
   brush: {
     height: 25,

--- a/packages/chart/src/scss/main.scss
+++ b/packages/chart/src/scss/main.scss
@@ -159,7 +159,7 @@
     border: 1px solid var(--lightGray);
     position: relative;
 
-    &.no-border {
+    &.border-0 {
       border: 1px solid transparent;
       padding: 0;
     }

--- a/packages/chart/src/scss/main.scss
+++ b/packages/chart/src/scss/main.scss
@@ -261,6 +261,10 @@
     }
   }
 
+  .legend-container__inner.flex-column-reverse div.legend-item:last-child {
+    margin-bottom: 0.2rem !important;
+  }
+
   .dynamic-legend-list {
     // overide traditional legend item that uses !important
     .legend-item {


### PR DESCRIPTION
## [DEV-9553] Chart > Legend Updates 
- Fixes an issue when building charts where "hide legend border" only worked in the chart package
- Removes `.no-border` class to favor bootstraps `.border-0` on legends
- Updates reversed legend ordering to have better spacing on the first item when the legend is reversed
- Moves `hooks/useLegendClasses` to `helpers/getLegendClasses`
- Adds tests for legend classes
- Removes duplicated hide legend item toggle

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)
![Screen Shot 2024-11-08 at 11 39 38 AM](https://github.com/user-attachments/assets/ad4856a2-91fb-4a27-be4c-85b69100d40f)
![Screen Shot 2024-11-08 at 11 39 50 AM](https://github.com/user-attachments/assets/e3de4dce-c53d-420a-850f-03891a40b1ee)
![Screen Shot 2024-11-08 at 11 23 29 AM](https://github.com/user-attachments/assets/768f7ee4-1efd-4006-ad52-b13105910ccc)



## Additional Notes

<!-- Add any additional notes about this PR -->
