### PR TITLE
Enhancement: Dev-9448 Data Reset Scenario

### DIFF
--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -542,7 +542,7 @@ export default function CdcDashboard({ initialState, isEditor = false, isDebug =
                     return (
                       <>
                         {/* Expand/Collapse All */}
-                        {row.expandCollapseAllButtons === true && (
+                        {!inNoDataState && row.expandCollapseAllButtons === true && (
                           <ExpandCollapseButtons setAllExpanded={setAllExpanded} />
                         )}
                         {Object.keys(dataGroups).map(groupName => {
@@ -559,6 +559,7 @@ export default function CdcDashboard({ initialState, isEditor = false, isDebug =
                               updateChildConfig={updateChildConfig}
                               apiFilterDropdowns={apiFilterDropdowns}
                               currentViewport={currentViewport}
+                              inNoDataState={inNoDataState}
                             />
                           )
                         })}
@@ -576,10 +577,13 @@ export default function CdcDashboard({ initialState, isEditor = false, isDebug =
                         updateChildConfig={updateChildConfig}
                         apiFilterDropdowns={apiFilterDropdowns}
                         currentViewport={currentViewport}
+                        inNoDataState={inNoDataState}
                       />
                     )
                   }
                 })}
+
+            {inNoDataState ? <span>Please complete your selection to continue.</span> : <></>}
 
             {/* Image or PDF Inserts */}
             <section className='download-buttons'>

--- a/packages/dashboard/src/components/VisualizationRow.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.tsx
@@ -24,6 +24,7 @@ type VisualizationWrapperProps = {
   children: React.ReactNode
   currentViewport: ViewPort
   groupName: string
+  hideVisualization: boolean
   row: ConfigRow
 }
 
@@ -31,10 +32,13 @@ const VisualizationWrapper: React.FC<VisualizationWrapperProps> = ({
   allExpanded,
   currentViewport,
   groupName,
+  hideVisualization,
   row,
   children
 }) => {
-  return row.expandCollapseAllButtons ? (
+  return hideVisualization ? (
+    <></>
+  ) : row.expandCollapseAllButtons ? (
     <div className='collapsable-multiviz-container'>
       <CollapsibleVisualizationRow
         allExpanded={allExpanded}
@@ -47,7 +51,7 @@ const VisualizationWrapper: React.FC<VisualizationWrapperProps> = ({
     </div>
   ) : (
     <>
-      <h3>{groupName}</h3>
+      {groupName !== '' ? <h3>{groupName}</h3> : <></>}
       {children}
     </>
   )
@@ -59,6 +63,7 @@ type VizRowProps = {
   groupName: string
   row: ConfigRow
   rowIndex: number
+  inNoDataState: boolean
   setSharedFilter: Function
   updateChildConfig: Function
   apiFilterDropdowns: APIFilterDropdowns
@@ -71,6 +76,7 @@ const VisualizationRow: React.FC<VizRowProps> = ({
   groupName,
   row,
   rowIndex: index,
+  inNoDataState,
   setSharedFilter,
   updateChildConfig,
   apiFilterDropdowns,
@@ -81,11 +87,6 @@ const VisualizationRow: React.FC<VizRowProps> = ({
   const setToggled = (colIndex: number) => {
     setShow(show.map((_, i) => i === colIndex))
   }
-  const inNoDataState = useMemo(() => {
-    const vals = Object.values(rawData).flatMap(val => val)
-    if (!vals.length) return true
-    return vals.some(val => val === undefined)
-  }, [rawData])
 
   const footnotesConfig = useMemo(() => {
     if (row.footnotesId) {
@@ -150,10 +151,10 @@ const VisualizationRow: React.FC<VizRowProps> = ({
               {visualizationConfig.dataKey} (Go to Table)
             </a>
           )
-          const hideFilter =
+          const hideVisualization =
             inNoDataState &&
-            visualizationConfig.type === 'dashboardFilters' &&
-            applyButtonNotClicked(visualizationConfig)
+            visualizationConfig.filterBehavior !== 'Apply Button' &&
+            (visualizationConfig.type !== 'dashboardFilters' || applyButtonNotClicked(visualizationConfig))
 
           const shouldShow = row.toggle === undefined || (row.toggle && show[colIndex])
 
@@ -166,6 +167,7 @@ const VisualizationRow: React.FC<VizRowProps> = ({
                 allExpanded={allExpanded}
                 currentViewport={currentViewport}
                 groupName={groupName}
+                hideVisualization={hideVisualization}
                 row={row}
               >
                 {visualizationConfig.type === 'chart' && (
@@ -272,7 +274,7 @@ const VisualizationRow: React.FC<VizRowProps> = ({
                     configUrl={undefined}
                   />
                 )}
-                {visualizationConfig.type === 'dashboardFilters' && !hideFilter && (
+                {visualizationConfig.type === 'dashboardFilters' && (
                   <DashboardSharedFilters
                     setConfig={newConfig => {
                       updateChildConfig(col.widget, newConfig)


### PR DESCRIPTION
## DEV-9448
[https://websupport.cdc.gov/browse/DEV-9448](https://websupport.cdc.gov/browse/DEV-9448)

When a drop-down option is changed, all affected items in the dashboard are hidden and the message "Please complete your selection to continue." appears

## Testing Steps

Scenario: Upload [dev-9448-config.json](https://github.com/user-attachments/files/17751499/dev-9448-config.json)  and navigate to the dashboard preview.

Expected: There are 2 dashboard filters and under them the message "Please complete your selection to continue." 

Make a selection in both dropdowns
Click the Go! Button

Expected: The message has been removed and a new Quarter dropdown has taken its place. There is also the Expand and Collapse All toggles and the Table toggle for multi-viz rows. 

Change the option in the Location dropdown

Expected: The Quarter dropdown and the rest of the visualizations have been removed and the message is back.

## Self Review

- I have added testing steps for reviewers

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
