### PR TITLE
Enhancement: auto calculate padding for overflowing grid labels

### DIFF
--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -647,7 +647,8 @@ const EditorPanel = () => {
     visSupportsValueAxisLine,
     visSupportsValueAxisMax,
     visSupportsValueAxisMin,
-    visSupportsValueAxisTicks
+    visSupportsValueAxisTicks,
+    visSupportsYPadding
   } = useEditorPermissions()
 
   // when the visualization type changes we
@@ -1768,14 +1769,16 @@ const EditorPanel = () => {
                           title={!config.yAxis.gridLines ? 'Show gridlines to enable' : ''}
                         />
                       )}
-                      <CheckBox
-                        value={config.yAxis.enablePadding}
-                        section='yAxis'
-                        fieldName='enablePadding'
-                        label='Add Padding to Value Axis Scale'
-                        updateField={updateField}
-                      />
-                      {config.yAxis.enablePadding && (
+                      {visSupportsYPadding() && (
+                        <CheckBox
+                          value={config.yAxis.enablePadding}
+                          section='yAxis'
+                          fieldName='enablePadding'
+                          label='Add Padding to Value Axis Scale'
+                          updateField={updateField}
+                        />
+                      )}
+                      {config.yAxis.enablePadding && visSupportsYPadding() && (
                         <TextField
                           type='number'
                           section='yAxis'

--- a/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
+++ b/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
@@ -383,6 +383,10 @@ export const useEditorPermissions = () => {
     )
   }
 
+  const visSupportsYPadding = () => {
+    return !config.dataFormat.onlyShowTopPrefixSuffix || !config.dataFormat.suffix?.includes(' ')
+  }
+
   const visHasSingleSeriesTooltip = () => {
     if (visualizationType === 'Bar' || visualizationType === 'Line') {
       return true
@@ -456,6 +460,7 @@ export const useEditorPermissions = () => {
     visSupportsValueAxisMax,
     visSupportsValueAxisMin,
     visSupportsDynamicSeries,
+    visSupportsYPadding,
     visHasSingleSeriesTooltip,
     visHasCategoricalAxis
   }

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -175,7 +175,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   }
 
   // VARS/MEMOS
-  const labelsOverflow = onlyShowTopPrefixSuffix || labelsAboveGridlines
   const shouldAbbreviate = true
   const isHorizontal = orientation === 'horizontal' || config.visualizationType === 'Forest Plot'
   const isLogarithmicAxis = config.yAxis.type === 'logarithmic'
@@ -251,8 +250,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
       ...config,
       yAxis: {
         ...config.yAxis,
-        scalePadding: labelsOverflow ? autoPadding : config.yAxis.scalePadding,
-        enablePadding: labelsOverflow || config.yAxis.enablePadding
+        scalePadding: onlyShowTopPrefixSuffix ? autoPadding : config.yAxis.scalePadding,
+        enablePadding: onlyShowTopPrefixSuffix || config.yAxis.enablePadding
       }
     },
     minValue,
@@ -456,14 +455,14 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     if (orientation === 'horizontal') return
 
     const maxValueIsGreaterThanTopGridLine = maxValue > Math.max(...yScale.ticks(handleNumTicks))
-    if (!maxValueIsGreaterThanTopGridLine || !labelsOverflow) return
+    if (!maxValueIsGreaterThanTopGridLine || !onlyShowTopPrefixSuffix) return
 
     const tickGap = yScale.ticks(handleNumTicks)[1] - yScale.ticks(handleNumTicks)[0]
     const nextTick = Math.max(...yScale.ticks(handleNumTicks)) + tickGap
     const newPadding = minValue < 0 ? (nextTick - maxValue) / maxValue / 2 : (nextTick - maxValue) / maxValue
 
     setAutoPadding(newPadding * 100)
-  }, [maxValue, labelsOverflow, yScale, handleNumTicks])
+  }, [maxValue, onlyShowTopPrefixSuffix, yScale, handleNumTicks])
 
   // Render Functions
   const generatePairedBarAxis = () => {

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -222,8 +222,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   )
   const handleNumTicks = isForestPlot ? config.data.length : yTickCount
   const maxValueIsGreaterThanTopGridLine = maxValue > Math.max(...yScale.ticks(handleNumTicks))
-  const needsYAxisAutoPadding = maxValueIsGreaterThanTopGridLine && labelsOverflow
-  const needsNewRender = needsYAxisAutoPadding && (!yAxisAutoPadding || lastMaxValue.current !== maxValue)
 
   // Tooltip Helpers
   const { tooltipData, showTooltip, hideTooltip, tooltipOpen, tooltipLeft, tooltipTop } = useTooltip()
@@ -568,8 +566,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
       </>
     )
   }
-
-  if (needsNewRender) return <></>
 
   return isNaN(width) ? (
     <React.Fragment></React.Fragment>

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -222,7 +222,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   )
   const handleNumTicks = isForestPlot ? config.data.length : yTickCount
   const maxValueIsGreaterThanTopGridLine = maxValue > Math.max(...yScale.ticks(handleNumTicks))
-  const needsNewRender = maxValueIsGreaterThanTopGridLine && (!yAxisAutoPadding || lastMaxValue.current !== maxValue)
+  const needsYAxisAutoPadding = maxValueIsGreaterThanTopGridLine && labelsOverflow
+  const needsNewRender = needsYAxisAutoPadding && (!yAxisAutoPadding || lastMaxValue.current !== maxValue)
 
   // Tooltip Helpers
   const { tooltipData, showTooltip, hideTooltip, tooltipOpen, tooltipLeft, tooltipTop } = useTooltip()

--- a/packages/chart/src/helpers/countNumOfTicks.ts
+++ b/packages/chart/src/helpers/countNumOfTicks.ts
@@ -1,0 +1,57 @@
+export const countNumOfTicks = ({ axis, max, runtime, currentViewport, isHorizontal, data, config, min }) => {
+  let { numTicks } = runtime[axis]
+  if (runtime[axis].viewportNumTicks && runtime[axis].viewportNumTicks[currentViewport]) {
+    numTicks = runtime[axis].viewportNumTicks[currentViewport]
+  }
+  let tickCount = undefined
+
+  if (axis === 'yAxis') {
+    tickCount =
+      isHorizontal && !numTicks
+        ? data.length
+        : isHorizontal && numTicks
+        ? numTicks
+        : !isHorizontal && !numTicks
+        ? undefined
+        : !isHorizontal && numTicks && numTicks
+    // to fix edge case of small numbers with decimals
+    if (tickCount === undefined && !config.dataFormat.roundTo) {
+      // then it is set to Auto
+      if (Number(max) <= 3) {
+        tickCount = 2
+      } else {
+        tickCount = 4 // same default as standalone components
+      }
+    }
+    if (Number(tickCount) > Number(max) && !isHorizontal) {
+      // cap it and round it so its an integer
+      tickCount = Number(min) < 0 ? Math.round(max) * 2 : Math.round(max)
+    }
+  }
+
+  if (axis === 'xAxis') {
+    tickCount =
+      isHorizontal && !numTicks
+        ? undefined
+        : isHorizontal && numTicks
+        ? numTicks
+        : !isHorizontal && !numTicks
+        ? undefined
+        : !isHorizontal && numTicks && numTicks
+    if (isHorizontal && tickCount === undefined && !config.dataFormat.roundTo) {
+      // then it is set to Auto
+      // - check for small numbers situation
+      if (max <= 3) {
+        tickCount = 2
+      } else {
+        tickCount = 4 // same default as standalone components
+      }
+    }
+
+    if (config.visualizationType === 'Forest Plot') {
+      tickCount = config.yAxis.numTicks !== '' ? config.yAxis.numTicks : 4
+    }
+  }
+
+  return tickCount
+}


### PR DESCRIPTION
## No Ticket

In an effort to never overlap data with grid when "Only show top prefix/suffix" is activated - auto generate padding if gridline is above maxValue

## Testing Steps
1. Create of view linear chart vertical chart with "Only show top prefix/suffix" activated
2. Observe the label does not overlap data

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

### Before
<img width="637" alt="Screenshot 2024-11-26 at 2 40 04 PM" src="https://github.com/user-attachments/assets/94904eb8-7954-42a8-8974-d53fd747371d">

### After
<img width="650" alt="Screenshot 2024-11-26 at 2 40 11 PM" src="https://github.com/user-attachments/assets/b6282ad0-bf2d-46f9-990f-98c5cad3e0df">
