### PR TITLE
[DEV-9859] Improve mobile data table font sizes

### DIFF
--- a/packages/core/components/DataTable/components/ExpandCollapse.tsx
+++ b/packages/core/components/DataTable/components/ExpandCollapse.tsx
@@ -2,7 +2,7 @@ import Icon from '../../ui/Icon'
 import { fontSizes } from '../../../helpers/cove/fontSettings'
 
 const ExpandCollapse = ({ expanded, setExpanded, tableTitle, fontSize, viewport }) => {
-  const titleFontSize = ['sm', 'xs', 'xxs'].includes(viewport) ? '13px' : `${fontSizes[fontSize]}px`
+  const titleFontSize = ['xs', 'xxs'].includes(viewport) ? '13px' : `${fontSizes[fontSize]}px`
   return (
     <div
       style={{ fontSize: titleFontSize }}

--- a/packages/core/components/DataTable/components/SortIcon/sort-icon.css
+++ b/packages/core/components/DataTable/components/SortIcon/sort-icon.css
@@ -19,3 +19,18 @@
     top: 0.5rem;
   }
 }
+
+@media (max-width: 576px) {
+  .sort-icon {
+    :is(svg) {
+      width: 0.9rem;
+      height: 0.9rem;
+    }
+    .up {
+      bottom: 0.3rem;
+    }
+    .down {
+      top: 0.3rem;
+    }
+  }
+}

--- a/packages/core/components/Table/components/Row.tsx
+++ b/packages/core/components/Table/components/Row.tsx
@@ -19,7 +19,7 @@ const Row: FC<RowProps> = props => {
   const whiteSpace = wrapColumns ? 'unset' : 'nowrap'
   const minWidth = cellMinWidth + 'px'
   const fontSizes = { small: 16, medium: 18, large: 20 }
-  const cellFontSize = ['sm', 'xs', 'xxs'].includes(viewport) ? '11px' : `${fontSizes[fontSize]}px`
+  const cellFontSize = ['xs', 'xxs'].includes(viewport) ? '12px' : `${fontSizes[fontSize]}px`
 
   return (
     <tr>

--- a/packages/core/styles/_global-variables.scss
+++ b/packages/core/styles/_global-variables.scss
@@ -91,8 +91,8 @@ $colors: (
   --font-size: 17px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 576px) {
   :root {
-    --font-size: 0.9em;
+    --font-size: 13px;
   }
 }

--- a/packages/dashboard/src/components/CollapsibleVisualizationRow.tsx
+++ b/packages/dashboard/src/components/CollapsibleVisualizationRow.tsx
@@ -8,10 +8,16 @@ type CollapsableVizRow = {
   groupName: string
   currentViewport: string
 }
-const CollapsibleVisualizationRow: React.FC<CollapsableVizRow> = ({ allExpanded, fontSize, groupName, currentViewport, children }) => {
+const CollapsibleVisualizationRow: React.FC<CollapsableVizRow> = ({
+  allExpanded,
+  fontSize,
+  groupName,
+  currentViewport,
+  children
+}) => {
   const [isExpanded, setIsExpanded] = useState(allExpanded)
   const fontSizes = { small: 16, medium: 18, large: 20 }
-  const titleFontSize = ['sm', 'xs', 'xxs'].includes(currentViewport) ? '13px' : `${fontSizes[fontSize]}px`
+  const titleFontSize = ['xs', 'xxs'].includes(currentViewport) ? '13px' : `${fontSizes[fontSize]}px`
 
   useEffect(() => {
     setIsExpanded(allExpanded)


### PR DESCRIPTION
## [DEV-9859]

This does three things:

1) Changes the mobile breakpoint for displaying mobile data table font sizes from `768px` to `576px` so desktop font sizes will be used in the DFE center column
2) Reduces font size of mobile table headers, increases size of mobile cells
3) Improves layout of sorting triangles on mobile

## Testing Steps

View some charts with data tables on all screens sizes.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

Before:

![Screenshot 2024-11-22 at 1 31 44 PM](https://github.com/user-attachments/assets/649abea4-2d15-4c74-92d3-925c8a8f942a)

After:

![Screenshot 2024-11-22 at 1 32 04 PM](https://github.com/user-attachments/assets/6129ad85-0eff-4acb-9d10-888d6fe34571)

## Additional Notes

There is a larger data table font refactor coming from the UX team, this PR just makes some interim improvements.
