### PR TITLE
[DEV-9555] Fix height not updating when filter added in editor

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -130,7 +130,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   // height before bottom axis
   const initialHeight = useMemo(
     () => calcInitialHeight(config, currentViewport),
-    [config, currentViewport, parentHeight]
+    [config, currentViewport, parentHeight, config.heights?.vertical, config.heights?.horizontal]
   )
   const forestHeight = useMemo(() => initialHeight + forestRowsHeight, [initialHeight, forestRowsHeight])
 


### PR DESCRIPTION
## [DEV-9555]

See ticket, fixes issue flagged by Cailin when adding filters to horizontal bar charts in the editor.

## Testing steps

* Run the editor locally
* Create a bar chart using sample data
* Change orientation to horizontal, set x/y axes, click "I'm done"
* Add a filter, see that chart height resizes correctly (unlike on `dev`)

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
