### PR TITLE
[DEV-9802] District of Columbia support on hex maps

### DIFF
--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -274,6 +274,22 @@ const CdcMap = ({
         if (!uid && geoName) {
           uid = cityKeys.find(key => key === geoName.toUpperCase())
         }
+
+        if (state.general.displayAsHex) {
+          const upperCaseKey = geoName.toUpperCase()
+          const supportedDc = [
+            'WASHINGTON D.C.',
+            'DISTRICT OF COLUMBIA',
+            'WASHINGTON DC',
+            'DC',
+            'WASHINGTON DC.',
+            'D.C.',
+            'D.C'
+          ]
+          if (supportedDc.includes(upperCaseKey)) {
+            uid = 'US-DC'
+          }
+        }
       }
 
       if ('us-region' === obj.general.geoType && obj.columns.geo.name) {

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -19,6 +19,7 @@ import { patternSizes } from '../helpers/patternSizes'
 import Annotation from '../../Annotation'
 
 import Territory from './Territory'
+import { cityKeys } from '../../../data/supported-geos'
 
 import useMapLayers from '../../../hooks/useMapLayers'
 import ConfigContext from '../../../context'
@@ -59,7 +60,6 @@ const UsaMap = () => {
       data,
       displayGeoName,
       geoClickHandler,
-      handleCircleClick,
       handleMapAriaLabels,
       setSharedFilterValue,
       state,
@@ -67,7 +67,6 @@ const UsaMap = () => {
       titleCase,
       tooltipId,
       handleDragStateChange,
-      setState,
       mapId
     } = useContext<MapContext>(ConfigContext)
 
@@ -246,8 +245,6 @@ const UsaMap = () => {
       // Map the name from the geo data with the appropriate key for the processed data
       let geoKey = geo.properties.iso
       let geoName = geo.properties.name
-
-      // Manually add Washington D.C. in for Hex maps
 
       if (!geoKey) return
 


### PR DESCRIPTION
## [[DEV-9802] District of Columbia support on hex maps](https://websupport-cdc.msappproxy.net/browse/DEV-9802)

- Create a state map
- Upload a csv file with "District of Columbia" as the state value in a csv file.
- Under Type > Check "Display as hex map"

Previously the only value that was working was "DC". This was because that value is in the state dictionary file. These changes fit a number of the possibilities of DC to fit the US-DC code in the hex code topojson file.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
