### PR TITLE
Fix: Dev-9864 Duplicate Dropdown label in Dashboard

### DIFF
--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -470,7 +470,6 @@ const Filters = (props: FilterProps) => {
                 activeSubGroup={(singleFilter.subGrouping?.active as string) || (singleFilter.queuedActive || [])[1]}
                 filterIndex={outerIndex}
                 options={getNestedOptions(singleFilter)}
-                listLabel={label}
                 handleSelectedItems={value => changeFilterActive(outerIndex, value)}
               />
             )}

--- a/packages/core/components/NestedDropdown/NestedDropdown.tsx
+++ b/packages/core/components/NestedDropdown/NestedDropdown.tsx
@@ -107,7 +107,8 @@ type NestedDropdownProps = {
   activeGroup: string
   activeSubGroup?: string
   filterIndex: number
-  listLabel: string
+  isEditor?: boolean
+  isUrlFilter?: boolean
   handleSelectedItems: ([group, subgroup]: [string, string]) => void
   options: NestedOptions
   loading?: boolean
@@ -118,7 +119,6 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
   activeGroup,
   activeSubGroup,
   filterIndex,
-  listLabel,
   handleSelectedItems,
   loading
 }) => {
@@ -245,11 +245,6 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
 
   return (
     <>
-      {listLabel && (
-        <label className='text-capitalize font-weight-bold' htmlFor={dropdownId}>
-          {listLabel}
-        </label>
-      )}
       <div
         id={dropdownId}
         className={`nested-dropdown nested-dropdown-${filterIndex} ${isListOpened ? 'open-filter' : ''}`}
@@ -286,7 +281,7 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
         {loading && <Loader spinnerType={'text-secondary'} />}
         <ul
           role='tree'
-          key={listLabel}
+          key={`Nested-Dropdown-${filterIndex}`}
           tabIndex={-1}
           aria-labelledby='main-nested-dropdown'
           aria-expanded={isListOpened}


### PR DESCRIPTION
## Fix: Dev-9864
https://websupport.cdc.gov/browse/DEV-9864

On Nested Dropdowns the label does not repeat.

## Testing Steps

Scenario: Upload [dev-9864-config.json](https://github.com/user-attachments/files/17821457/dev-9864-config.json) and navigate to the dashboard preview.

Expected: There are 3 filters on top, a markup include, and then 2 filters in the Trends over Time section. The Demographic filter's title is only shown once.

## Self Review

- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
