### PR TITLE
Fix/Dev-9916 Y-Axis not responding to max value for line chart

### DIFF
--- a/packages/chart/src/hooks/useMinMax.ts
+++ b/packages/chart/src/hooks/useMinMax.ts
@@ -37,7 +37,7 @@ const useMinMax = ({ config, minValue, maxValue, existPositiveValue, data, isAll
 
   const { visualizationType, series } = config
   const { max: enteredMaxValue, min: enteredMinValue } = config.runtime.yAxis
-  const minRequiredCIPadding = 1.15 // regardless of Editor if CI data, there must be 10% padding added
+  const paddingAddedToAxis = config.yAxis.enablePadding ? 1 + config.yAxis.scalePadding / 100 : 1
   const isLogarithmicAxis = config.yAxis.type === 'logarithmic'
   // do validation bafore applying t0 charts
   const isMaxValid = existPositiveValue ? Number(enteredMaxValue) >= maxValue : Number(enteredMaxValue) >= 0
@@ -52,8 +52,8 @@ const useMinMax = ({ config, minValue, maxValue, existPositiveValue, data, isAll
 
   if (lower && upper && config.visualizationType === 'Bar') {
     const buffer = min < 0 ? 1.1 : 0
-    const maxValueWithCI = Math.max(...data.flatMap(d => [d[upper], d[lower]])) * 1.15
-    const minValueWithCIPlusBuffer = Math.min(...data.flatMap(d => [d[upper], d[lower]])) * 1.15 * buffer
+    const maxValueWithCI = Math.max(...data.flatMap(d => [d[upper], d[lower]])) * paddingAddedToAxis
+    const minValueWithCIPlusBuffer = Math.min(...data.flatMap(d => [d[upper], d[lower]])) * paddingAddedToAxis * buffer
     max = max > maxValueWithCI ? max : maxValueWithCI
     min = min < minValueWithCIPlusBuffer ? min : minValueWithCIPlusBuffer
   }


### PR DESCRIPTION
## Fix/Dev-9916

Preventing the yAxis Max from exceeding the max amount set unless a value is higher than the max. 

## Testing Steps

Scenario: Upload [dev-9916-config.json](https://github.com/user-attachments/files/17925557/dev-9916-config.json) and navigate to Dashboard preview.
Expected: There are a 6 filters

1. Select the following choices for the fitlers:
- Dataset: NationWide
- Location: States - Georgia
- Class: Chronic Health Indicators
- Topic: Asthma
- Year: 2021
- Question: 1st choice - Adults who have been...
2. Push View Results button
Expected: A bar chart is shows with the "No" response approaching 100% and the yAxis does not exceed 100%


## Self Review

- I have added testing steps for reviewers

