### PR TITLE
[DEV-9858] Make filter intro text customizable

### DIFF
--- a/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
@@ -130,6 +130,12 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
               </Tooltip>
             }
           />
+          <TextField
+            label='Filter intro text'
+            value={config.filterIntro}
+            updateField={updateField}
+            fieldName='filterIntro'
+          />
           <br />
           <ul className='filters-list'>
             {/* Whether filters should apply onChange or Apply Button */}

--- a/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
@@ -131,6 +131,7 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
             }
           />
           <TextField
+            type='textarea'
             label='Filter intro text'
             value={config.filterIntro}
             updateField={updateField}

--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -446,7 +446,7 @@ const Filters = (props: FilterProps) => {
         <div className={classList.join(' ')} key={outerIndex}>
           <>
             {label && (
-              <label className='text-capitalize font-weight-bold mt-1 mb-0' htmlFor={`filter-${outerIndex}`}>
+              <label className='font-weight-bold mt-1 mb-0' htmlFor={`filter-${outerIndex}`}>
                 {label}
               </label>
             )}

--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -249,9 +249,7 @@ export const useFilters = props => {
 
   const filterConstants = {
     buttonText: 'Apply Filters',
-    resetText: 'Reset All',
-    introText: `Make a selection from the filters to change the visualization information.`,
-    applyText: 'Select the apply button to update the visualization information.'
+    resetText: 'Reset All'
   }
 
   // prettier-ignore
@@ -502,10 +500,9 @@ const Filters = (props: FilterProps) => {
 
   return (
     <section className={getClasses().join(' ')}>
-      <p className='filters-section__intro-text'>
-        {filters?.some(filter => filter.showDropdown) ? filterConstants.introText : ''}{' '}
-        {visualizationConfig.filterBehavior === 'Apply Button' && filterConstants.applyText}
-      </p>
+      {visualizationConfig.filterIntro && (
+        <p className='filters-section__intro-text'>{visualizationConfig.filterIntro}</p>
+      )}
       <div className='d-flex flex-wrap w-100 filters-section__wrapper'>
         {' '}
         <>

--- a/packages/core/components/MultiSelect/MultiSelect.tsx
+++ b/packages/core/components/MultiSelect/MultiSelect.tsx
@@ -82,7 +82,7 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
   return (
     <>
       {label && (
-        <label className='text-capitalize font-weight-bold' id={multiID + label} htmlFor={multiID}>
+        <label className='font-weight-bold' id={multiID + label} htmlFor={multiID}>
           {label}
         </label>
       )}

--- a/packages/core/components/NestedDropdown/NestedDropdown.tsx
+++ b/packages/core/components/NestedDropdown/NestedDropdown.tsx
@@ -246,7 +246,7 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
   return (
     <>
       {listLabel && (
-        <label className='text-capitalize font-weight-bold' htmlFor={dropdownId}>
+        <label className='font-weight-bold' htmlFor={dropdownId}>
           {listLabel}
         </label>
       )}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -125,7 +125,7 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
           </div>
         ) : (
           <div className={formGroupClass} key={`${filter.key}-filtersection-${filterIndex}`}>
-            <label className='text-capitalize font-weight-bold' htmlFor={`filter-${filterIndex}`}>
+            <label className='font-weight-bold' htmlFor={`filter-${filterIndex}`}>
               {filter.key}
             </label>
             <select

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -1096,6 +1096,7 @@ const EditorPanel = ({ columnsRequiredChecker }) => {
         </label>
         <label>
           <TextField
+            type='textarea'
             value={state.filterIntro}
             fieldName='filterIntro'
             label='Filter Intro text'

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -1094,6 +1094,14 @@ const EditorPanel = ({ columnsRequiredChecker }) => {
             </option>
           </select>
         </label>
+        <label>
+          <TextField
+            value={state.filterIntro}
+            fieldName='filterIntro'
+            label='Filter Intro text'
+            updateField={updateField}
+          />
+        </label>
         {filtersJSX}
       </>
     )
@@ -1262,6 +1270,14 @@ const EditorPanel = ({ columnsRequiredChecker }) => {
   })
 
   const updateField = (section, subsection, fieldName, newValue) => {
+    if (!section) {
+      setState({
+        ...state,
+        [fieldName]: newValue
+      })
+      return
+    }
+
     const isArray = Array.isArray(state[section])
 
     let sectionValue = isArray ? [...state[section], newValue] : { ...state[section], [fieldName]: newValue }

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -126,5 +126,6 @@ export default {
       }
     ]
   },
-  filterBehavior: 'Filter Change'
+  filterBehavior: 'Filter Change',
+  filterIntro: ''
 }

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -164,6 +164,7 @@ export type MapConfig = Visualization & {
   }
   hexMap: HexMapSettings
   filterBehavior: string
+  filterIntro: string
   visual: MapVisualSettings
   // version of the map
   version: Version


### PR DESCRIPTION
## [DEV-9858]

Adds an editor field to customize the filter intro text, and removes forced capitalization from filter labels.
 
## Testing Steps

* Create a chart with a filter, change the text in the "filter intro text" field, see the intro text change.
* Change the filter label, note that it doesn't have forced capitalization
* Compare to the dev branch, where the filter intro text is hardcoded and can not be hidden, and filter labels are always capitalized.

Try a few setups (single chart, map, dashboard).

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

![Screenshot 2024-11-18 at 4 04 13 PM](https://github.com/user-attachments/assets/95a55d9b-e206-40d6-86fb-bb10d86fd898)


## Additional Notes

<!-- Add any additional notes about this PR -->
