### PR TITLE
Enhancement: Dev-9453 World Map No Data Scenario

### DIFF
--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -810,6 +810,20 @@ const CdcMap = ({
 
     legendMemo.current = newLegendMemo
 
+    if (state.general.geoType === 'world') {
+      const runtimeDataKeys = Object.keys(runtimeData)
+      const isCountriesWithNoDataState =
+        obj.data === undefined ? false : !countryKeys.every(countryKey => runtimeDataKeys.includes(countryKey))
+
+      if (result.length > 0 && isCountriesWithNoDataState) {
+        result.push({
+          min: null,
+          max: null,
+          color: '#E6E6E6'
+        })
+      }
+    }
+
     //----------
     // DEV-784
     // before returning the legend result

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -17,7 +17,6 @@ import ResizeObserver from 'resize-observer-polyfill'
 
 // Third party
 import { Tooltip as ReactTooltip } from 'react-tooltip'
-import chroma from 'chroma-js'
 import Papa from 'papaparse'
 import parse from 'html-react-parser'
 import 'react-tooltip/dist/react-tooltip.css'
@@ -78,7 +77,7 @@ import WorldMap from './components/WorldMap' // Future: Lazy
 import useTooltip from './hooks/useTooltip'
 import { isSolrCsv, isSolrJson } from '@cdc/core/helpers/isSolr'
 import SkipTo from '@cdc/core/components/elements/SkipTo'
-import { isOlderVersion } from '@cdc/core/helpers/ver/versionNeedsUpdate'
+import { getGeoFillColor } from './helpers/colors'
 
 // Data props
 const stateKeys = Object.keys(supportedStates)
@@ -819,7 +818,7 @@ const CdcMap = ({
         result.push({
           min: null,
           max: null,
-          color: '#E6E6E6'
+          color: getGeoFillColor(state)
         })
       }
     }

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -93,6 +93,10 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
         formattedText = '0'
       }
 
+      if (entry.max === null && entry.min === null) {
+        formattedText = 'No data'
+      }
+
       let legendLabel = formattedText
 
       if (entry.hasOwnProperty('special')) {

--- a/packages/map/src/components/WorldMap/WorldMap.tsx
+++ b/packages/map/src/components/WorldMap/WorldMap.tsx
@@ -104,13 +104,8 @@ const WorldMap = () => {
         legendColors = applyLegendToRow(geoData)
       }
 
-<<<<<<< HEAD
       const geoStrokeColor = getGeoStrokeColor(state)
       const geoFillColor = getGeoFillColor(state)
-=======
-      const geoStrokeColor =
-        state.general.geoBorderColor === 'darkGray' ? 'rgba(0, 0, 0, 0.2)' : 'rgba(255,255,255,0.7)'
->>>>>>> 20a2d8030 (Enhancement: Dev-9453 World Map No Data Scenario)
 
       let styles: Record<string, string | Record<string, string>> = {
         fill: geoFillColor,
@@ -170,12 +165,10 @@ const WorldMap = () => {
           stroke={geoStrokeColor}
           strokeWidth={strokeWidth}
           style={styles}
+          styles={styles}
           path={path}
-<<<<<<< HEAD
-=======
           data-tooltip-id={`tooltip__${tooltipId}`}
           data-tooltip-html={toolTip}
->>>>>>> 20a2d8030 (Enhancement: Dev-9453 World Map No Data Scenario)
         />
       )
     })

--- a/packages/map/src/components/WorldMap/WorldMap.tsx
+++ b/packages/map/src/components/WorldMap/WorldMap.tsx
@@ -104,8 +104,13 @@ const WorldMap = () => {
         legendColors = applyLegendToRow(geoData)
       }
 
+<<<<<<< HEAD
       const geoStrokeColor = getGeoStrokeColor(state)
       const geoFillColor = getGeoFillColor(state)
+=======
+      const geoStrokeColor =
+        state.general.geoBorderColor === 'darkGray' ? 'rgba(0, 0, 0, 0.2)' : 'rgba(255,255,255,0.7)'
+>>>>>>> 20a2d8030 (Enhancement: Dev-9453 World Map No Data Scenario)
 
       let styles: Record<string, string | Record<string, string>> = {
         fill: geoFillColor,
@@ -115,9 +120,8 @@ const WorldMap = () => {
       const strokeWidth = 0.9
 
       // If a legend applies, return it with appropriate information.
+      const toolTip = applyTooltipsToGeo(geoDisplayName, geoData)
       if (legendColors && legendColors[0] !== '#000000' && state.general.type !== 'bubble') {
-        const toolTip = applyTooltipsToGeo(geoDisplayName, geoData)
-
         styles = {
           ...styles,
           fill: state.general.type !== 'world-geocode' ? legendColors[0] : geoFillColor,
@@ -167,6 +171,11 @@ const WorldMap = () => {
           strokeWidth={strokeWidth}
           style={styles}
           path={path}
+<<<<<<< HEAD
+=======
+          data-tooltip-id={`tooltip__${tooltipId}`}
+          data-tooltip-html={toolTip}
+>>>>>>> 20a2d8030 (Enhancement: Dev-9453 World Map No Data Scenario)
         />
       )
     })

--- a/packages/map/src/hooks/useTooltip.ts
+++ b/packages/map/src/hooks/useTooltip.ts
@@ -14,7 +14,9 @@ const useTooltip = props => {
     if (geoType === 'us-county' && type !== 'us-geocode') {
       let stateFipsCode = row[config.columns.geo.name].substring(0, 2)
       const stateName = supportedStatesFipsCodes[stateFipsCode]
-      toolTipText += hideGeoColumnInTooltip ? `<strong>${stateName}</strong><br/>` : `<strong>Location:  ${stateName}</strong><br/>`
+      toolTipText += hideGeoColumnInTooltip
+        ? `<strong>${stateName}</strong><br/>`
+        : `<strong>Location:  ${stateName}</strong><br/>`
     }
     return toolTipText
   }
@@ -73,7 +75,8 @@ const useTooltip = props => {
   const handleTooltipPrimaryColumn = (tooltipValue, column) => {
     const { hidePrimaryColumnInTooltip } = config.general as { hidePrimaryColumnInTooltip: boolean }
     let tooltipPrefix = column.label?.length > 0 ? column.label : ''
-    if ((column.name === config.columns.primary.name && hidePrimaryColumnInTooltip) || !tooltipPrefix) return `<li class="tooltip-body">${tooltipValue}</li>`
+    if ((column.name === config.columns.primary.name && hidePrimaryColumnInTooltip) || !tooltipPrefix)
+      return `<li class="tooltip-body">${tooltipValue}</li>`
     return `<li class="tooltip-body">${tooltipPrefix}: ${tooltipValue}</li>`
   }
 
@@ -91,7 +94,7 @@ const useTooltip = props => {
       legend: { specialClasses }
     } = config
 
-    if (tooltipEnabledMaps.includes(currentMapType) && undefined !== row) {
+    if (tooltipEnabledMaps.includes(currentMapType) && (row !== undefined || config.general.geoType === 'world')) {
       toolTipText += `<ul>`
 
       // if tooltips are allowed, loop through each column
@@ -102,7 +105,7 @@ const useTooltip = props => {
           let tooltipValue = handleTooltipSpecialClassText(specialClasses, column, row, '', columnKey)
 
           if (!tooltipValue) {
-            tooltipValue = displayDataAsText(row[column.name], columnKey)
+            tooltipValue = row ? displayDataAsText(row[column.name], columnKey) : 'No Data'
           }
 
           toolTipText += handleTooltipPrimaryColumn(tooltipValue, column)
@@ -115,7 +118,7 @@ const useTooltip = props => {
   }
 
   const buildTooltip = (row, geoName, toolTipText = '') => {
-    if (!row) return
+    if (!row && config.general.geoType !== 'world') return
 
     // Handle County Location Columns
     toolTipText += handleTooltipStateNameColumn(toolTipText, row)


### PR DESCRIPTION
## Enhancement: Dev-9453 World Map No Data Scenario
https://websupport.cdc.gov/browse/DEV-9453

When there is no data to show in the map, a "No Data" message is added to the legend and a tooltip is created with no data on hover.

## Testing Steps

Scenario: Upload [dev-9453-config.json](https://github.com/user-attachments/files/17816638/dev-9453-config.json) and navigate to the dashboard preview.

Expected: There is a world map with some countries highlighted according to the Legend and the Legend has a category call "No Data"

Hover over a country that is gray.
Expected: A tooltip appears with the country name and "No Data" at the bottom of the tooltip.

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
