### PR TITLE
[DEV-9857] Label last tick

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -35,7 +35,7 @@ import { calcInitialHeight } from '../helpers/sizeHelpers'
 import useMinMax from '../hooks/useMinMax'
 import useReduceData from '../hooks/useReduceData'
 import useRightAxis from '../hooks/useRightAxis'
-import useScales, { getTickValues } from '../hooks/useScales'
+import useScales, { getTickValues, filterAndShiftLinearDateTicks } from '../hooks/useScales'
 import useTopAxis from '../hooks/useTopAxis'
 import { useTooltip as useCoveTooltip } from '../hooks/useTooltip'
 import { useEditorPermissions } from './EditorPanel/useEditorPermissions'
@@ -1364,10 +1364,16 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       config.xAxis.type === 'date-time' ? countNumOfTicks('xAxis') : getManualStep(),
                       config
                     )
+                  : config.xAxis.type === 'date'
+                  ? xAxisDataMapped
                   : undefined
               }
             >
               {props => {
+                if (config.xAxis.type === 'date') {
+                  props.ticks = filterAndShiftLinearDateTicks(config, props, xAxisDataMapped)
+                }
+
                 const axisMaxHeight = bottomLabelStart + BOTTOM_LABEL_PADDING
 
                 const axisCenter =

--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -340,15 +340,16 @@ export const getTickValues = (xAxisDataMapped, xScale, num, config) => {
 export const filterAndShiftLinearDateTicks = (config, axisProps, xAxisDataMapped) => {
   const filteredTickValues = getTicks(axisProps.scale, axisProps.numTicks)
   if (filteredTickValues.length < xAxisDataMapped.length) {
+    let shift = 0
     const lastIdx = xAxisDataMapped.indexOf(filteredTickValues[filteredTickValues.length - 1])
     if (lastIdx < xAxisDataMapped.length - 1) {
-      const shift = !config.xAxis.sortByRecentDate
+      shift = !config.xAxis.sortByRecentDate
         ? xAxisDataMapped.length - 1 - lastIdx
         : xAxisDataMapped.indexOf(filteredTickValues[0]) * -1
-      return filteredTickValues.map(value => {
-        return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
-      })
     }
+    return filteredTickValues.map(value => {
+      return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
+    })
   }
   return axisProps.ticks
 }

--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -1,4 +1,13 @@
-import { LinearScaleConfig, LogScaleConfig, scaleBand, scaleLinear, scaleLog, scalePoint, scaleTime } from '@visx/scale'
+import {
+  LinearScaleConfig,
+  LogScaleConfig,
+  scaleBand,
+  scaleLinear,
+  scaleLog,
+  scalePoint,
+  scaleTime,
+  getTicks
+} from '@visx/scale'
 import { useContext } from 'react'
 import ConfigContext from '../ConfigContext'
 import { ChartConfig } from '../types/ChartConfig'
@@ -325,6 +334,23 @@ export const getTickValues = (xAxisDataMapped, xScale, num, config) => {
 
     return tickValues
   }
+}
+
+// Ensure that the last tick is shown for charts with a "Date (Linear Scale)" scale
+export const filterAndShiftLinearDateTicks = (config, axisProps, xAxisDataMapped) => {
+  const filteredTickValues = getTicks(axisProps.scale, axisProps.numTicks)
+  if (filteredTickValues.length < xAxisDataMapped.length) {
+    const lastIdx = xAxisDataMapped.indexOf(filteredTickValues[filteredTickValues.length - 1])
+    if (lastIdx < xAxisDataMapped.length - 1) {
+      const shift = !config.xAxis.sortByRecentDate
+        ? xAxisDataMapped.length - 1 - lastIdx
+        : xAxisDataMapped.indexOf(filteredTickValues[0]) * -1
+      return filteredTickValues.map(value => {
+        return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
+      })
+    }
+  }
+  return axisProps.ticks
 }
 
 /// helper functions


### PR DESCRIPTION
## [DEV-9857]

Label latest tick for date (linear scale) bar charts

## Testing Steps

Using the config attached to the ticket or another bar chart with a "Date (Linear Scale") x-axis, verify that the last tick is always labeled on all screen sizes.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

Before:
![Screenshot 2024-11-18 at 4 10 02 PM](https://github.com/user-attachments/assets/40554f07-a146-4138-b375-d9ad563f0491)

After:
![Screenshot 2024-11-18 at 4 10 12 PM](https://github.com/user-attachments/assets/968796e8-cf31-46c8-acc0-e6ec5c0b0000)


## Additional Notes

<!-- Add any additional notes about this PR -->
