### PR TITLE
Fix [X-Axis] Last tick overflow

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -613,7 +613,7 @@ const CdcChart = ({
   const resizeObserver = new ResizeObserver(entries => {
     for (let entry of entries) {
       let { width, height } = entry.contentRect
-      const svgMarginWidth = 35
+      const svgMarginWidth = 15
       const editorWidth = 350
 
       width = isEditor ? width - editorWidth : width

--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -613,11 +613,12 @@ const CdcChart = ({
   const resizeObserver = new ResizeObserver(entries => {
     for (let entry of entries) {
       let { width, height } = entry.contentRect
-      let editorWidth = 350
+      const svgMarginWidth = 35
+      const editorWidth = 350
 
       width = isEditor ? width - editorWidth : width
 
-      let newViewport = getViewport(width)
+      const newViewport = getViewport(width)
 
       setCurrentViewport(newViewport)
 
@@ -625,7 +626,7 @@ const CdcChart = ({
         width = width - 2.5
       }
 
-      width = width
+      width = width - svgMarginWidth
 
       setDimensions([width, height])
     }

--- a/packages/core/components/Layout/components/Visualization/visualizations.scss
+++ b/packages/core/components/Layout/components/Visualization/visualizations.scss
@@ -1,6 +1,6 @@
 .cdc-open-viz-module {
   .cdc-chart-inner-container .cove-component__content {
-    padding: 25px 0px !important;
+    padding: 25px 35px 25px 0 !important;
   }
   &.isEditor {
     overflow: auto;

--- a/packages/core/components/Layout/components/Visualization/visualizations.scss
+++ b/packages/core/components/Layout/components/Visualization/visualizations.scss
@@ -1,6 +1,6 @@
 .cdc-open-viz-module {
   .cdc-chart-inner-container .cove-component__content {
-    padding: 25px 35px 25px 0 !important;
+    padding: 25px 15px 25px 0 !important;
   }
   &.isEditor {
     overflow: auto;


### PR DESCRIPTION
## [No Ticket]

Last tick sometimes overflows the bounds of the viz

### Solution
Add Padding
Force wrap if tick is close to edge

## Testing Steps

1. Open linear chart with long tick close to edge (Storybook ex: components-templates-chart--multiple-lines)
2. Observe tick should not overflow

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

### Before
<img width="906" alt="Screenshot 2024-12-06 at 11 31 10 AM" src="https://github.com/user-attachments/assets/d08324f3-6822-401e-b17d-cb2b1c9406ff">

### After
<img width="882" alt="Screenshot 2024-12-06 at 11 30 36 AM" src="https://github.com/user-attachments/assets/15fc5593-fe50-454a-b939-b09f18150ab4">