### PR TITLE
Feature [DEV-9215] Display decimal points on pie charts

### DIFF
--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1839,6 +1839,17 @@ const EditorPanel = () => {
                     className='number-narrow'
                     updateField={updateField}
                     min={0}
+                  />{' '}
+                  <TextField
+                    display={config.visualizationType === 'Pie'}
+                    value={config.dataFormat.roundingPercentage ? config.dataFormat.roundingPercentage : 0}
+                    type='number'
+                    section='dataFormat'
+                    fieldName='roundingPercentage'
+                    label='Rounding Percentage'
+                    className='number-narrow'
+                    updateField={updateField}
+                    min={0}
                   />
                   <div className='two-col-inputs'>
                     <TextField
@@ -1886,7 +1897,6 @@ const EditorPanel = () => {
                       }
                     />
                   </div>
-
                   {config.orientation === 'horizontal' ? ( // horizontal - x is vertical y is horizontal
                     <>
                       {visSupportsValueAxisLine() && (
@@ -2028,7 +2038,6 @@ const EditorPanel = () => {
                       </>
                     )
                   )}
-
                   {/* start: anchors */}
                   {visHasAnchors() && config.orientation !== 'horizontal' && (
                     <div className='edit-block'>
@@ -2155,7 +2164,6 @@ const EditorPanel = () => {
                       </button>
                     </div>
                   )}
-
                   {visHasAnchors() && config.orientation === 'horizontal' && (
                     <div className='edit-block'>
                       <span className='edit-label column-heading'>Anchors</span>

--- a/packages/chart/src/components/PieChart/PieChart.tsx
+++ b/packages/chart/src/components/PieChart/PieChart.tsx
@@ -170,6 +170,7 @@ const PieChart = props => {
           )
         })}
         {transitions.map(({ item: arc, key }, i) => {
+          const roundTo = Number(config.dataFormat.roundingPercentage) || 0
           const [centroidX, centroidY] = path.centroid(arc)
           const hasSpaceForLabel = arc.endAngle - arc.startAngle >= 0.1
 
@@ -177,6 +178,11 @@ const PieChart = props => {
           if (_colorScale(arc.data[config.runtime.xAxis.dataKey])) {
             textColor = getContrastColor(textColor, _colorScale(arc.data[config.runtime.xAxis.dataKey]))
           }
+          const degrees = ((arc.endAngle - arc.startAngle) * 180) / Math.PI
+
+          // Calculate the percentage of the full circle (360 degrees)
+          const percentageOfCircle = (degrees / 360) * 100
+          const roundedPercentage = percentageOfCircle.toFixed(roundTo)
 
           return (
             <animated.g key={`${key}${i}`}>
@@ -189,7 +195,7 @@ const PieChart = props => {
                   textAnchor='middle'
                   pointerEvents='none'
                 >
-                  {Math.round((((arc.endAngle - arc.startAngle) * 180) / Math.PI / 360) * 100) + '%'}
+                  {roundedPercentage + '%'}
                 </Text>
               )}
             </animated.g>

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -196,7 +196,8 @@ export default {
     abbreviated: false,
     bottomSuffix: '',
     bottomPrefix: '',
-    bottomAbbreviated: false
+    bottomAbbreviated: false,
+    roundingPercentage: '0'
   },
   confidenceKeys: {},
   visual: {

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -68,6 +68,7 @@ type DataFormat = {
   roundTo: number
   suffix: string
   onlyShowTopPrefixSuffix?: boolean
+  roundingPercentage: string
 }
 
 type Exclusions = {


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Open Pie chart
On Data Format panel added new field "Rounding percentage"
Update rounding percentage to 1 to see results on pie chart.
<img width="1496" alt="Screenshot 2024-11-26 at 15 00 44" src="https://github.com/user-attachments/assets/e1ba0130-78bf-4160-b303-89d1f7fa30dd">

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
