### PR TITLE
Fix: Dev-9910 yAxis Max and Min height can be set

### DIFF
--- a/packages/chart/src/hooks/useMinMax.ts
+++ b/packages/chart/src/hooks/useMinMax.ts
@@ -52,8 +52,10 @@ const useMinMax = ({ config, minValue, maxValue, existPositiveValue, data, isAll
 
   if (lower && upper && config.visualizationType === 'Bar') {
     const buffer = min < 0 ? 1.1 : 0
-    max = Math.max(maxValue, Math.max(...data.flatMap(d => [d[upper], d[lower]])) * 1.15)
-    min = Math.min(minValue, Math.min(...data.flatMap(d => [d[upper], d[lower]])) * 1.15) * buffer
+    const maxValueWithCI = Math.max(...data.flatMap(d => [d[upper], d[lower]])) * 1.15
+    const minValueWithCIPlusBuffer = Math.min(...data.flatMap(d => [d[upper], d[lower]])) * 1.15 * buffer
+    max = max > maxValueWithCI ? max : maxValueWithCI
+    min = min < minValueWithCIPlusBuffer ? min : minValueWithCIPlusBuffer
   }
 
   if (config.series.filter(s => s?.type === 'Forecasting')) {


### PR DESCRIPTION
## Dev-9910
https://websupport.cdc.gov/browse/DEV-9910

The Max and Min values can be set for the yAxis

## Testing Steps

Scenario: Upload [dev-9910.json](https://github.com/user-attachments/files/17922575/dev-9910.json) and navigate to Configuration
Expected: The Editor is open for a Bar Graph. The left axis's max amount is 50+.

1. Open the "Left Value Axis" accordion
2. In the "Left Axis Max Value" box, change the amount to 100
Expected: The left axis's max amount is 100

## Self Review

- I have added testing steps for reviewers
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
