### PR TITLE
[DEV-9840] add confidence intervals to line charts

### DIFF
--- a/packages/chart/src/_stories/Chart.stories.tsx
+++ b/packages/chart/src/_stories/Chart.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import Chart from '../CdcChart'
 import lineChartTwoPointsRegressionTest from './_mock/line_chart_two_points_regression_test.json'
 import lineChartTwoPointsNewChart from './_mock/line_chart_two_points_new_chart.json'
+import lineChartConfidenceIntervals from './_mock/line_chart_confidence_intervals.json'
 import lollipop from './_mock/lollipop.json'
 import forestPlot from '../../examples/feature/forest-plot/forest-plot.json'
 import pairedBar from './_mock/paired-bar.json'
@@ -17,6 +18,13 @@ const meta: Meta<typeof Chart> = {
 }
 
 type Story = StoryObj<typeof Chart>
+
+export const line_Chart_Confidence_Intervals: Story = {
+  args: {
+    config: lineChartConfidenceIntervals,
+    isEditor: false
+  }
+}
 
 export const line_Chart_Two_Points_Regression_Test: Story = {
   args: {

--- a/packages/chart/src/_stories/_mock/line_chart_confidence_intervals.json
+++ b/packages/chart/src/_stories/_mock/line_chart_confidence_intervals.json
@@ -1,0 +1,543 @@
+{
+  "annotations": [],
+  "type": "chart",
+  "debugSvg": false,
+  "chartMessage": {
+    "noData": "No Data Available"
+  },
+  "title": "",
+  "showTitle": true,
+  "showDownloadMediaButton": false,
+  "theme": "theme-blue",
+  "animate": false,
+  "fontSize": "medium",
+  "lineDatapointStyle": "hover",
+  "lineDatapointColor": "Same as Line",
+  "barHasBorder": "false",
+  "isLollipopChart": false,
+  "lollipopShape": "circle",
+  "lollipopColorStyle": "two-tone",
+  "visualizationSubType": "regular",
+  "barStyle": "flat",
+  "roundingStyle": "standard",
+  "tipRounding": "top",
+  "isResponsiveTicks": false,
+  "general": {
+    "annotationDropdownText": "Annotations",
+    "showDownloadButton": false,
+    "showMissingDataLabel": true,
+    "showSuppressedSymbol": true,
+    "showZeroValueData": true,
+    "hideNullValue": true
+  },
+  "padding": {
+    "left": 5,
+    "right": 5
+  },
+  "preliminaryData": [],
+  "yAxis": {
+    "hideAxis": false,
+    "displayNumbersOnBar": false,
+    "hideLabel": false,
+    "hideTicks": false,
+    "size": 50,
+    "gridLines": false,
+    "enablePadding": false,
+    "min": "",
+    "max": "",
+    "labelColor": "#333",
+    "tickLabelColor": "#333",
+    "tickColor": "#333",
+    "rightHideAxis": true,
+    "rightAxisSize": 0,
+    "rightLabel": "",
+    "rightLabelOffsetSize": 0,
+    "rightAxisLabelColor": "#333",
+    "rightAxisTickLabelColor": "#333",
+    "rightAxisTickColor": "#333",
+    "numTicks": "",
+    "axisPadding": 0,
+    "scalePadding": 10,
+    "tickRotation": 0,
+    "anchors": [],
+    "shoMissingDataLabel": true,
+    "showMissingDataLine": true,
+    "categories": []
+  },
+  "boxplot": {
+    "plots": [],
+    "borders": "true",
+    "plotOutlierValues": false,
+    "plotNonOutlierValues": true,
+    "labels": {
+      "q1": "Lower Quartile",
+      "q2": "q2",
+      "q3": "Upper Quartile",
+      "q4": "q4",
+      "minimum": "Minimum",
+      "maximum": "Maximum",
+      "mean": "Mean",
+      "median": "Median",
+      "sd": "Standard Deviation",
+      "iqr": "Interquartile Range",
+      "count": "Count",
+      "outliers": "Outliers",
+      "values": "Values",
+      "lowerBounds": "Lower Bounds",
+      "upperBounds": "Upper Bounds"
+    }
+  },
+  "topAxis": {
+    "hasLine": false
+  },
+  "isLegendValue": false,
+  "barThickness": 0.35,
+  "barHeight": 25,
+  "barSpace": 15,
+  "heights": {
+    "vertical": 300,
+    "horizontal": 750
+  },
+  "xAxis": {
+    "sortDates": false,
+    "anchors": [],
+    "type": "categorical",
+    "showTargetLabel": true,
+    "targetLabel": "Target",
+    "hideAxis": false,
+    "hideLabel": false,
+    "hideTicks": false,
+    "size": 75,
+    "tickRotation": "45",
+    "min": "",
+    "max": "",
+    "labelColor": "#333",
+    "tickLabelColor": "#333",
+    "tickColor": "#333",
+    "numTicks": "",
+    "labelOffset": 0,
+    "axisPadding": 200,
+    "target": 0,
+    "maxTickRotation": 0,
+    "padding": "0",
+    "showYearsOnce": false,
+    "sortByRecentDate": false,
+    "dataKey": "date",
+    "axisBBox": 115.91039276123047,
+    "tickWidthMax": 93,
+    "dateParseFormat": "%Y-%m-%d",
+    "dateDisplayFormat": "%Y-%m-%d",
+    "manual": false,
+    "label": "Date"
+  },
+  "table": {
+    "label": "Data Table",
+    "expanded": true,
+    "limitHeight": false,
+    "height": "",
+    "caption": "",
+    "showDownloadUrl": false,
+    "showDataTableLink": true,
+    "showDownloadLinkBelow": true,
+    "indexLabel": "",
+    "download": true,
+    "showVertical": true,
+    "dateDisplayFormat": "%Y-%m-%d",
+    "showMissingDataLabel": true,
+    "showSuppressedSymbol": true,
+    "show": true
+  },
+  "orientation": "vertical",
+  "color": "pinkpurple",
+  "columns": {
+    "male_ci": {
+      "label": "Male (CI)",
+      "dataTable": true,
+      "tooltips": false,
+      "prefix": "",
+      "suffix": "",
+      "forestPlot": false,
+      "startingPoint": "0",
+      "forestPlotAlignRight": false,
+      "roundToPlace": 0,
+      "commas": false,
+      "showInViz": false,
+      "forestPlotStartingPoint": 0,
+      "name": "male_ci"
+    },
+    "female_ci": {
+      "label": "Female (CI)",
+      "dataTable": true,
+      "tooltips": false,
+      "prefix": "",
+      "suffix": "",
+      "forestPlot": false,
+      "startingPoint": "0",
+      "forestPlotAlignRight": false,
+      "roundToPlace": 0,
+      "commas": false,
+      "showInViz": false,
+      "forestPlotStartingPoint": 0,
+      "name": "female_ci"
+    },
+    "male": {
+      "label": "male",
+      "dataTable": false,
+      "tooltips": false,
+      "prefix": "",
+      "suffix": "",
+      "forestPlot": false,
+      "startingPoint": "0",
+      "forestPlotAlignRight": false,
+      "roundToPlace": 0,
+      "commas": false,
+      "showInViz": false,
+      "forestPlotStartingPoint": 0,
+      "name": "male"
+    },
+    "female": {
+      "label": "female",
+      "dataTable": false,
+      "tooltips": false,
+      "prefix": "",
+      "suffix": "",
+      "forestPlot": false,
+      "startingPoint": "0",
+      "forestPlotAlignRight": false,
+      "roundToPlace": 0,
+      "commas": false,
+      "showInViz": false,
+      "forestPlotStartingPoint": 0,
+      "name": "female"
+    },
+    "date": {
+      "label": "Date",
+      "dataTable": true,
+      "tooltips": false,
+      "prefix": "",
+      "suffix": "",
+      "forestPlot": false,
+      "startingPoint": "0",
+      "forestPlotAlignRight": false,
+      "roundToPlace": 0,
+      "commas": false,
+      "showInViz": false,
+      "forestPlotStartingPoint": 0,
+      "name": "date"
+    }
+  },
+  "legend": {
+    "hide": false,
+    "behavior": "isolate",
+    "axisAlign": true,
+    "singleRow": true,
+    "colorCode": "",
+    "reverseLabelOrder": false,
+    "description": "",
+    "dynamicLegend": false,
+    "dynamicLegendDefaultText": "Show All",
+    "dynamicLegendItemLimit": 5,
+    "dynamicLegendItemLimitMessage": "Dynamic Legend Item Limit Hit.",
+    "dynamicLegendChartMessage": "Select Options from the Legend",
+    "label": "",
+    "lineMode": false,
+    "verticalSorted": false,
+    "highlightOnHover": false,
+    "hideSuppressedLabels": false,
+    "hideSuppressionLink": false,
+    "seriesHighlight": [],
+    "style": "circles",
+    "subStyle": "linear blocks",
+    "tickRotation": "",
+    "hideBorder": {
+      "side": false,
+      "topBottom": true
+    }
+  },
+  "brush": {
+    "height": 25,
+    "active": false
+  },
+  "exclusions": {
+    "active": true,
+    "keys": [],
+    "dateStart": "2023-01-02",
+    "dateEnd": "2023-01-11"
+  },
+  "palette": "qualitative-bold",
+  "isPaletteReversed": false,
+  "twoColor": {
+    "palette": "monochrome-1",
+    "isPaletteReversed": false
+  },
+  "labels": false,
+  "dataFormat": {
+    "commas": false,
+    "prefix": "",
+    "suffix": "",
+    "abbreviated": false,
+    "bottomSuffix": "",
+    "bottomPrefix": "",
+    "bottomAbbreviated": false
+  },
+  "confidenceKeys": {
+    "upper": "upper",
+    "lower": "lower"
+  },
+  "visual": {
+    "border": true,
+    "accent": true,
+    "background": true,
+    "verticalHoverLine": false,
+    "horizontalHoverLine": false
+  },
+  "useLogScale": false,
+  "filterBehavior": "Filter Change",
+  "highlightedBarValues": [],
+  "series": [
+    {
+      "dataKey": "male",
+      "type": "Line",
+      "axis": "Left",
+      "tooltip": false,
+      "confidenceIntervals": [
+        {
+          "high": "male_upper",
+          "low": "male_lower"
+        }
+      ],
+      "lineType": "curveMonotoneX",
+      "weight": 3
+    },
+    {
+      "dataKey": "female",
+      "type": "Line",
+      "axis": "Left",
+      "tooltip": false,
+      "confidenceIntervals": [
+        {
+          "high": "female_upper",
+          "low": "female_lower"
+        }
+      ],
+      "lineType": "curveMonotoneX",
+      "weight": 3
+    }
+  ],
+  "tooltips": {
+    "opacity": 90,
+    "singleSeries": false,
+    "dateDisplayFormat": ""
+  },
+  "forestPlot": {
+    "startAt": 0,
+    "colors": {
+      "line": "",
+      "shape": ""
+    },
+    "lineOfNoEffect": {
+      "show": true
+    },
+    "type": "",
+    "pooledResult": {
+      "diamondHeight": 5,
+      "column": ""
+    },
+    "estimateField": "",
+    "estimateRadius": "",
+    "shape": "square",
+    "rowHeight": 20,
+    "description": {
+      "show": true,
+      "text": "description",
+      "location": 0
+    },
+    "result": {
+      "show": true,
+      "text": "result",
+      "location": 100
+    },
+    "radius": {
+      "min": 2,
+      "max": 10,
+      "scalingColumn": ""
+    },
+    "regression": {
+      "lower": 0,
+      "upper": 0,
+      "estimateField": 0
+    },
+    "leftWidthOffset": 0,
+    "rightWidthOffset": 0,
+    "showZeroLine": false,
+    "leftLabel": "",
+    "rightLabel": ""
+  },
+  "area": {
+    "isStacked": false
+  },
+  "sankey": {
+    "title": {
+      "defaultColor": "black"
+    },
+    "iterations": 1,
+    "rxValue": 0.9,
+    "overallSize": {
+      "width": 900,
+      "height": 700
+    },
+    "margin": {
+      "margin_y": 25,
+      "margin_x": 0
+    },
+    "nodeSize": {
+      "nodeWidth": 26,
+      "nodeHeight": 40
+    },
+    "nodePadding": 55,
+    "nodeFontColor": "black",
+    "nodeColor": {
+      "default": "#ff8500",
+      "inactive": "#808080"
+    },
+    "linkColor": {
+      "default": "#ffc900",
+      "inactive": "#D3D3D3"
+    },
+    "opacity": {
+      "nodeOpacityDefault": 1,
+      "nodeOpacityInactive": 0.1,
+      "LinkOpacityDefault": 1,
+      "LinkOpacityInactive": 0.1
+    },
+    "storyNodeFontColor": "#006778",
+    "storyNodeText": [],
+    "nodeValueStyle": {
+      "textBefore": "(",
+      "textAfter": ")"
+    },
+    "data": []
+  },
+  "visualizationType": "Line",
+  "data": [
+    {
+      "date": "2023-01-01",
+      "male": 67,
+      "male_lower": 65,
+      "male_upper": 69,
+      "female": 77,
+      "female_lower": 73,
+      "female_upper": 81,
+      "male_ci": "CI (65, 69)",
+      "female_ci": "CI (73, 81)"
+    },
+    {
+      "date": "2023-01-02",
+      "male": 11,
+      "male_lower": 10,
+      "male_upper": 13,
+      "female": 21,
+      "female_lower": 18,
+      "female_upper": 24,
+      "male_ci": "CI (10, 13)",
+      "female_ci": "CI (18, 24)"
+    },
+    {
+      "date": "2023-01-03",
+      "male": 94,
+      "male_lower": 92,
+      "male_upper": 96,
+      "female": 104,
+      "female_lower": 100,
+      "female_upper": 108,
+      "male_ci": "CI (92, 96)",
+      "female_ci": "CI (100, 108)"
+    },
+    {
+      "date": "2023-01-04",
+      "male": 95,
+      "male_lower": 93,
+      "male_upper": 97,
+      "female": 105,
+      "female_lower": 101,
+      "female_upper": 109,
+      "male_ci": "CI (93, 97)",
+      "female_ci": "CI (101, 109)"
+    },
+    {
+      "date": "2023-01-05",
+      "male": 79,
+      "male_lower": 77,
+      "male_upper": 81,
+      "female": 89,
+      "female_lower": 85,
+      "female_upper": 93,
+      "male_ci": "CI (77, 81)",
+      "female_ci": "CI (85, 93)"
+    },
+    {
+      "date": "2023-01-06",
+      "male": 2,
+      "male_lower": 1,
+      "male_upper": 3,
+      "female": 12,
+      "female_lower": 9,
+      "female_upper": 15,
+      "male_ci": "CI (1, 3)",
+      "female_ci": "CI (9, 15)"
+    },
+    {
+      "date": "2023-01-07",
+      "male": 36,
+      "male_lower": 34,
+      "male_upper": 38,
+      "female": 46,
+      "female_lower": 42,
+      "female_upper": 50,
+      "male_ci": "CI (34, 38)",
+      "female_ci": "CI (42, 50)"
+    },
+    {
+      "date": "2023-01-08",
+      "male": 9,
+      "male_lower": 7,
+      "male_upper": 11,
+      "female": 19,
+      "female_lower": 16,
+      "female_upper": 22,
+      "male_ci": "CI (7, 11)",
+      "female_ci": "CI (16, 22)"
+    },
+    {
+      "date": "2023-01-09",
+      "male": 3,
+      "male_lower": 2,
+      "male_upper": 4,
+      "female": 13,
+      "female_lower": 10,
+      "female_upper": 16,
+      "male_ci": "CI (2, 4)",
+      "female_ci": "CI (10, 16)"
+    },
+    {
+      "date": "2023-01-10",
+      "male": 64,
+      "male_lower": 62,
+      "male_upper": 66,
+      "female": 74,
+      "female_lower": 70,
+      "female_upper": 78,
+      "male_ci": "CI (62, 66)",
+      "female_ci": "CI (70, 78)"
+    }
+  ],
+  "dataFileName": "valid-forecast-data.csv",
+  "dataFileSourceType": "file",
+  "dataDescription": {
+    "horizontal": false,
+    "series": false
+  },
+  "version": "4.24.10",
+  "dynamicMarginTop": 0,
+  "regions": []
+}

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1506,7 +1506,7 @@ const EditorPanel = () => {
                               label='Upper'
                               updateField={updateField}
                               initial='Select'
-                              options={getColumns()}
+                              options={getColumns(false)}
                             />
                             <Select
                               value={config.confidenceKeys.lower || ''}
@@ -1515,7 +1515,7 @@ const EditorPanel = () => {
                               label='Lower'
                               updateField={updateField}
                               initial='Select'
-                              options={getColumns()}
+                              options={getColumns(false)}
                             />
                           </>
                         )}

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
@@ -29,9 +29,32 @@ const SeriesWrapper = props => {
 
   const supportedRightAxisTypes = ['Line', 'dashed-sm', 'dashed-md', 'dashed-lg']
 
+  const updateNestedProperty = (obj, propertyPath, value) => {
+    if (!Array.isArray(propertyPath)) {
+      obj[propertyPath] = value
+      return
+    }
+
+    let current = obj
+    for (let i = 0; i < propertyPath.length - 1; i++) {
+      if (!current[propertyPath[i]]) {
+        current[propertyPath[i]] = {}
+      }
+      current = current[propertyPath[i]]
+    }
+    current[propertyPath[propertyPath.length - 1]] = value
+  }
+
   const updateSeries = (index, value, property) => {
     let series = [...config.series]
     series[index][property] = value
+
+    // if property is an array, we need to update the series object with the array
+    if (Array.isArray(property)) {
+      updateNestedProperty(series[index], property, value)
+    } else {
+      series[index][property] = value
+    }
 
     // Reset bars to the left axis if changed.
     if (property === 'type') {
@@ -48,7 +71,7 @@ const SeriesWrapper = props => {
       forecastingStages.forEach(stage => {
         forecastingStageArr.push({ key: stage })
       })
-      // debugger
+
       series[index].stages = forecastingStageArr
       series[index].stageColumn = series[index].dataKey
     }
@@ -281,7 +304,8 @@ const SeriesDropdownConfidenceInterval = props => {
   const { config, updateConfig } = useContext(ConfigContext)
   const { series, index } = props
   const { getColumns } = useContext(SeriesContext)
-  if (series.type !== 'Forecasting') return
+
+  if (series.type !== 'Forecasting' && series.type !== 'Line') return
 
   return (
     <div className='edit-block'>
@@ -327,27 +351,29 @@ const SeriesDropdownConfidenceInterval = props => {
                   </>
                 </AccordionItemHeading>
                 <AccordionItemPanel>
-                  <div className='input-group'>
-                    <label htmlFor='showInTooltip'>Show In Tooltip</label>
-                    <div
-                      className={'cove-input__checkbox--small'}
-                      onClick={e => updateShowInTooltip(e, index, ciIndex)}
-                    >
+                  {series.type !== 'Line' && (
+                    <div className='input-group'>
+                      <label htmlFor='showInTooltip'>Show In Tooltip</label>
                       <div
-                        className={`cove-input__checkbox-box${'blue' ? ' custom-color' : ''}`}
-                        style={{ backgroundColor: '' }}
+                        className={'cove-input__checkbox--small'}
+                        onClick={e => updateShowInTooltip(e, index, ciIndex)}
                       >
-                        {showInTooltip && <Check className='' style={{ fill: '#025eaa' }} />}
+                        <div
+                          className={`cove-input__checkbox-box${'blue' ? ' custom-color' : ''}`}
+                          style={{ backgroundColor: '' }}
+                        >
+                          {showInTooltip && <Check className='' style={{ fill: '#025eaa' }} />}
+                        </div>
+                        <input
+                          className='cove-input--hidden'
+                          type='checkbox'
+                          name={'showInTooltip'}
+                          checked={showInTooltip ? showInTooltip : false}
+                          readOnly
+                        />
                       </div>
-                      <input
-                        className='cove-input--hidden'
-                        type='checkbox'
-                        name={'showInTooltip'}
-                        checked={showInTooltip ? showInTooltip : false}
-                        readOnly
-                      />
                     </div>
-                  </div>
+                  )}
 
                   <InputSelect
                     initial='Select an option'
@@ -395,7 +421,7 @@ const SeriesDropdownConfidenceInterval = props => {
           })}
         </Accordion>
         <button
-          className='btn btn-primary full-width'
+          className='btn btn-primary full-width mt-2 mb-4'
           onClick={e => {
             e.preventDefault()
             let copiedIndex = null


### PR DESCRIPTION
## [DEV-8940] add confidence intervals to line charts

- [ ] Run `yarn storybook`
- [ ] Navigate to `/story/components-templates-chart--line-chart-confidence-intervals`

CI's are added under the series level as a repeating field. This decision was made because not all CI's will be uniform. The repeater allows multiple confidence intervals to be added to the line if needed (ie. 25/50/95). We're re-using the pattern from Forecasting charts to keep the config lean `series.confidenceIntervals` since its the same feature.

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)
<img width="1245" alt="Screen Shot 2024-11-15 at 12 57 05 PM" src="https://github.com/user-attachments/assets/f0b79f7c-a35f-4a57-98a1-9193e985182d">



<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
