### PR TITLE
[DEV-9801] review territory no data state

### DIFF
--- a/packages/map/src/_stories/UsaMap.NoData.stories.tsx
+++ b/packages/map/src/_stories/UsaMap.NoData.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import CdcMap from '../CdcMap'
+import cityStateConfig from './_mock/example-city-state.json'
+import { editConfigKeys } from '@cdc/chart/src/helpers/configHelpers'
+
+const meta: Meta<typeof CdcMap> = {
+  title: 'Components/Templates/Map',
+  component: CdcMap
+}
+
+type Story = StoryObj<typeof CdcMap>
+
+export const USA_Map_No_Data: Story = {
+  args: {
+    config: editConfigKeys(cityStateConfig, [{ path: ['data'], value: [] }])
+  }
+}
+
+export default meta

--- a/packages/map/src/_stories/_mock/example-city-state.json
+++ b/packages/map/src/_stories/_mock/example-city-state.json
@@ -1,0 +1,858 @@
+{
+  "annotations": [],
+  "general": {
+    "title": "Example Data Map with Cities",
+    "subtext": "*: Lorem ipsum; NA: Lorem ipsum.",
+    "type": "data",
+    "geoType": "us",
+    "headerColor": "theme-cyan",
+    "showSidebar": true,
+    "showTitle": true,
+    "showDownloadButton": true,
+    "expandDataTable": false,
+    "backgroundColor": "#f5f5f5",
+    "geoBorderColor": "darkGray",
+    "territoriesLabel": "Territories",
+    "language": "en",
+    "hasRegions": false,
+    "showDownloadMediaButton": false,
+    "displayAsHex": false,
+    "displayStateLabels": false,
+    "fullBorder": false,
+    "palette": {
+      "isReversed": false
+    },
+    "allowMapZoom": true,
+    "hideGeoColumnInTooltip": false,
+    "hidePrimaryColumnInTooltip": false,
+    "statePicked": {
+      "fipsCode": "01",
+      "stateName": "Alabama"
+    },
+    "showDownloadImgButton": false,
+    "showDownloadPdfButton": false,
+    "territoriesAlwaysShow": true,
+    "geoLabelOverride": "",
+    "convertFipsCodes": true,
+    "noStateFoundMessage": "Map Unavailable",
+    "annotationDropdownText": "Annotations"
+  },
+  "type": "map",
+  "color": "yelloworangered",
+  "columns": {
+    "geo": {
+      "dataTable": true,
+      "label": "",
+      "name": "STATE",
+      "tooltip": false
+    },
+    "primary": {
+      "dataTable": true,
+      "label": "Rate",
+      "name": "Rate",
+      "prefix": "",
+      "suffix": "",
+      "tooltip": false,
+      "roundToPlace": 0
+    },
+    "navigate": {
+      "dataTable": false,
+      "name": "",
+      "tooltip": false
+    },
+    "additionalColumn1": {
+      "label": "Location",
+      "dataTable": true,
+      "tooltips": false,
+      "prefix": "",
+      "suffix": "",
+      "name": "Location",
+      "tooltip": true
+    },
+    "geosInRegion": {
+      "name": ""
+    },
+    "latitude": {
+      "name": ""
+    },
+    "longitude": {
+      "name": ""
+    }
+  },
+  "legend": {
+    "numberOfItems": 3,
+    "position": "side",
+    "title": "Legend Title",
+    "description": "Legend Text",
+    "type": "equalnumber",
+    "specialClasses": [
+      {
+        "key": "Rate",
+        "value": "*",
+        "label": "*"
+      },
+      {
+        "key": "Rate",
+        "value": "NA",
+        "label": "N/A"
+      }
+    ],
+    "unified": false,
+    "singleColumn": false,
+    "dynamicDescription": false,
+    "descriptions": {},
+    "singleRow": false,
+    "showSpecialClassesLast": false,
+    "verticalSorted": false,
+    "style": "circles",
+    "subStyle": "linear blocks",
+    "tickRotation": "",
+    "singleColumnLegend": false,
+    "hideBorder": false
+  },
+  "filters": [],
+  "table": {
+    "showDownloadUrl": false,
+    "showDataTableLink": true,
+    "wrapColumns": false,
+    "label": "Data Table",
+    "expanded": true,
+    "limitHeight": false,
+    "height": "",
+    "caption": "",
+    "showFullGeoNameInCSV": false,
+    "forceDisplay": true,
+    "download": true,
+    "indexLabel": "",
+    "showDownloadLinkBelow": true
+  },
+  "tooltips": {
+    "appearanceType": "hover",
+    "linkLabel": "Learn More",
+    "capitalizeLabels": true,
+    "opacity": 90
+  },
+  "runtime": {
+    "editorErrorMessage": []
+  },
+  "visual": {
+    "cityStyle": "pin",
+    "minBubbleSize": 1,
+    "maxBubbleSize": 20,
+    "extraBubbleBorder": false,
+    "showBubbleZeros": false,
+    "geoCodeCircleSize": 2,
+    "cityStyleLabel": "",
+    "additionalCityStyles": []
+  },
+  "mapPosition": {
+    "coordinates": [
+      0,
+      30
+    ],
+    "zoom": 1
+  },
+  "map": {
+    "layers": [],
+    "patterns": []
+  },
+  "hexMap": {
+    "type": "",
+    "shapeGroups": [
+      {
+        "legendTitle": "",
+        "legendDescription": "",
+        "items": [
+          {
+            "key": "",
+            "shape": "Arrow Up",
+            "column": "",
+            "operator": "=",
+            "value": ""
+          }
+        ]
+      }
+    ]
+  },
+  "filterBehavior": "Filter Change",
+  "dataTable": {
+    "title": "Data Table",
+    "forceDisplay": true
+  },
+  "sharing": {
+    "enabled": false,
+    "dataHost": "wcms-wp.cdc.gov",
+    "configUrl": "/wcms/4.0/cdc-wp/data-presentation/examples/city-data-map-example.json"
+  },
+  "usingWidgetLoader": true,
+  "data": [
+    {
+      "STATE": "AL",
+      "Rate": 1000,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Great Plains Tribal Leaders Health Board",
+      "Rate": 1000,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Montana American Indian Women’s Health Coalition",
+      "Rate": 1000,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "AK",
+      "Rate": 1200,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "AS",
+      "Rate": 14,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "EAU CLAIRE",
+      "Rate": 140,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "AZ",
+      "Rate": 9,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "AR",
+      "Rate": 17,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "CA",
+      "Rate": "*",
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "CO",
+      "Rate": 22,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "CT",
+      "Rate": 10,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "DE",
+      "Rate": 12,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "DC",
+      "Rate": 14,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "FL",
+      "Rate": 9,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "GA",
+      "Rate": 17,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "GU",
+      "Rate": 20,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "HI",
+      "Rate": 22,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "GAINESVILLE",
+      "Rate": 22,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "ID",
+      "Rate": "*",
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "IL",
+      "Rate": 12,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "IN",
+      "Rate": 14,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "IA",
+      "Rate": 9,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "KS",
+      "Rate": "NA",
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "KY",
+      "Rate": 20,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "LA",
+      "Rate": 22,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "ME",
+      "Rate": 10,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "MH",
+      "Rate": 12,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "MD",
+      "Rate": "*",
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "MA",
+      "Rate": 9,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "MI",
+      "Rate": 17,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "FM",
+      "Rate": 20,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "MN",
+      "Rate": 22,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "MS",
+      "Rate": 10,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "MO",
+      "Rate": 11,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "MT",
+      "Rate": 14,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "NE",
+      "Rate": 9,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "NV",
+      "Rate": 17,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "NH",
+      "Rate": 20,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "NJ",
+      "Rate": 28,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "NM",
+      "Rate": 10,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "NY",
+      "Rate": 12,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "NC",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "ND",
+      "Rate": 9,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "MP",
+      "Rate": 17,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "OH",
+      "Rate": "NA",
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "OK",
+      "Rate": 22,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "OR",
+      "Rate": 10,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "PW",
+      "Rate": 12,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "PA",
+      "Rate": 14,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "PR",
+      "Rate": 6,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "RI",
+      "Rate": 17,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "SC",
+      "Rate": 20,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "SD",
+      "Rate": 22,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "TN",
+      "Rate": 10,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "TX",
+      "Rate": 12,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "VT",
+      "Rate": 9,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "VI",
+      "Rate": 17,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "VA",
+      "Rate": 20,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "WA",
+      "Rate": 22,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "WV",
+      "Rate": 10,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "WI",
+      "Rate": 12,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "WY",
+      "Rate": 14,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Los Angeles",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Grand Rapids, MICHIGAN",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Salem, OReGON",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Round Rock, TEXAS",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "PROVO, UT",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "SALUDA, VIRGINIA",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "ELLENSBURG, WA",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Atlanta",
+      "Rate": 12,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Boston",
+      "Rate": 20,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "New York City",
+      "Rate": 22,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Dallas",
+      "Rate": 18,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Seattle",
+      "Rate": 17,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "New Orleans",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Birmingham",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "St Paul",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Hershey",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Salt Lake City",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Syracuse",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Philadelphia",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Alaska Native Tribal Health Consortium",
+      "Rate": 24,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "American Indian Cancer Foundation",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Arctic Slope Native Association Limited",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "California Rural Indian Health Board Inc.",
+      "Rate": 19,
+      "Location": "Work",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Cherokee Nation",
+      "Rate": 12,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Cheyenne River Sioux Tribe",
+      "Rate": 11,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Fond du Lac Reservation",
+      "Rate": 22,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Great Plains Tribal Leaders Health Board",
+      "Rate": 18,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Hopi Tribe",
+      "Rate": 19,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Inter-Tribal Council of Michigan, Inc.",
+      "Rate": 14,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Kaw Nation of Oklahoma",
+      "Rate": 16,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Native American Rehabilitation Association of the Northwest, Inc.",
+      "Rate": 22,
+      "Location": "School",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Navajo Nation",
+      "Rate": 24,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Northwest Portland Area Indian Health Board",
+      "Rate": 24,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "South Puget Intertribal Planning Agency",
+      "Rate": 9,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Southcentral Foundation",
+      "Rate": 29,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Southeast Alaska Regional Health Consortium",
+      "Rate": 8,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Yukon-Kuskokwim Health Corporation",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Modesto",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Lakeview",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Lockport",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Warren",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Salem, Oregon",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Salem, Connecticut",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Salem, Alabama",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Salem, Florida",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Salem, Massachusetts",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "San Benito",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "Alexandria",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    },
+    {
+      "STATE": "San Juan",
+      "Rate": 5,
+      "Location": "Vehicle",
+      "URL": "https://www.cdc.gov/"
+    }
+  ],
+  "filterStyle": "Filter Changes",
+  "version": "4.24.11"
+}

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -140,6 +140,7 @@ const UsaMap = () => {
 
     let styles = {
       fill: geoFillColor,
+      stroke: geoStrokeColor,
       color: '#202020'
     }
 


### PR DESCRIPTION
## [DEV-9801] review territory no data state

<!-- Provide a brief description of the changes made in this PR -->
Part of this ticket was already resolved where territories were showing black when no data was passed in. This adds the stroke color around the squares as well.

## Testing Steps
- [ ] Run `yarn storybook`
- [ ] Open `story/components-templates-map--usa-map-no-data`

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)
<img width="437" alt="Screen Shot 2024-11-22 at 12 54 08 PM" src="https://github.com/user-attachments/assets/39642174-a38a-4cb5-a7c7-37ade6a7c77c">


## Additional Notes

<!-- Add any additional notes about this PR -->
