### PR TITLE
[DEV-9624] Update filters reset label logic

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -81,15 +81,17 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
           }
         } else {
           // Data Filter
-          filter.values?.forEach((filterOption, index) => {
-            const labeledOpt = filter.labels && filter.labels[filterOption]
-            values.push(
-              <option key={`${filter.key}-option-${index}`} value={filterOption}>
-                {labeledOpt || filterOption}
-              </option>
-            )
-            multiValues.push({ value: filterOption, label: labeledOpt || filterOption })
-          })
+          filter.values
+            .filter(value => value !== filter.resetLabel)
+            ?.forEach((filterOption, index) => {
+              const labeledOpt = filter.labels && filter.labels[filterOption]
+              values.push(
+                <option key={`${filter.key}-option-${index}`} value={filterOption}>
+                  {labeledOpt || filterOption}
+                </option>
+              )
+              multiValues.push({ value: filterOption, label: labeledOpt || filterOption })
+            })
         }
 
         return filter.filterStyle === FILTER_STYLE.multiSelect ? (

--- a/packages/dashboard/src/helpers/addValuesToDashboardFilters.ts
+++ b/packages/dashboard/src/helpers/addValuesToDashboardFilters.ts
@@ -47,9 +47,7 @@ export const addValuesToDashboardFilters = (
         const active: string[] = Array.isArray(filterCopy.active) ? filterCopy.active : [filterCopy.active]
         filterCopy.active = active.filter(val => defaultValues.includes(val))
       } else {
-        const defaultLabel = filters.find(filter => filter.resetLabel)
-        const defaultValue = defaultLabel ? defaultLabel.resetLabel : filterCopy.values[0] || filterCopy.active
-        filterCopy.active = defaultValue
+        filterCopy.active = filter.resetLabel || filterCopy.values[0]
       }
     }
     return filterCopy

--- a/packages/dashboard/src/helpers/filterData.ts
+++ b/packages/dashboard/src/helpers/filterData.ts
@@ -24,7 +24,10 @@ function getMaxTierAndSetFilterTiers(filters: SharedFilter[]): number {
 }
 
 function filter(data = [], filters: SharedFilter[], condition) {
-  const activeFilters = filters.filter(f => f.resetLabel !== f.active)
+  const activeFilters = filters.filter(
+    filter => filter.resetLabel !== filter.active || filter.values.some(value => value === filter.resetLabel)
+  )
+
   return data.filter(row => {
     const foundMatchingFilter = activeFilters.find(filter => {
       const currentValue = row[filter.columnName]

--- a/packages/dashboard/src/helpers/filterData.ts
+++ b/packages/dashboard/src/helpers/filterData.ts
@@ -25,7 +25,7 @@ function getMaxTierAndSetFilterTiers(filters: SharedFilter[]): number {
 
 function filter(data = [], filters: SharedFilter[], condition) {
   const activeFilters = filters.filter(
-    filter => filter.resetLabel !== filter.active || filter.values.some(value => value === filter.resetLabel)
+    filter => filter.resetLabel !== filter.active || filter.values?.some(value => value === filter.resetLabel)
   )
 
   return data.filter(row => {


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
To verify the fix, follow these steps in the dashboard:

Open the Dashboard: Navigate to the main dashboard view.
Add Shared Filters: Include shared filters applicable to the dataset.
Insert Visualization: Add either a Bar chart or a Map to the dashboard.
Configure Shared Filters: Setup the shared filters to interact with the visualization.
Set Reset Label: In the filter configuration, set the "Reset Label" to a valid entry such as "Arizona" (assuming the filter category is "State").
Expected Behavior
Before the Fix: Selecting "Arizona" as a reset label resulted in its duplication in the filter selector—one as a reset label and once as a data value.
After the Fix: "Arizona" now only appears once in the selector. It is set as the default (active) filter value and filters the data based on this state without redundancy in the display.
<img width="825" alt="Screenshot 2024-11-14 at 14 06 58" src="https://github.com/user-attachments/assets/61d78713-8dd7-48f7-a121-3df8d37bf2d9">


<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
