### PR TITLE
Fix: Dev-9744 - Charts: No data state doesn't show

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -598,6 +598,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     )
   }
 
+  const isNoDataAvailable = config.filters && config.filters.values.length === 0 && data.length === 0
+
   return isNaN(width) ? (
     <React.Fragment></React.Fragment>
   ) : (
@@ -611,7 +613,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           ref={svgRef}
           onMouseMove={onMouseMove}
           width={parentWidth}
-          height={parentHeight}
+          height={isNoDataAvailable ? 1 : parentHeight}
           className={`linear ${config.animate ? 'animated' : ''} ${animatedChart && config.animate ? 'animate' : ''} ${
             debugSvg && 'debug'
           } ${isDraggingAnnotation && 'dragging-annotation'}`}
@@ -949,7 +951,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               />
             </Group>
           )}
-          {config.filters && config.filters.values.length === 0 && data.length === 0 && (
+          {isNoDataAvailable && (
             <Text
               x={Number(config.yAxis.size) + Number(xMax / 2)}
               y={initialHeight / 2 - (config.xAxis.padding || 0) / 2}


### PR DESCRIPTION
## DEV-9744
[https://websupport.cdc.gov/browse/DEV-9744](https://websupport.cdc.gov/browse/DEV-9744)

The bar graphs display a "No Data Available"

## Testing Steps

Scenario: Upload [dev-9744-config.json](https://github.com/user-attachments/files/17756894/dev-9744-config.json) and navigate to the dashboard preview.
Expected: There is a dashboard filters with "No Option Selected" and there is a message that says, "No Data Available." This is the chart that has no data. 

1. In the Location Filter choose a state
  Expected: The chart now appears with data
    
  2. In the Location Filter, select "No Option Selected"
  Expected: "No Data Available" has taken the place of the chart

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
