### PR TITLE
Fix [DEV-9285] Show prefix/suffix on top tooltip item

### DIFF
--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -553,8 +553,12 @@ export const useTooltip = props => {
             (!pd.column || key === pd.column)
         )) ||
       {}
-    const newValue = label || value
+    let newValue = label || value
     const style = displayGray ? { color: '#8b8b8a' } : {}
+
+    if (index == 1 && config.dataFormat.onlyShowTopPrefixSuffix) {
+      newValue = `${config.dataFormat.prefix}${newValue}${config.dataFormat.suffix}`
+    }
 
     return <li style={style} className='tooltip-body'>{`${getSeriesNameFromLabel(key)}: ${newValue}`}</li>
   }


### PR DESCRIPTION
## [DEV-9285]

This fixes an issue introduced in DEV-9285 that prevented a prefix/suffix from showing in tooltips. This fix shows it only on the first item.

## Testing Steps

Create a chart with the "onlyShowTopPrefixSuffix", ensure that the prefix/suffix is visible on the first item in the tooltip.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

Before:

![Screenshot 2024-12-02 at 2 30 08 PM](https://github.com/user-attachments/assets/67e0a437-7907-4414-9159-67c1bb23751e)

After:

![Screenshot 2024-12-02 at 2 29 38 PM](https://github.com/user-attachments/assets/9317271a-6dac-4a46-9447-52e6bf502b3d)

## Additional Notes

<!-- Add any additional notes about this PR -->
