### PR TITLE
FIX [DEV-9233] Update y position for lollipop chart

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -358,7 +358,7 @@ export const BarChartVertical = () => {
                           <rect
                             display={displaylollipopShape}
                             x={barX - lollipopBarWidth / 2}
-                            y={barY}
+                            y={bar.y}
                             width={lollipopShapeSize}
                             height={lollipopShapeSize}
                             fill={getBarBackgroundColor(colorScale(config.runtime.seriesLabels[bar.key]))}


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Open Bar chart vertical (regular)
Switch to Lollipop
Make sure we have negative values in our data set example (Data 1: -300) 
select that series while chart is lillipop;
on visual panel change lollipop shape from circle to square. 
Square should be on top of the bar even if that bar is negative.

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
