### PR TITLE
Fix: Dev-9755 - Nested dropdown doesn't close on blur to another dropdown

### DIFF
--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -468,6 +468,7 @@ const Filters = (props: FilterProps) => {
               <NestedDropdown
                 activeGroup={(singleFilter.active as string) || (singleFilter.queuedActive || [])[0]}
                 activeSubGroup={(singleFilter.subGrouping?.active as string) || (singleFilter.queuedActive || [])[1]}
+                filterIndex={outerIndex}
                 options={getNestedOptions(singleFilter)}
                 listLabel={label}
                 handleSelectedItems={value => changeFilterActive(outerIndex, value)}

--- a/packages/core/components/NestedDropdown/NestedDropdown.tsx
+++ b/packages/core/components/NestedDropdown/NestedDropdown.tsx
@@ -5,11 +5,12 @@ import { filterSearchTerm, NestedOptions, ValueTextPair } from './nestedDropdown
 
 const Options: React.FC<{
   subOptions: ValueTextPair[]
+  filterIndex: number
   label: string
   handleSubGroupSelect: Function
   userSelectedLabel: string
   userSearchTerm: string
-}> = ({ subOptions, label, handleSubGroupSelect, userSelectedLabel, userSearchTerm }) => {
+}> = ({ subOptions, filterIndex, label, handleSubGroupSelect, userSelectedLabel, userSearchTerm }) => {
   const [isTierOneExpanded, setIsTierOneExpanded] = useState(true)
   const checkMark = <>&#10004;</>
 
@@ -18,7 +19,7 @@ const Options: React.FC<{
   }, [userSearchTerm])
 
   const handleGroupClick = e => {
-    const leaveExpanded = e.target.className === 'selectable-item' ? true : !isTierOneExpanded
+    const leaveExpanded = e.target.className === `selectable-item-${filterIndex}` ? true : !isTierOneExpanded
     setIsTierOneExpanded(leaveExpanded)
   }
 
@@ -26,10 +27,10 @@ const Options: React.FC<{
     const currentItem = e.target
     if (e.key === 'ArrowRight') setIsTierOneExpanded(true)
     else if (e.key === 'ArrowLeft') {
-      if (currentItem.className === 'selectable-item') currentItem.parentNode.parentNode.focus()
+      if (currentItem.className === `selectable-item-${filterIndex}`) currentItem.parentNode.parentNode.focus()
       setIsTierOneExpanded(false)
     } else if (e.key === 'Enter') {
-      currentItem.className === 'selectable-item'
+      currentItem.className === `selectable-item-${filterIndex}`
         ? handleSubGroupSelect(currentItem.dataset.value)
         : setIsTierOneExpanded(!isTierOneExpanded)
     }
@@ -44,7 +45,7 @@ const Options: React.FC<{
         aria-label={label}
         onClick={handleGroupClick}
         onKeyUp={handleKeyUp}
-        className='nested-dropdown-group'
+        className={`nested-dropdown-group-${filterIndex}`}
       >
         <span className={'font-weight-bold'}>{label} </span>
         {
@@ -73,7 +74,7 @@ const Options: React.FC<{
             return (
               <li
                 key={regionID}
-                className='selectable-item'
+                className={`selectable-item-${filterIndex}`}
                 tabIndex={0}
                 role='treeitem'
                 aria-label={regionID}
@@ -104,6 +105,7 @@ const Options: React.FC<{
 type NestedDropdownProps = {
   activeGroup: string
   activeSubGroup?: string
+  filterIndex: number
   isEditor?: boolean
   isUrlFilter?: boolean
   listLabel: string
@@ -116,6 +118,7 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
   options,
   activeGroup,
   activeSubGroup,
+  filterIndex,
   listLabel,
   handleSelectedItems
 }) => {
@@ -151,7 +154,7 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
           setIsListOpened(true)
           // Move focus from Input to top of dropdown
           Dropdown.firstChild.focus()
-        } else if (className === 'selectable-item') {
+        } else if (className === `selectable-item-${filterIndex}`) {
           // Move focus to next item on list: next Tier Two item or the next Tier One or SearchInput
           const itemToFocusOnAfterKeyUp = nextSibling ?? parentNode.parentNode.nextSibling ?? searchInput.current
           itemToFocusOnAfterKeyUp.focus()
@@ -176,7 +179,7 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
             // Move focus to last item of the last collapsed Tier Two in dropdown
             Dropdown.lastChild.lastChild.lastChild.focus()
           }
-        } else if (className === 'selectable-item') {
+        } else if (className === `selectable-item-${filterIndex}`) {
           // Move focus to previous Tier Two or Move focus to current Tier One
           const itemToFocusOnAfterKeyUp = previousSibling ?? parentNode.parentNode
           itemToFocusOnAfterKeyUp.focus()
@@ -226,6 +229,20 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
     setInputValue(newSearchTerm)
   }
 
+  const handleOnBlur = e => {
+    if (
+      e.relatedTarget === null ||
+      ![
+        `nested-dropdown-${filterIndex}`,
+        `nested-dropdown-group-${filterIndex}`,
+        `selectable-item-${filterIndex}`
+      ].includes(e.relatedTarget.className)
+    ) {
+      setInputHasFocus(false)
+      setIsListOpened(false)
+    }
+  }
+
   return (
     <>
       {listLabel && (
@@ -233,9 +250,19 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
           {listLabel}
         </label>
       )}
+<<<<<<< HEAD
       <div id={dropdownId} className={`nested-dropdown ${isListOpened ? 'open-filter' : ''}`} onKeyUp={handleKeyUp}>
         <div className='nested-dropdown-input-container' aria-label='searchInput' role='textbox'>
+=======
+      <div
+        id={dropdownId}
+        className={`nested-dropdown nested-dropdown-${filterIndex} ${isListOpened ? 'open-filter' : ''}`}
+        onKeyUp={handleKeyUp}
+      >
+        <div className='nested-dropdown-input-container form-control' aria-label='searchInput' role='textbox'>
+>>>>>>> e3ce4cfce (dev-9755-Nested-Dropdown-doesnt-close-on-blur)
           <input
+            id={`nested-dropdown-${filterIndex}`}
             className='search-input'
             ref={searchInput}
             aria-label='searchInput'
@@ -249,7 +276,7 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
               if (inputHasFocus) setIsListOpened(!isListOpened)
             }}
             onFocus={() => setInputHasFocus(true)}
-            onBlur={() => setInputHasFocus(false)}
+            onBlur={e => handleOnBlur(e)}
           />
           <span className='list-arrow' aria-hidden={true}>
             <Icon display='caretDown' />
@@ -272,6 +299,7 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
                   <Options
                     key={groupTextValue + '_' + index}
                     subOptions={subgroup}
+                    filterIndex={filterIndex}
                     label={groupTextValue}
                     handleSubGroupSelect={subGroupValue => {
                       chooseSelectedSubGroup(groupValue, subGroupValue)

--- a/packages/core/components/NestedDropdown/nesteddropdown.styles.css
+++ b/packages/core/components/NestedDropdown/nesteddropdown.styles.css
@@ -6,7 +6,7 @@
 }
 
 .nested-dropdown {
-  .nested-dropdown-group {
+  [class^='nested-dropdown-group-'] {
     list-style: none;
   }
 
@@ -27,7 +27,7 @@
     font-size: 1em;
   }
 
-  .selectable-item {
+  [class^='selectable-item-'] {
     list-style: none;
     padding-left: 20px;
     position: relative;

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -108,6 +108,7 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
             <NestedDropdown
               activeGroup={filter.active as string}
               activeSubGroup={filter.subGrouping?.active}
+              filterIndex={filterIndex}
               options={getNestedDropdownOptions(apiFilterDropdowns[_key])}
               listLabel={filter.key}
               handleSelectedItems={value => updateField(null, null, filterIndex, value)}


### PR DESCRIPTION
## Fix: Dev-9755 Nested dropdown doesn't close on blur to another dropdown 
[https://websupport.cdc.gov/browse/DEV-9755](https://websupport.cdc.gov/browse/DEV-9755)

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: Upload [dev-9755-config.json](https://github.com/user-attachments/files/17721438/dev-9755-config.json) and navigate to the dashboard preview.
Expected: There are 2 dashboard filters. The first is a Nested Dropdown and the second is a Dropdown filter. 

1. Click on the Nested dropdown box
Expected: The Nested dropdown filter opens up

2. Click anywhere outside of the Nested Dropdown
Expected: The Nested dropdown filter closes


## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
