### PR TITLE
Fix: Dev-9864 Duplicate Dropdown label in Dashboard

### DIFF
--- a/packages/core/components/MultiSelect/MultiSelect.tsx
+++ b/packages/core/components/MultiSelect/MultiSelect.tsx
@@ -80,93 +80,86 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
 
   const multiID = 'multiSelect_' + label
   return (
-    <>
-      {label && (
-        <label className='font-weight-bold' id={multiID + label} htmlFor={multiID}>
-          {label}
-        </label>
-      )}
-      <div ref={multiSelectRef} className='cove-multiselect'>
-        {tooltip && tooltip}
+    <div ref={multiSelectRef} className='cove-multiselect'>
+      {tooltip && tooltip}
 
-        <div className='wrapper'>
-          <div
-            id={multiID}
-            onClick={() => {
-              if (!selectedItems.length && !loading) {
-                setExpanded(true)
-              }
+      <div className='wrapper'>
+        <div
+          id={multiID}
+          onClick={() => {
+            if (!selectedItems.length && !loading) {
+              setExpanded(true)
+            }
+          }}
+          className='selected'
+          aria-disabled={loading}
+        >
+          {selectedItems.length ? (
+            selectedItems.map(item => (
+              <div key={item.value} aria-labelledby={label ? multiID + label : undefined}>
+                {item.label}
+                <button
+                  aria-label='Remove'
+                  onClick={e => {
+                    e.preventDefault()
+                    handleItemRemove(item)
+                  }}
+                  onKeyUp={e => {
+                    handleItemRemove(item, e)
+                  }}
+                >
+                  x
+                </button>
+              </div>
+            ))
+          ) : (
+            <span className='pl-1 pt-1'>{loading ? 'Loading...' : '- Select -'}</span>
+          )}
+          <button
+            aria-label={expanded ? 'Collapse' : 'Expand'}
+            aria-labelledby={label ? multiID : undefined}
+            className='expand'
+            onClick={e => {
+              e.preventDefault()
+              setExpanded(!expanded)
             }}
-            className='selected'
-            aria-disabled={loading || !options.length}
           >
-            {selectedItems.length ? (
-              selectedItems.map(item => (
-                <div key={item.value} aria-labelledby={label ? multiID + label : undefined}>
-                  {item.label}
-                  <button
-                    aria-label='Remove'
-                    onClick={e => {
-                      e.preventDefault()
-                      handleItemRemove(item)
-                    }}
-                    onKeyUp={e => {
-                      handleItemRemove(item, e)
-                    }}
-                  >
-                    x
-                  </button>
-                </div>
-              ))
-            ) : (
-              <span className='pl-1 pt-1'>{loading ? 'Loading...' : '- Select -'}</span>
-            )}
-            <button
-              aria-label={expanded ? 'Collapse' : 'Expand'}
-              aria-labelledby={label ? multiID : undefined}
-              className='expand'
+            <Icon display={'caretDown'} style={{ cursor: 'pointer' }} />
+          </button>
+        </div>
+        {loading && <Loader spinnerType={'text-secondary'} />}
+        {!!limit && (
+          <Tooltip style={{ textTransform: 'none' }}>
+            <Tooltip.Target>
+              <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+            </Tooltip.Target>
+            <Tooltip.Content>
+              <p>Select up to {limit} items</p>
+            </Tooltip.Content>
+          </Tooltip>
+        )}
+      </div>
+
+      <ul className={'dropdown' + (expanded ? '' : ' d-none')}>
+        {options
+          .filter(option => !selectedItems.find(item => item.value === option.value))
+          .map(option => (
+            <li
+              className='cove-multiselect-li'
+              key={option.value}
+              role='option'
+              tabIndex={0}
               onClick={e => {
                 e.preventDefault()
-                setExpanded(!expanded)
+                handleItemSelect(option, e)
               }}
+              onKeyUp={e => handleItemSelect(option, e)}
             >
-              <Icon display={'caretDown'} style={{ cursor: 'pointer' }} />
-            </button>
-          </div>
-          {loading && <Loader spinnerType={'text-secondary'} />}
-          {!!limit && (
-            <Tooltip style={{ textTransform: 'none' }}>
-              <Tooltip.Target>
-                <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-              </Tooltip.Target>
-              <Tooltip.Content>
-                <p>Select up to {limit} items</p>
-              </Tooltip.Content>
-            </Tooltip>
-          )}
-        </div>
-
-        <ul className={'dropdown' + (expanded ? '' : ' d-none')}>
-          {options
-            .filter(option => !selectedItems.find(item => item.value === option.value))
-            .map(option => (
-              <li
-                className='cove-multiselect-li'
-                key={option.value}
-                role='option'
-                tabIndex={0}
-                onClick={e => {
-                  e.preventDefault()
-                  handleItemSelect(option, e)
-                }}
-                onKeyUp={e => handleItemSelect(option, e)}
-              >
-                {option.label}
-              </li>
-            ))}
-        </ul>
-      </div>
-    </>
+              {option.label}
+            </li>
+          ))}
+      </ul>
+    </div>
   )
 }
 

--- a/packages/core/components/NestedDropdown/NestedDropdown.tsx
+++ b/packages/core/components/NestedDropdown/NestedDropdown.tsx
@@ -245,11 +245,6 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
 
   return (
     <>
-      {listLabel && (
-        <label className='font-weight-bold' htmlFor={dropdownId}>
-          {listLabel}
-        </label>
-      )}
       <div
         id={dropdownId}
         className={`nested-dropdown nested-dropdown-${filterIndex} ${isListOpened ? 'open-filter' : ''}`}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -49,11 +49,13 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
     <form className='d-flex flex-wrap'>
       {sharedFilters.map((filter, filterIndex) => {
         const urlFilterType = filter.type === 'urlfilter'
+        const label = filter.key
+
         if (
           (!urlFilterType && !filter.showDropdown && filter.filterStyle !== FILTER_STYLE.nestedDropdown) ||
           (show && !show.includes(filterIndex))
         )
-          return <React.Fragment key={`${filter.key}-filtersection-${filterIndex}-option`} />
+          return <React.Fragment key={`${label}-filtersection-${filterIndex}-option`} />
         const values: JSX.Element[] = []
 
         const _key = filter.apiFilter?.apiEndpoint
@@ -75,17 +77,15 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
           }
         } else {
           // Data Filter
-          filter?.values
-            .filter(value => value !== filter.resetLabel)
-            ?.forEach((filterOption, index) => {
-              const labeledOpt = filter.labels && filter.labels[filterOption]
-              values.push(
-                <option key={`${filter.key}-option-${index}`} value={filterOption}>
-                  {labeledOpt || filterOption}
-                </option>
-              )
-              multiValues.push({ value: filterOption, label: labeledOpt || filterOption })
-            })
+          filter.values?.forEach((filterOption, index) => {
+            const labeledOpt = filter.labels && filter.labels[filterOption]
+            values.push(
+              <option key={`${label}-option-${index}`} value={filterOption}>
+                {labeledOpt || filterOption}
+              </option>
+            )
+            multiValues.push({ value: filterOption, label: labeledOpt || filterOption })
+          })
         }
 
         const isDisabled = !values.length
@@ -99,55 +99,60 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
         }
 
         const formGroupClass = `form-group mr-3 mb-1${loading ? ' loading-filter' : ''}`
-        return filter.filterStyle === FILTER_STYLE.multiSelect ? (
-          <div className={formGroupClass} key={`${filter.key}-filtersection-${filterIndex}`}>
-            <MultiSelect
-              label={filter.key}
-              options={multiValues}
-              fieldName={filterIndex}
-              updateField={updateField}
-              selected={filter.active as string[]}
-              limit={filter.selectLimit || 5}
-              loading={loading}
-            />
-          </div>
-        ) : filter.filterStyle === FILTER_STYLE.nestedDropdown ? (
-          <div className={formGroupClass} key={`${filter.key}-filtersection-${filterIndex}`}>
-            <NestedDropdown
-              activeGroup={filter.active as string}
-              activeSubGroup={filter.subGrouping?.active}
-              filterIndex={filterIndex}
-              options={getNestedDropdownOptions(apiFilterDropdowns[_key])}
-              listLabel={filter.key}
-              handleSelectedItems={value => updateField(null, null, filterIndex, value)}
-              loading={loading}
-            />
-          </div>
-        ) : (
-          <div className={formGroupClass} key={`${filter.key}-filtersection-${filterIndex}`}>
-            <label className='font-weight-bold' htmlFor={`filter-${filterIndex}`}>
-              {filter.key}
-            </label>
-            <select
-              id={`filter-${filterIndex}`}
-              className='cove-form-select'
-              data-index='0'
-              value={loading ? 'Loading...' : filter.queuedActive || filter.active}
-              onChange={val => {
-                handleOnChange(filterIndex, val.target.value)
-              }}
-              disabled={loading || isDisabled}
-            >
-              {loading && <option value='Loading...'>Loading...</option>}
-              {nullVal(filter) && (
-                <option key={`select`} value=''>
-                  {filter.resetLabel || '- Select -'}
-                </option>
+
+        return (
+          <>
+            <div className={formGroupClass} key={`${label}-filtersection-${filterIndex}`}>
+              {label && (
+                <label className='text-capitalize font-weight-bold mt-1 mb-0' htmlFor={`filter-${filterIndex}`}>
+                  {label}
+                </label>
               )}
-              {values}
-            </select>
-            {loading && <Loader spinnerType={'text-secondary'} />}
-          </div>
+              {filter.filterStyle === FILTER_STYLE.multiSelect ? (
+                <MultiSelect
+                  label={label}
+                  options={multiValues}
+                  fieldName={filterIndex}
+                  updateField={updateField}
+                  selected={filter.active as string[]}
+                  limit={filter.selectLimit || 5}
+                  loading={loading}
+                />
+              ) : filter.filterStyle === FILTER_STYLE.nestedDropdown ? (
+                <NestedDropdown
+                  activeGroup={filter.active as string}
+                  activeSubGroup={filter.subGrouping?.active}
+                  filterIndex={filterIndex}
+                  options={getNestedDropdownOptions(apiFilterDropdowns[_key])}
+                  listLabel={label}
+                  handleSelectedItems={value => updateField(null, null, filterIndex, value)}
+                  loading={loading}
+                />
+              ) : (
+                <>
+                  <select
+                    id={`filter-${filterIndex}`}
+                    className='cove-form-select'
+                    data-index='0'
+                    value={loading ? 'Loading...' : filter.queuedActive || filter.active}
+                    onChange={val => {
+                      handleOnChange(filterIndex, val.target.value)
+                    }}
+                    disabled={loading ? true : values.length === 1 && !nullVal(filter)}
+                  >
+                    {loading && <option value='Loading...'>Loading...</option>}
+                    {nullVal(filter) && (
+                      <option key={`select`} value=''>
+                        {filter.resetLabel || '- Select -'}
+                      </option>
+                    )}
+                    {values}
+                  </select>
+                  {loading && <Loader spinnerType={'text-secondary'} />}
+                </>
+              )}
+            </div>
+          </>
         )
       })}
       {showSubmit && (


### PR DESCRIPTION
## Fix: Dev-9864
https://websupport.cdc.gov/browse/DEV-9864

Removed the duplicate filter labels from Nested Dropdowns and Multi-Selects

## Testing Steps 

2 Scenarios

Scenario 1: Upload [dev-9864-Dashboard-Filters.json](https://github.com/user-attachments/files/17837859/dev-9864-Dashboard-Filters.json) and navigate to the Dashboard Preview

Expected: There are 3 Dashboard filters labeled with their style name and there is only one label for each

Scenario 2: Upload [dev-9864-Visualization-Filters.json](https://github.com/user-attachments/files/17837900/dev-9864-Visualization-Filters.json) and navigate to the Dashboard Preview

Expected: There are 3 Visualization filters labeled with their style name and there is only one label for each

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
