### PR TITLE
Fix [DEV-9860] feedback

### DIFF
--- a/packages/map/src/components/Legend/components/index.scss
+++ b/packages/map/src/components/Legend/components/index.scss
@@ -112,11 +112,6 @@
 
         &:not(.vertical-sorted, .legend-container__ul--single-column, .single-row) {
           width: 100%;
-          @include breakpoint(sm) {
-            .legend-container__li {
-              width: 50%;
-            }
-          }
         }
         .legend-container__li {
           flex-shrink: 0;

--- a/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
+++ b/packages/map/src/components/UsaMap/components/Territory/Territory.Hexagon.tsx
@@ -176,7 +176,7 @@ const TerritoryHexagon = ({
 
   return (
     territoryData && (
-      <svg viewBox='0 0 45 51' className='territory-wrapper--hex'>
+      <svg viewBox='-1 -1 46 53' className='territory-wrapper--hex'>
         <g {...props} data-tooltip-html={dataTooltipHtml} data-tooltip-id={dataTooltipId} onClick={handleShapeClick}>
           <polygon
             stroke={stroke}


### PR DESCRIPTION
## [DEV-9860](https://websupport-cdc.msappproxy.net/browse/DEV-9860)

<img width="702" alt="Screenshot 2024-12-04 at 3 29 42 PM" src="https://github.com/user-attachments/assets/0a93c76f-a08f-4524-bdb6-3e238fd84710">

## Testing Steps

### Long legend items overflowing
1. Create or view map with long legend items
2. Observe that items should wrap before they overflow

### Hex territories 
1. Open map
2. Observe hex territory icons are not cut off

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

