### PR TITLE
Fix: [DEV-9931] Adjust color palette settings on maps

### DIFF
--- a/packages/map/examples/default-geocode.json
+++ b/packages/map/examples/default-geocode.json
@@ -5,7 +5,7 @@
       "fipsCode": "32",
       "stateName": "Nevada"
     },
-    "geoType": "us-county",
+    "geoType": "us",
     "geoBorderColor": "darkGray",
     "headerColor": "theme-blue",
     "showTitle": true,
@@ -19,7 +19,7 @@
     "hasRegions": false,
     "expandDataTable": false,
     "fullBorder": false,
-    "type": "us-geocode",
+    "type": "map",
     "title": "Default US Map",
     "palette": {
       "isReversed": false
@@ -93,7 +93,8 @@
     "forceDisplay": true,
     "download": true,
     "indexLabel": "",
-    "wrapColumns": false
+    "wrapColumns": false,
+    "showDownloadLinkBelow": true
   },
   "tooltips": {
     "appearanceType": "hover",
@@ -144,6 +145,14 @@
     ]
   },
   "filterBehavior": "Filter Change",
+  "customColors": [
+    "red",
+    "orange",
+    "yellow",
+    "green",
+    "blue",
+    "violet"
+  ],
   "dataTable": {
     "title": "Data Table",
     "forceDisplay": true

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -5,6 +5,7 @@ import Waiting from '@cdc/core/components/Waiting'
 import Annotation from './components/Annotation'
 import Error from './components/EditorPanel/components/Error'
 import _ from 'lodash'
+import { applyColorToLegend } from './helpers/applyColorToLegend'
 
 // types
 import { type ViewportSize } from './types/MapConfig'
@@ -391,49 +392,6 @@ const CdcMap = ({
       10: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     }
 
-    const applyColorToLegend = legendIdx => {
-      // Default to "bluegreen" color scheme if the passed color isn't valid
-      let mapColorPalette = obj.customColors || colorPalettes[obj.color] || colorPalettes['bluegreen']
-
-      // Handle Region Maps need for a 10th color
-      if (general.geoType === 'us-region' && mapColorPalette.length < 10 && mapColorPalette.length > 8) {
-        if (!general.palette.isReversed) {
-          mapColorPalette.push(chroma(mapColorPalette[8]).darken(0.75).hex())
-        } else {
-          mapColorPalette.unshift(chroma(mapColorPalette[0]).darken(0.75).hex())
-        }
-      }
-
-      let colorIdx = legendIdx - specialClasses
-
-      // Special Classes (No Data)
-      if (result[legendIdx].special) {
-        if (isOlderVersion(state.version, '4.24.11')) {
-          const specialClassColors = chroma.scale(['#D4D4D4', '#939393']).colors(specialClasses)
-          return specialClassColors[legendIdx]
-        } else {
-          const specialClassColors = ['#A9AEB1', '#71767A']
-          return specialClassColors[legendIdx]
-        }
-      }
-
-      if (obj.color.includes('qualitative')) return mapColorPalette[colorIdx]
-
-      let amt = Math.max(result.length - specialClasses, 1)
-      let distributionArray = colorDistributions[amt]
-
-      let specificColor
-      if (distributionArray) {
-        specificColor = distributionArray[colorIdx]
-      } else if (mapColorPalette[colorIdx]) {
-        specificColor = colorIdx
-      } else {
-        specificColor = mapColorPalette.length - 1
-      }
-
-      return mapColorPalette[specificColor]
-    }
-
     let specialClasses = 0
     let specialClassesHash = {}
 
@@ -454,7 +412,7 @@ const CdcMap = ({
                   label: specialClass.label
                 })
 
-                result[result.length - 1].color = applyColorToLegend(result.length - 1)
+                result[result.length - 1].color = applyColorToLegend(result.length - 1, state, result)
 
                 specialClasses += 1
               }
@@ -486,7 +444,7 @@ const CdcMap = ({
                 value: val
               })
 
-              result[result.length - 1].color = applyColorToLegend(result.length - 1)
+              result[result.length - 1].color = applyColorToLegend(result.length - 1, state, result)
 
               specialClasses += 1
             }
@@ -568,7 +526,7 @@ const CdcMap = ({
 
       // Add color to new legend item
       for (let i = 0; i < result.length; i++) {
-        result[i].color = applyColorToLegend(i)
+        result[i].color = applyColorToLegend(i, state, result)
       }
 
       legendMemo.current = newLegendMemo
@@ -632,7 +590,7 @@ const CdcMap = ({
         let lastIdx = result.length - 1
 
         // Add color to new legend item
-        result[lastIdx].color = applyColorToLegend(lastIdx)
+        result[lastIdx].color = applyColorToLegend(lastIdx, state, result)
       }
     }
 
@@ -684,7 +642,7 @@ const CdcMap = ({
             max
           })
 
-          result[result.length - 1].color = applyColorToLegend(result.length - 1)
+          result[result.length - 1].color = applyColorToLegend(result.length - 1, state, result)
 
           changingNumber -= 1
           numberOfRows -= chunkAmt
@@ -842,12 +800,12 @@ const CdcMap = ({
 
         result.push(range)
 
-        result[result.length - 1].color = applyColorToLegend(result.length - 1)
+        result[result.length - 1].color = applyColorToLegend(result.length - 1, state, result)
       }
     }
 
     result.forEach((legendItem, idx) => {
-      legendItem.color = applyColorToLegend(idx, specialClasses, result)
+      legendItem.color = applyColorToLegend(idx, state, result)
     })
 
     legendMemo.current = newLegendMemo

--- a/packages/map/src/_stories/CdcMap.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react'
 import CdcMap from '../CdcMap'
 import EqualNumberOptInExample from './_mock/DEV-7286.json'
 import SingleStateWithFilters from './_mock/DEV-8942.json'
+import exampleCityState from './_mock/example-city-state.json'
+import { editConfigKeys } from '@cdc/chart/src/helpers/configHelpers'
 
 const meta: Meta<typeof CdcMap> = {
   title: 'Components/Templates/Map',
@@ -91,6 +93,63 @@ export const Custom_Map_Layers: Story = {
 export const Single_State_With_Filters: Story = {
   args: {
     config: SingleStateWithFilters
+  }
+}
+
+let newConfig = editConfigKeys(exampleCityState, [
+  { path: ['customColors'], value: ['red', 'orange', 'yellow', 'green', 'blue', 'violet'] }
+])
+newConfig = editConfigKeys(newConfig, [
+  {
+    path: ['legend', 'specialClasses'],
+    value: [
+      {
+        key: 'Rate',
+        value: '*',
+        label: '*'
+      }
+    ]
+  }
+])
+let exampleCityStateStandardColors = editConfigKeys(exampleCityState, [
+  {
+    path: ['legend', 'specialClasses'],
+    value: [
+      {
+        key: 'Rate',
+        value: '*',
+        label: '*'
+      }
+    ]
+  }
+])
+export const Custom_Color_Distributions_With_Special_Classes: Story = {
+  args: {
+    config: newConfig
+  }
+}
+
+export const Custom_Color_Distributions_Without_Special_Classes: Story = {
+  args: {
+    config: editConfigKeys(newConfig, [{ path: ['legend', 'specialClasses'], value: [] }])
+  }
+}
+
+export const Standard_Color_Distributions_With_Special_Classes: Story = {
+  args: {
+    config: exampleCityStateStandardColors
+  }
+}
+
+export const Standard_Color_Distributions_Without_Special_Classes: Story = {
+  args: {
+    config: editConfigKeys(exampleCityStateStandardColors, [{ path: ['legend', 'specialClasses'], value: [] }])
+  }
+}
+
+export const Custom_Color_Distributions_With_Update_Needed: Story = {
+  args: {
+    config: editConfigKeys(newConfig, [{ path: ['version'], value: '4.24.11' }])
   }
 }
 

--- a/packages/map/src/_stories/_mock/example-city-state.json
+++ b/packages/map/src/_stories/_mock/example-city-state.json
@@ -854,5 +854,5 @@
     }
   ],
   "filterStyle": "Filter Changes",
-  "version": "4.24.11"
+  "version": "4.24.12"
 }

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -41,7 +41,7 @@ export const applyColorToLegend = (legendIdx: number, config: ChartConfig, resul
       }
     }
 
-    let colorIdx = legendIdx - specialClasses
+    let colorIdx = legendIdx - specialClasses.length
 
     // Special Classes (No Data)
     if (result[legendIdx].special) {
@@ -56,12 +56,17 @@ export const applyColorToLegend = (legendIdx: number, config: ChartConfig, resul
 
     if (config.color.includes('qualitative')) return mapColorPalette[colorIdx]
 
-    let amt = Math.max(result.length - specialClasses, 1)
+    // If the current version is newer than 4.24.10, use the color palette
+    if (!isOlderVersion(config.version, '4.24.12')) {
+      if (config.customColors) return mapColorPalette[legendIdx - specialClasses.length]
+    }
+
+    let amt = Math.max(result.length - specialClasses.length, 1)
     let distributionArray = colorDistributions[amt]
-    // debugger
     let specificColor
-    if (distributionArray && !config.customColors && isOlderVersion(config.version, '4.24.12')) {
-      specificColor = distributionArray[colorIdx]
+
+    if (distributionArray) {
+      specificColor = distributionArray[legendIdx - specialClasses.length]
     } else if (mapColorPalette[colorIdx]) {
       specificColor = colorIdx
     } else {

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -1,0 +1,75 @@
+import colorPalettes from '@cdc/core/data/colorPalettes'
+import chroma from 'chroma-js'
+import { isOlderVersion } from '@cdc/core/helpers/ver/versionNeedsUpdate'
+import { type ChartConfig } from '@cdc/chart/src/types/ChartConfig'
+
+/**
+ * applyColorToLegend
+ * @param legendIdx legend item index
+ * @param config chart config
+ * @param result hash of legend items
+ * @returns
+ */
+export const applyColorToLegend = (legendIdx: number, config: ChartConfig, result = []) => {
+  try {
+    if (!config) throw new Error('Config is required')
+
+    const colorDistributions = {
+      1: [1],
+      2: [1, 3],
+      3: [1, 3, 5],
+      4: [0, 2, 4, 6],
+      5: [0, 2, 4, 6, 7],
+      6: [0, 2, 3, 4, 5, 7],
+      7: [0, 2, 3, 4, 5, 6, 7],
+      8: [0, 2, 3, 4, 5, 6, 7, 8],
+      9: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      10: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    }
+
+    const specialClasses = config?.legend?.specialClasses
+    const { general } = config || {}
+    // Default to "bluegreen" color scheme if the passed color isn't valid
+    let mapColorPalette = config.customColors || colorPalettes[config.color] || colorPalettes['bluegreen']
+
+    // Handle Region Maps need for a 10th color
+    if (general.geoType === 'us-region' && mapColorPalette.length < 10 && mapColorPalette.length > 8) {
+      if (!general.palette.isReversed) {
+        mapColorPalette.push(chroma(mapColorPalette[8]).darken(0.75).hex())
+      } else {
+        mapColorPalette.unshift(chroma(mapColorPalette[0]).darken(0.75).hex())
+      }
+    }
+
+    let colorIdx = legendIdx - specialClasses
+
+    // Special Classes (No Data)
+    if (result[legendIdx].special) {
+      if (isOlderVersion(config.version, '4.24.11')) {
+        const specialClassColors = chroma.scale(['#D4D4D4', '#939393']).colors(specialClasses)
+        return specialClassColors[legendIdx]
+      } else {
+        const specialClassColors = ['#A9AEB1', '#71767A']
+        return specialClassColors[legendIdx]
+      }
+    }
+
+    if (config.color.includes('qualitative')) return mapColorPalette[colorIdx]
+
+    let amt = Math.max(result.length - specialClasses, 1)
+    let distributionArray = colorDistributions[amt]
+    // debugger
+    let specificColor
+    if (distributionArray && !config.customColors && isOlderVersion(config.version, '4.24.12')) {
+      specificColor = distributionArray[colorIdx]
+    } else if (mapColorPalette[colorIdx]) {
+      specificColor = colorIdx
+    } else {
+      specificColor = mapColorPalette.length - 1
+    }
+
+    return mapColorPalette[specificColor]
+  } catch (error) {
+    console.error('Error in applyColorToLegend', error)
+  }
+}


### PR DESCRIPTION
## [DEV-9931] Adjust color palette settings on maps
Prior to this release custom color palettes were using the color distributions array which was confusing folks. For example if users had a legend with three items they would need to enter ['red', 'red', 'yellow', 'yellow', 'orange', 'orange'] as a workaround to achieve red, yellow, and orange since thats how the color distribution matrix picks our sandard colors. This also moves the ts file out of CdcMap and fixes issues with calculating special class colors. See testing steps for more info.

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
- [ ] Run `yarn storybook`
- [ ] Open `story/components-templates-map--custom-color-distributions-with-special-classes`
- [ ] Verify red ,orange, yellow custom color scheme
- [ ] Open `/story/components-templates-map--custom-color-distributions-without-special-classes`
- [ ] Verify custom colors are red, orange, yellow color scheme with single special class
- [ ] Open `/story/components-templates-map--standard-color-distributions-with-special-classes`
- [ ] Verify STANDARD yelloworangered palette inside of the config using color distributions with the special
- [ ] Open `/story/components-templates-map--standard-color-distributions-without-special-classes`
- [ ] Verify STANDARD yelloworangered palette inside of the config using color distributions without the special class
- [ ] Open `story/components-templates-map--custom-color-distributions-with-update-needed` to verify color schemes implemented before 4.24.12 (skips red, yellow, blue) in ROYGBIV


## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
