### PR TITLE
Fix: [DEV-9850] Add confidence interval migrations to bar charts

### DIFF
--- a/packages/chart/src/_stories/Chart.stories.tsx
+++ b/packages/chart/src/_stories/Chart.stories.tsx
@@ -11,6 +11,7 @@ import horizontalBarConfig from './_mock/horizontal_bar.json'
 import pieConfig from './_mock/pie_with_data.json'
 import boxPlotConfig from './_mock/boxplot_multiseries.json'
 import areaChartStacked from './_mock/area_chart_stacked.json'
+import { editConfigKeys } from '../helpers/configHelpers'
 
 const meta: Meta<typeof Chart> = {
   title: 'Components/Templates/Chart',
@@ -22,6 +23,13 @@ type Story = StoryObj<typeof Chart>
 export const line_Chart_Confidence_Intervals: Story = {
   args: {
     config: lineChartConfidenceIntervals,
+    isEditor: false
+  }
+}
+
+export const Bar_Chart_Confidence_Intervals: Story = {
+  args: {
+    config: editConfigKeys(lineChartConfidenceIntervals, [{ path: ['visualizationType'], value: 'Bar' }]),
     isEditor: false
   }
 }

--- a/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
@@ -60,7 +60,7 @@ export const BarChartHorizontal = () => {
 
   const { HighLightedBarUtils } = useHighlightedBars(config)
 
-  const hasConfidenceInterval = Object.keys(config.confidenceKeys).length > 0
+  const hasConfidenceInterval = config.series.filter(s => s.confidenceIntervals).length > 0
 
   const _data = getBarData(config, data, hasConfidenceInterval)
 

--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -59,7 +59,7 @@ export const BarChartVertical = () => {
     data = brushConfig.data
   }
 
-  const hasConfidenceInterval = Object.keys(config.confidenceKeys).length > 0
+  const hasConfidenceInterval = config.series.filter(s => s.confidenceIntervals).length > 0
 
   const _data = getBarData(config, data, hasConfidenceInterval)
   return (
@@ -225,9 +225,16 @@ export const BarChartVertical = () => {
                   // Confidence Interval Variables
                   const tickWidth = 5
                   const xPos = barX + (config.xAxis.type !== 'date-time' ? barWidth / 2 : 0)
-                  const [upperPos, lowerPos] = ['upper', 'lower'].map(position => {
+                  const [upperPos, lowerPos] = ['high', 'low'].map(position => {
                     if (!hasConfidenceInterval) return
-                    const d = datum.dynamicData ? datum.CI[bar.key][position] : datum[config.confidenceKeys[position]]
+                    let d = datum
+                    if (datum.dynamicData) {
+                      d = datum.CI[bar.key][position]
+                    } else if (config.series[index].confidenceIntervals) {
+                      config.series[index].confidenceIntervals.forEach((ci, ciIndex) => {
+                        d = datum[config.series[index].confidenceIntervals[ciIndex][position]]
+                      })
+                    }
                     return yScale(d)
                   })
                   // End Confidence Interval Variables

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1496,29 +1496,6 @@ const EditorPanel = () => {
                             </Panels.Series.Wrapper>
                           )}
                         </>
-                        {config.series && config.series.length <= 1 && config.visualizationType === 'Bar' && (
-                          <>
-                            <span className='divider-heading'>Confidence Keys</span>
-                            <Select
-                              value={config.confidenceKeys.upper || ''}
-                              section='confidenceKeys'
-                              fieldName='upper'
-                              label='Upper'
-                              updateField={updateField}
-                              initial='Select'
-                              options={getColumns(false)}
-                            />
-                            <Select
-                              value={config.confidenceKeys.lower || ''}
-                              section='confidenceKeys'
-                              fieldName='lower'
-                              label='Lower'
-                              updateField={updateField}
-                              initial='Select'
-                              options={getColumns(false)}
-                            />
-                          </>
-                        )}
                         {visSupportsRankByValue() && config.series && config.series.length === 1 && (
                           <Select
                             value={config.rankByValue}

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
@@ -304,8 +304,7 @@ const SeriesDropdownConfidenceInterval = props => {
   const { config, updateConfig } = useContext(ConfigContext)
   const { series, index } = props
   const { getColumns } = useContext(SeriesContext)
-
-  if (series.type !== 'Forecasting' && series.type !== 'Line') return
+  if (series.type !== 'Forecasting' && series.type !== 'Line' && series.type !== 'Bar') return
 
   return (
     <div className='edit-block'>
@@ -393,7 +392,7 @@ const SeriesDropdownConfidenceInterval = props => {
                         series: copyOfSeries
                       })
                     }}
-                    options={getColumns()}
+                    options={getColumns(false)}
                   />
                   <InputSelect
                     initial='Select an option'
@@ -413,7 +412,7 @@ const SeriesDropdownConfidenceInterval = props => {
                         series: copyOfSeries
                       })
                     }}
-                    options={getColumns()}
+                    options={getColumns(false)}
                   />
                 </AccordionItemPanel>
               </AccordionItem>

--- a/packages/core/helpers/coveUpdateWorker.ts
+++ b/packages/core/helpers/coveUpdateWorker.ts
@@ -10,6 +10,7 @@ import update_4_24_7 from './ver/4.24.7'
 import update_4_24_9 from './ver/4.24.9'
 import versionNeedsUpdate from './ver/versionNeedsUpdate'
 import update_4_24_10 from './ver/4.24.10'
+import update_4_24_12 from './ver/4.24.12'
 
 export const coveUpdateWorker = config => {
   let genConfig = config
@@ -20,7 +21,8 @@ export const coveUpdateWorker = config => {
     ['4.24.5', update_4_24_5],
     ['4.24.7', update_4_24_7, true],
     ['4.24.9', update_4_24_9],
-    ['4.24.10', update_4_24_10]
+    ['4.24.10', update_4_24_10],
+    ['4.24.12', update_4_24_12]
   ]
 
   versions.forEach(([version, updateFunction, alwaysRun]: [string, UpdateFunction, boolean?]) => {

--- a/packages/core/helpers/ver/4.24.12.ts
+++ b/packages/core/helpers/ver/4.24.12.ts
@@ -1,0 +1,37 @@
+import _ from 'lodash'
+import type { AllChartsConfig } from '@cdc/chart/src/types/ChartConfig'
+
+/**
+ * migrateConfidenceKeys
+ * Previous confidence keys were stored in the single object config.confidenceKeys.lower and config.confidenceKeys.upper
+ * We need to migrate these to the new format in config.series to handle multiple series and multiple confidence intervals
+ * @param newConfig
+ * @returns newConfig
+ */
+const migrateConfidenceKeys = (newConfig: AllChartsConfig) => {
+  // Move confidence keys to series
+  if (newConfig.confidenceKeys && newConfig.series.length === 1 && newConfig.series[0].type === 'Bar') {
+    return newConfig.series.forEach((series, index) => {
+      newConfig.series[index].confidenceIntervals = [
+        {
+          low: String(newConfig.confidenceKeys.lower),
+          high: String(newConfig.confidenceKeys.upper),
+          showInTooltip: true
+        }
+      ]
+    })
+  }
+  // Remove old confidence keys
+  delete newConfig.confidenceKeys
+  return newConfig
+}
+
+const update_4_24_12 = config => {
+  const ver = '4.24.12'
+  const newConfig = _.cloneDeep(config)
+  migrateConfidenceKeys(newConfig)
+  newConfig.version = ver
+  return newConfig
+}
+
+export default update_4_24_12

--- a/packages/core/types/Series.ts
+++ b/packages/core/types/Series.ts
@@ -1,3 +1,9 @@
+type ConfidenceInterval = {
+  low: string
+  high: string
+  showInTooltip: boolean
+}
+
 export type Series = {
   dataKey: string
   name: string
@@ -5,4 +11,5 @@ export type Series = {
   type: string
   tooltip: boolean
   dynamicCategory?: string
+  confidenceIntervals?: ConfidenceInterval[]
 }[]


### PR DESCRIPTION
## [DEV-9850] Add confidence interval migrations to bar charts
From the ticket:
Multiple data series confidence intervals on charts are not currently supported. You can hack this by using a dynamic series and still having the CI options display, but then they cause issues with the y-axis (ex max height isn't maintained and the suffix overlaps the number).

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
- [ ] Run `yarn storybook`
- [ ] Open `components-templates-chart--bar-chart-confidence-intervals`
- [ ] Switch to the editor panel screen
- [ ] Notice that CI is now under the series and each series can choose its own CI groupings

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
