### PR TITLE
Enhancement [DEV-9857] Label last tick

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
@@ -13,32 +13,62 @@ import createBarElement from '@cdc/core/components/createBarElement'
 const BarChartStackedVertical = () => {
   const [barWidth, setBarWidth] = useState(0)
   const { xScale, yScale, seriesScale, xMax, yMax } = useContext(BarChartContext)
-  const { transformedData, colorScale, seriesHighlight, config, formatNumber, formatDate, parseDate, setSharedFilter } = useContext(ConfigContext)
-  const { isHorizontal, barBorderWidth, applyRadius, hoveredBar, getAdditionalColumn, onMouseLeaveBar, onMouseOverBar, barStackedSeriesKeys } = useBarChart()
+  const { transformedData, colorScale, seriesHighlight, config, formatNumber, formatDate, parseDate, setSharedFilter } =
+    useContext(ConfigContext)
+  const {
+    isHorizontal,
+    barBorderWidth,
+    applyRadius,
+    hoveredBar,
+    getAdditionalColumn,
+    onMouseLeaveBar,
+    onMouseOverBar,
+    barStackedSeriesKeys
+  } = useBarChart()
   const { orientation } = config
 
   const data = config.brush?.active && config.brush.data?.length ? config.brush.data : transformedData
   const isDateAxisType = config.runtime.xAxis.type === 'date-time' || config.runtime.xAxis.type === 'date'
+  const isDateTimeScaleAxisType = config.runtime.xAxis.type === 'date-time'
 
   return (
     config.visualizationSubType === 'stacked' &&
     !isHorizontal && (
       <>
-        <BarStack data={data} keys={barStackedSeriesKeys} x={d => d[config.runtime.xAxis.dataKey]} xScale={xScale} yScale={yScale} color={colorScale}>
+        <BarStack
+          data={data}
+          keys={barStackedSeriesKeys}
+          x={d => d[config.runtime.xAxis.dataKey]}
+          xScale={xScale}
+          yScale={yScale}
+          color={colorScale}
+        >
           {barStacks =>
             barStacks.reverse().map(barStack =>
               barStack.bars.map(bar => {
-                let transparentBar = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(bar.key) === -1
-                let displayBar = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(bar.key) !== -1
-                let barThickness = isDateAxisType ? seriesScale.range()[1] - seriesScale.range()[0] : xMax / barStack.bars.length
+                let transparentBar =
+                  config.legend.behavior === 'highlight' &&
+                  seriesHighlight.length > 0 &&
+                  seriesHighlight.indexOf(bar.key) === -1
+                let displayBar =
+                  config.legend.behavior === 'highlight' ||
+                  seriesHighlight.length === 0 ||
+                  seriesHighlight.indexOf(bar.key) !== -1
+                let barThickness = isDateAxisType
+                  ? seriesScale.range()[1] - seriesScale.range()[0]
+                  : xMax / barStack.bars.length
                 if (config.runtime.xAxis.type !== 'date') barThickness = config.barThickness * barThickness
                 // tooltips
                 const rawXValue = bar.bar.data[config.runtime.xAxis.dataKey]
                 const xAxisValue = isDateAxisType ? formatDate(parseDate(rawXValue)) : rawXValue
                 const yAxisValue = formatNumber(bar.bar ? bar.bar.data[bar.key] : 0, 'left')
                 if (!yAxisValue) return
-                const barX = xScale(isDateAxisType ? parseDate(rawXValue) : rawXValue) - (isDateAxisType ? barThickness / 2 : 0)
-                const xAxisTooltip = config.runtime.xAxis.label ? `${config.runtime.xAxis.label}: ${xAxisValue}` : xAxisValue
+                const barX =
+                  xScale(isDateAxisType ? parseDate(rawXValue) : rawXValue) -
+                  (isDateTimeScaleAxisType ? barThickness / 2 : 0)
+                const xAxisTooltip = config.runtime.xAxis.label
+                  ? `${config.runtime.xAxis.label}: ${xAxisValue}`
+                  : xAxisValue
                 const additionalColTooltip = getAdditionalColumn(hoveredBar)
                 const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${yAxisValue}`
                 const tooltip = `<ul>
@@ -51,7 +81,11 @@ const BarChartStackedVertical = () => {
 
                 return (
                   <Group key={`${barStack.index}--${bar.index}--${orientation}`}>
-                    <Group key={`bar-stack-${barStack.index}-${bar.index}`} id={`barStack${barStack.index}-${bar.index}`} className='stack vertical'>
+                    <Group
+                      key={`bar-stack-${barStack.index}-${bar.index}`}
+                      id={`barStack${barStack.index}-${bar.index}`}
+                      className='stack vertical'
+                    >
                       {createBarElement({
                         config: config,
                         seriesHighlight,

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -1362,8 +1362,10 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               }
             >
               {props => {
-                if (config.xAxis.type === 'date') {
-                  props.ticks = filterAndShiftLinearDateTicks(config, props, xAxisDataMapped)
+                // For these charts, we generated all ticks in tickValues above, and now need to filter/shift them
+                // so the last tick is always labeled
+                if (config.xAxis.type === 'date' && !config.xAxis.manual) {
+                  props.ticks = filterAndShiftLinearDateTicks(config, props, xAxisDataMapped, formatDate)
                 }
 
                 const axisMaxHeight = bottomLabelStart + BOTTOM_LABEL_PADDING

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -35,7 +35,7 @@ import { calcInitialHeight } from '../helpers/sizeHelpers'
 import useMinMax from '../hooks/useMinMax'
 import useReduceData from '../hooks/useReduceData'
 import useRightAxis from '../hooks/useRightAxis'
-import useScales, { getTickValues } from '../hooks/useScales'
+import useScales, { getTickValues, filterAndShiftLinearDateTicks } from '../hooks/useScales'
 import useTopAxis from '../hooks/useTopAxis'
 import { useTooltip as useCoveTooltip } from '../hooks/useTooltip'
 import { useEditorPermissions } from './EditorPanel/useEditorPermissions'
@@ -1356,10 +1356,16 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       config.xAxis.type === 'date-time' ? countNumOfTicks('xAxis') : getManualStep(),
                       config
                     )
+                  : config.xAxis.type === 'date'
+                  ? xAxisDataMapped
                   : undefined
               }
             >
               {props => {
+                if (config.xAxis.type === 'date') {
+                  props.ticks = filterAndShiftLinearDateTicks(config, props, xAxisDataMapped)
+                }
+
                 const axisMaxHeight = bottomLabelStart + BOTTOM_LABEL_PADDING
 
                 const axisCenter =

--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -337,7 +337,8 @@ export const getTickValues = (xAxisDataMapped, xScale, num, config) => {
 }
 
 // Ensure that the last tick is shown for charts with a "Date (Linear Scale)" scale
-export const filterAndShiftLinearDateTicks = (config, axisProps, xAxisDataMapped) => {
+export const filterAndShiftLinearDateTicks = (config, axisProps, xAxisDataMapped, formatDate) => {
+  let ticks = axisProps.ticks
   const filteredTickValues = getTicks(axisProps.scale, axisProps.numTicks)
   if (filteredTickValues.length < xAxisDataMapped.length) {
     let shift = 0
@@ -347,11 +348,14 @@ export const filterAndShiftLinearDateTicks = (config, axisProps, xAxisDataMapped
         ? xAxisDataMapped.length - 1 - lastIdx
         : xAxisDataMapped.indexOf(filteredTickValues[0]) * -1
     }
-    return filteredTickValues.map(value => {
+    ticks = filteredTickValues.map(value => {
       return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
     })
   }
-  return axisProps.ticks
+  ticks.forEach((tick, i) => {
+    tick.formattedValue = formatDate(tick.value, i, ticks)
+  })
+  return ticks
 }
 
 /// helper functions

--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -340,15 +340,16 @@ export const getTickValues = (xAxisDataMapped, xScale, num, config) => {
 export const filterAndShiftLinearDateTicks = (config, axisProps, xAxisDataMapped) => {
   const filteredTickValues = getTicks(axisProps.scale, axisProps.numTicks)
   if (filteredTickValues.length < xAxisDataMapped.length) {
+    let shift = 0
     const lastIdx = xAxisDataMapped.indexOf(filteredTickValues[filteredTickValues.length - 1])
     if (lastIdx < xAxisDataMapped.length - 1) {
-      const shift = !config.xAxis.sortByRecentDate
+      shift = !config.xAxis.sortByRecentDate
         ? xAxisDataMapped.length - 1 - lastIdx
         : xAxisDataMapped.indexOf(filteredTickValues[0]) * -1
-      return filteredTickValues.map(value => {
-        return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
-      })
     }
+    return filteredTickValues.map(value => {
+      return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
+    })
   }
   return axisProps.ticks
 }

--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -1,4 +1,13 @@
-import { LinearScaleConfig, LogScaleConfig, scaleBand, scaleLinear, scaleLog, scalePoint, scaleTime } from '@visx/scale'
+import {
+  LinearScaleConfig,
+  LogScaleConfig,
+  scaleBand,
+  scaleLinear,
+  scaleLog,
+  scalePoint,
+  scaleTime,
+  getTicks
+} from '@visx/scale'
 import { useContext } from 'react'
 import ConfigContext from '../ConfigContext'
 import { ChartConfig } from '../types/ChartConfig'
@@ -325,6 +334,23 @@ export const getTickValues = (xAxisDataMapped, xScale, num, config) => {
 
     return tickValues
   }
+}
+
+// Ensure that the last tick is shown for charts with a "Date (Linear Scale)" scale
+export const filterAndShiftLinearDateTicks = (config, axisProps, xAxisDataMapped) => {
+  const filteredTickValues = getTicks(axisProps.scale, axisProps.numTicks)
+  if (filteredTickValues.length < xAxisDataMapped.length) {
+    const lastIdx = xAxisDataMapped.indexOf(filteredTickValues[filteredTickValues.length - 1])
+    if (lastIdx < xAxisDataMapped.length - 1) {
+      const shift = !config.xAxis.sortByRecentDate
+        ? xAxisDataMapped.length - 1 - lastIdx
+        : xAxisDataMapped.indexOf(filteredTickValues[0]) * -1
+      return filteredTickValues.map(value => {
+        return axisProps.ticks[axisProps.ticks.findIndex(tick => tick.value === value) + shift]
+      })
+    }
+  }
+  return axisProps.ticks
 }
 
 /// helper functions


### PR DESCRIPTION
## [DEV-9857]

Label latest tick for charts with a "Date (Linear Scale)" x-axis.

## Testing Steps

Using the config attached to the ticket or another chart with a "Date (Linear Scale") x-axis, verify that the last tick is always labeled on all screen sizes.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

Before:
![Screenshot 2024-11-18 at 4 10 02 PM](https://github.com/user-attachments/assets/40554f07-a146-4138-b375-d9ad563f0491)

After:
![Screenshot 2024-11-18 at 4 10 12 PM](https://github.com/user-attachments/assets/968796e8-cf31-46c8-acc0-e6ec5c0b0000)


## Additional Notes

<!-- Add any additional notes about this PR -->
