### PR TITLE
Fix/Dev-9917 Highlight option was disabled from the Bar graph

### DIFF
--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1347,6 +1347,9 @@ const EditorPanel = () => {
     updateConfig(updatedConfig)
   }
 
+  const hasDynamicCategory = ![undefined, '- Select - '].includes(config.series?.[0]?.dynamicCategory)
+  const hasMultipleSeries = config.series?.length > 1
+
   const editorContextValues = {
     addNewExclusion,
     data,
@@ -3704,7 +3707,7 @@ const EditorPanel = () => {
                     </>
                   } */}
                   <Select
-                    display={config.series?.length > 1}
+                    display={hasDynamicCategory || hasMultipleSeries}
                     value={config.legend.behavior}
                     section='legend'
                     fieldName='behavior'


### PR DESCRIPTION
## Fix/Dev-9917
https://websupport.cdc.gov/browse/DEV-9917

Made the option to Isolate or Highlight a bar graph in the Legend when there are multiple bars on a singular xAxis point.

## Testing Steps

Scenario: Upload [dev-9917-config.json](https://github.com/user-attachments/files/18026134/dev-9917-config.json) and click on the Configuration tab, and click on the tools icon in the Bar graph visualization 
Expected: There is a bar graph with multiple bars and multiple legend icons. 

1. In the Legend, click USA
Expected: The Canada and Germany bars have been removed and USA has been Isolated

2. Open the Legend tab on the left
3. Under the "Legend Behavior (When Clicked)," change Isolate to Highlight
Expected: The Canada and Germany bars have returned and USA has been Highlighted

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings


## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
