### PR TITLE
Fix/Dev-9951 Dashboard Filter Used By rows Duplicating

### DIFF
--- a/packages/core/components/MultiSelect/multiselect.styles.css
+++ b/packages/core/components/MultiSelect/multiselect.styles.css
@@ -71,3 +71,7 @@
     }
   }
 }
+
+.accordion__panel .cove-multiselect .dropdown {
+  position: relative;
+}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -363,20 +363,23 @@ const FilterEditor: React.FC<FilterEditorProps> = ({ filter, config, updateFilte
               {isNestedDropDown && <APIInputs isSubgroup={true} />}
 
               {!!parentFilters.length && (
-                <MultiSelect
-                  label='Parent Filter(s): '
-                  options={parentFilters.map(key => ({ value: key, label: key }))}
-                  fieldName='parents'
-                  selected={filter.parents}
-                  updateField={(_section, _subsection, _fieldname, newItems) => {
-                    updateFilterProp('parents', newItems)
-                  }}
-                />
+                <label>
+                  <span className='edit-label column-heading mt-1'>Used By: </span>
+                  <MultiSelect
+                    label='Parent Filter(s): '
+                    options={parentFilters.map(key => ({ value: key, label: key }))}
+                    fieldName='parents'
+                    selected={filter.parents}
+                    updateField={(_section, _subsection, _fieldname, newItems) => {
+                      updateFilterProp('parents', newItems)
+                    }}
+                  />
+                </label>
               )}
 
-              <MultiSelect
-                label='Used By: (optional)'
-                tooltip={
+              <label>
+                <span className='edit-label column-heading mt-1'>
+                  Used By: (optional)
                   <Tooltip style={{ textTransform: 'none' }}>
                     <Tooltip.Target>
                       <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -388,17 +391,19 @@ const FilterEditor: React.FC<FilterEditorProps> = ({ filter, config, updateFilte
                       </p>
                     </Tooltip.Content>
                   </Tooltip>
-                }
-                options={[...usedByOptions, ...(filter.usedBy || [])].map(opt => ({
-                  value: opt,
-                  label: usedByNameLookup[opt]
-                }))}
-                fieldName='usedBy'
-                selected={filter.usedBy}
-                updateField={(_section, _subsection, _fieldname, newItems) => {
-                  updateFilterProp('usedBy', newItems)
-                }}
-              />
+                </span>
+                <MultiSelect
+                  options={usedByOptions.map(opt => ({
+                    value: opt,
+                    label: usedByNameLookup[opt]
+                  }))}
+                  fieldName='usedBy'
+                  selected={filter.usedBy}
+                  updateField={(_section, _subsection, _fieldname, newItems) => {
+                    updateFilterProp('usedBy', newItems)
+                  }}
+                />
+              </label>
 
               <TextField
                 label='Reset Label: '


### PR DESCRIPTION
## DEV-9951
https://websupport.cdc.gov/browse/DEV-9951

Used By section has a title 
the rows are not repeating
dropdown to select the rows is appearing 
rows can be added and deleted

## Testing Steps

Scenario: Upload [dev-9951-config.json](https://github.com/user-attachments/files/18081715/dev-9951-config.json) and open the Configuration tab. Then click on the tools icon on the Filter Dropdowns.
Expected: There is a Quarter filter.

1. Open the Filters section in the Accordion
2. Open the Quarter filter
3. Scroll down to the Used By section

Expected:
  - There is a "USED BY: (OPTIONAL)" Title
  - In the Used By selection area, there are Rows 2, 3, 5, 6, and 7. And they do not have duplicates.
  - Clicking on the down arrow in will create a dropdown with options of Rows to select from.

## Self Review

- I have added testing steps for reviewers
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
