### PR TITLE
Fix position of stacked Date (Linear Scale) bars

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
@@ -13,32 +13,62 @@ import createBarElement from '@cdc/core/components/createBarElement'
 const BarChartStackedVertical = () => {
   const [barWidth, setBarWidth] = useState(0)
   const { xScale, yScale, seriesScale, xMax, yMax } = useContext(BarChartContext)
-  const { transformedData, colorScale, seriesHighlight, config, formatNumber, formatDate, parseDate, setSharedFilter } = useContext(ConfigContext)
-  const { isHorizontal, barBorderWidth, applyRadius, hoveredBar, getAdditionalColumn, onMouseLeaveBar, onMouseOverBar, barStackedSeriesKeys } = useBarChart()
+  const { transformedData, colorScale, seriesHighlight, config, formatNumber, formatDate, parseDate, setSharedFilter } =
+    useContext(ConfigContext)
+  const {
+    isHorizontal,
+    barBorderWidth,
+    applyRadius,
+    hoveredBar,
+    getAdditionalColumn,
+    onMouseLeaveBar,
+    onMouseOverBar,
+    barStackedSeriesKeys
+  } = useBarChart()
   const { orientation } = config
 
   const data = config.brush?.active && config.brush.data?.length ? config.brush.data : transformedData
   const isDateAxisType = config.runtime.xAxis.type === 'date-time' || config.runtime.xAxis.type === 'date'
+  const isDateTimeScaleAxisType = config.runtime.xAxis.type === 'date-time'
 
   return (
     config.visualizationSubType === 'stacked' &&
     !isHorizontal && (
       <>
-        <BarStack data={data} keys={barStackedSeriesKeys} x={d => d[config.runtime.xAxis.dataKey]} xScale={xScale} yScale={yScale} color={colorScale}>
+        <BarStack
+          data={data}
+          keys={barStackedSeriesKeys}
+          x={d => d[config.runtime.xAxis.dataKey]}
+          xScale={xScale}
+          yScale={yScale}
+          color={colorScale}
+        >
           {barStacks =>
             barStacks.reverse().map(barStack =>
               barStack.bars.map(bar => {
-                let transparentBar = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(bar.key) === -1
-                let displayBar = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(bar.key) !== -1
-                let barThickness = isDateAxisType ? seriesScale.range()[1] - seriesScale.range()[0] : xMax / barStack.bars.length
+                let transparentBar =
+                  config.legend.behavior === 'highlight' &&
+                  seriesHighlight.length > 0 &&
+                  seriesHighlight.indexOf(bar.key) === -1
+                let displayBar =
+                  config.legend.behavior === 'highlight' ||
+                  seriesHighlight.length === 0 ||
+                  seriesHighlight.indexOf(bar.key) !== -1
+                let barThickness = isDateAxisType
+                  ? seriesScale.range()[1] - seriesScale.range()[0]
+                  : xMax / barStack.bars.length
                 if (config.runtime.xAxis.type !== 'date') barThickness = config.barThickness * barThickness
                 // tooltips
                 const rawXValue = bar.bar.data[config.runtime.xAxis.dataKey]
                 const xAxisValue = isDateAxisType ? formatDate(parseDate(rawXValue)) : rawXValue
                 const yAxisValue = formatNumber(bar.bar ? bar.bar.data[bar.key] : 0, 'left')
                 if (!yAxisValue) return
-                const barX = xScale(isDateAxisType ? parseDate(rawXValue) : rawXValue) - (isDateAxisType ? barThickness / 2 : 0)
-                const xAxisTooltip = config.runtime.xAxis.label ? `${config.runtime.xAxis.label}: ${xAxisValue}` : xAxisValue
+                const barX =
+                  xScale(isDateAxisType ? parseDate(rawXValue) : rawXValue) -
+                  (isDateTimeScaleAxisType ? barThickness / 2 : 0)
+                const xAxisTooltip = config.runtime.xAxis.label
+                  ? `${config.runtime.xAxis.label}: ${xAxisValue}`
+                  : xAxisValue
                 const additionalColTooltip = getAdditionalColumn(hoveredBar)
                 const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${yAxisValue}`
                 const tooltip = `<ul>
@@ -51,7 +81,11 @@ const BarChartStackedVertical = () => {
 
                 return (
                   <Group key={`${barStack.index}--${bar.index}--${orientation}`}>
-                    <Group key={`bar-stack-${barStack.index}-${bar.index}`} id={`barStack${barStack.index}-${bar.index}`} className='stack vertical'>
+                    <Group
+                      key={`bar-stack-${barStack.index}-${bar.index}`}
+                      id={`barStack${barStack.index}-${bar.index}`}
+                      className='stack vertical'
+                    >
                       {createBarElement({
                         config: config,
                         seriesHighlight,


### PR DESCRIPTION
## Fix stacked bar positions

Stacked bar charts that use a Date (Linear Scale) x-axis are currently positioned too far to the left by half a bar. This PR shifts the bars to the right by half a bar so they're lined up correctly

## Testing Steps

Use the attached config, see that the position of bars is correct on this branch.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

dev/test:

![Screenshot 2024-11-18 at 10 42 33 AM](https://github.com/user-attachments/assets/9676df3e-3c49-4a8d-be70-062dcd97b7e7)

this branch:

![Screenshot 2024-11-18 at 10 43 08 AM](https://github.com/user-attachments/assets/fcf8253f-1daf-417d-bd7c-622e23f505fd)

[vaxbars.json](https://github.com/user-attachments/files/17802911/vaxbars.json)

