### PR TITLE
Fix position of Date (Linear Scale) bars

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
@@ -13,32 +13,62 @@ import createBarElement from '@cdc/core/components/createBarElement'
 const BarChartStackedVertical = () => {
   const [barWidth, setBarWidth] = useState(0)
   const { xScale, yScale, seriesScale, xMax, yMax } = useContext(BarChartContext)
-  const { transformedData, colorScale, seriesHighlight, config, formatNumber, formatDate, parseDate, setSharedFilter } = useContext(ConfigContext)
-  const { isHorizontal, barBorderWidth, applyRadius, hoveredBar, getAdditionalColumn, onMouseLeaveBar, onMouseOverBar, barStackedSeriesKeys } = useBarChart()
+  const { transformedData, colorScale, seriesHighlight, config, formatNumber, formatDate, parseDate, setSharedFilter } =
+    useContext(ConfigContext)
+  const {
+    isHorizontal,
+    barBorderWidth,
+    applyRadius,
+    hoveredBar,
+    getAdditionalColumn,
+    onMouseLeaveBar,
+    onMouseOverBar,
+    barStackedSeriesKeys
+  } = useBarChart()
   const { orientation } = config
 
   const data = config.brush?.active && config.brush.data?.length ? config.brush.data : transformedData
   const isDateAxisType = config.runtime.xAxis.type === 'date-time' || config.runtime.xAxis.type === 'date'
+  const isDateTimeScaleAxisType = config.runtime.xAxis.type === 'date-time'
 
   return (
     config.visualizationSubType === 'stacked' &&
     !isHorizontal && (
       <>
-        <BarStack data={data} keys={barStackedSeriesKeys} x={d => d[config.runtime.xAxis.dataKey]} xScale={xScale} yScale={yScale} color={colorScale}>
+        <BarStack
+          data={data}
+          keys={barStackedSeriesKeys}
+          x={d => d[config.runtime.xAxis.dataKey]}
+          xScale={xScale}
+          yScale={yScale}
+          color={colorScale}
+        >
           {barStacks =>
             barStacks.reverse().map(barStack =>
               barStack.bars.map(bar => {
-                let transparentBar = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(bar.key) === -1
-                let displayBar = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(bar.key) !== -1
-                let barThickness = isDateAxisType ? seriesScale.range()[1] - seriesScale.range()[0] : xMax / barStack.bars.length
+                let transparentBar =
+                  config.legend.behavior === 'highlight' &&
+                  seriesHighlight.length > 0 &&
+                  seriesHighlight.indexOf(bar.key) === -1
+                let displayBar =
+                  config.legend.behavior === 'highlight' ||
+                  seriesHighlight.length === 0 ||
+                  seriesHighlight.indexOf(bar.key) !== -1
+                let barThickness = isDateAxisType
+                  ? seriesScale.range()[1] - seriesScale.range()[0]
+                  : xMax / barStack.bars.length
                 if (config.runtime.xAxis.type !== 'date') barThickness = config.barThickness * barThickness
                 // tooltips
                 const rawXValue = bar.bar.data[config.runtime.xAxis.dataKey]
                 const xAxisValue = isDateAxisType ? formatDate(parseDate(rawXValue)) : rawXValue
                 const yAxisValue = formatNumber(bar.bar ? bar.bar.data[bar.key] : 0, 'left')
                 if (!yAxisValue) return
-                const barX = xScale(isDateAxisType ? parseDate(rawXValue) : rawXValue) - (isDateAxisType ? barThickness / 2 : 0)
-                const xAxisTooltip = config.runtime.xAxis.label ? `${config.runtime.xAxis.label}: ${xAxisValue}` : xAxisValue
+                const barX =
+                  xScale(isDateAxisType ? parseDate(rawXValue) : rawXValue) -
+                  (isDateTimeScaleAxisType ? barThickness / 2 : 0)
+                const xAxisTooltip = config.runtime.xAxis.label
+                  ? `${config.runtime.xAxis.label}: ${xAxisValue}`
+                  : xAxisValue
                 const additionalColTooltip = getAdditionalColumn(hoveredBar)
                 const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${yAxisValue}`
                 const tooltip = `<ul>
@@ -51,7 +81,11 @@ const BarChartStackedVertical = () => {
 
                 return (
                   <Group key={`${barStack.index}--${bar.index}--${orientation}`}>
-                    <Group key={`bar-stack-${barStack.index}-${bar.index}`} id={`barStack${barStack.index}-${bar.index}`} className='stack vertical'>
+                    <Group
+                      key={`bar-stack-${barStack.index}-${bar.index}`}
+                      id={`barStack${barStack.index}-${bar.index}`}
+                      className='stack vertical'
+                    >
                       {createBarElement({
                         config: config,
                         seriesHighlight,

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -35,7 +35,7 @@ import { calcInitialHeight } from '../helpers/sizeHelpers'
 import useMinMax from '../hooks/useMinMax'
 import useReduceData from '../hooks/useReduceData'
 import useRightAxis from '../hooks/useRightAxis'
-import useScales, { getTickValues } from '../hooks/useScales'
+import useScales, { getTickValues, filterAndShiftLinearDateTicks } from '../hooks/useScales'
 import useTopAxis from '../hooks/useTopAxis'
 import { useTooltip as useCoveTooltip } from '../hooks/useTooltip'
 import { useEditorPermissions } from './EditorPanel/useEditorPermissions'
@@ -1362,10 +1362,16 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       config.xAxis.type === 'date-time' ? countNumOfTicks('xAxis') : getManualStep(),
                       config
                     )
+                  : config.xAxis.type === 'date'
+                  ? xAxisDataMapped
                   : undefined
               }
             >
               {props => {
+                if (config.xAxis.type === 'date') {
+                  props.ticks = filterAndShiftLinearDateTicks(config, props, xAxisDataMapped)
+                }
+
                 const axisMaxHeight = bottomLabelStart + BOTTOM_LABEL_PADDING
 
                 const axisCenter =

--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -340,15 +340,16 @@ export const getTickValues = (xAxisDataMapped, xScale, num, config) => {
 export const filterAndShiftLinearDateTicks = (config, axisProps, xAxisDataMapped) => {
   const filteredTickValues = getTicks(axisProps.scale, axisProps.numTicks)
   if (filteredTickValues.length < xAxisDataMapped.length) {
+    let shift = 0
     const lastIdx = xAxisDataMapped.indexOf(filteredTickValues[filteredTickValues.length - 1])
     if (lastIdx < xAxisDataMapped.length - 1) {
-      const shift = !config.xAxis.sortByRecentDate
+      shift = !config.xAxis.sortByRecentDate
         ? xAxisDataMapped.length - 1 - lastIdx
         : xAxisDataMapped.indexOf(filteredTickValues[0]) * -1
-      return filteredTickValues.map(value => {
-        return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
-      })
     }
+    return filteredTickValues.map(value => {
+      return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
+    })
   }
   return axisProps.ticks
 }

--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -1,4 +1,13 @@
-import { LinearScaleConfig, LogScaleConfig, scaleBand, scaleLinear, scaleLog, scalePoint, scaleTime } from '@visx/scale'
+import {
+  LinearScaleConfig,
+  LogScaleConfig,
+  scaleBand,
+  scaleLinear,
+  scaleLog,
+  scalePoint,
+  scaleTime,
+  getTicks
+} from '@visx/scale'
 import { useContext } from 'react'
 import ConfigContext from '../ConfigContext'
 import { ChartConfig } from '../types/ChartConfig'
@@ -325,6 +334,23 @@ export const getTickValues = (xAxisDataMapped, xScale, num, config) => {
 
     return tickValues
   }
+}
+
+// Ensure that the last tick is shown for charts with a "Date (Linear Scale)" scale
+export const filterAndShiftLinearDateTicks = (config, axisProps, xAxisDataMapped) => {
+  const filteredTickValues = getTicks(axisProps.scale, axisProps.numTicks)
+  if (filteredTickValues.length < xAxisDataMapped.length) {
+    const lastIdx = xAxisDataMapped.indexOf(filteredTickValues[filteredTickValues.length - 1])
+    if (lastIdx < xAxisDataMapped.length - 1) {
+      const shift = !config.xAxis.sortByRecentDate
+        ? xAxisDataMapped.length - 1 - lastIdx
+        : xAxisDataMapped.indexOf(filteredTickValues[0]) * -1
+      return filteredTickValues.map(value => {
+        return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
+      })
+    }
+  }
+  return axisProps.ticks
 }
 
 /// helper functions


### PR DESCRIPTION
This has one bug fix and one small enhancement to bar charts that use a Date (Linear Scale) x-axis:

1) Shifts the bars for stacked bar charts to the right by half a bar so they're lined up correctly
2) Ensures that the last bar (the most recent one) is always labeled

## Testing Steps

Use the attached config, see that the position of bars is correct on this branch.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

dev/test:

![Screenshot 2024-11-18 at 10 16 23 AM](https://github.com/user-attachments/assets/099ac597-7a1d-4439-87f0-a03a5daab363)

This branch:

![Screenshot 2024-11-18 at 10 16 42 AM](https://github.com/user-attachments/assets/f537d50c-8d67-4f24-bc6c-679c1ee647a6)

[vaxbars.json](https://github.com/user-attachments/files/17802660/vaxbars.json)

