### PR TITLE
Fix: Gradient legend shouldn't be selectable

### DIFF
--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -46,6 +46,7 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
   } = useContext(ConfigContext)
 
   const { legend } = state
+  const isLegendGradient = legend.style === 'gradient'
 
   // Toggles if a legend is active and being applied to the map and data table.
   const toggleLegendActive = (i, legendLabel) => {
@@ -207,7 +208,7 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
 
     return legendItems
   }
-  const legendListItems = legendList(state.legend.style === 'gradient')
+  const legendListItems = legendList(isLegendGradient)
 
   const { legendClasses } = useDataVizClasses(state, viewport)
 
@@ -250,7 +251,7 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
           className={legendClasses.aside.join(' ') || ''}
           role='region'
           aria-label='Legend'
-          tabIndex={0}
+          tabIndex={isLegendGradient ? -1 : 0}
           ref={ref}
         >
           <section className={legendClasses.section.join(' ') || ''} aria-label='Map Legend'>


### PR DESCRIPTION
## No Ticket

Gradient legend shouldn't be tabbable since nothing is selectable

## Testing Steps

1. Create or view map or chart with gradient legend
2. Try selecting via click or tab
3. Observe that is doesn't get selected

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
