### PR TITLE
Fix/dev 9951 dashboard filter used by rows duplication

### DIFF
--- a/packages/core/components/Legend/Legend.Gradient.tsx
+++ b/packages/core/components/Legend/Legend.Gradient.tsx
@@ -38,7 +38,7 @@ const LegendGradient = ({
 
   const numTicks = colors?.length
 
-  const longestLabel = labels && labels.length > 0 ? labels.reduce((a, b) => (a.length > b.length ? a : b)) : ''
+  const longestLabel = (labels || []).reduce((a: string, b) => (a.length > String(b).length ? a : b), '')
   const boxHeight = 20
   let height = 50
 

--- a/packages/core/components/MultiSelect/multiselect.styles.css
+++ b/packages/core/components/MultiSelect/multiselect.styles.css
@@ -71,3 +71,7 @@
     }
   }
 }
+
+.accordion__panel .cove-multiselect .dropdown {
+  position: relative;
+}

--- a/packages/dashboard/src/CdcDashboard.tsx
+++ b/packages/dashboard/src/CdcDashboard.tsx
@@ -13,8 +13,8 @@ import { InitialState } from './types/InitialState'
 import { DashboardConfig } from './types/DashboardConfig'
 import { coveUpdateWorker } from '@cdc/core/helpers/coveUpdateWorker'
 import _ from 'lodash'
-import { hasDashboardApplyBehavior } from './helpers/hasDashboardApplyBehavior'
 import { getQueryParams } from '@cdc/core/helpers/queryStringUtils'
+import { shouldLoadUnfilteredDataset } from './helpers/shouldLoadUnfilteredDataset'
 
 type MultiDashboardProps = Omit<WCMSProps, 'configUrl'> & {
   configUrl?: string
@@ -67,9 +67,12 @@ const MultiDashboardWrapper: React.FC<MultiDashboardProps> = ({
     let datasets: Record<string, Object[]> = {}
     await Promise.all(
       Object.keys(initialConfig.datasets).map(async key => {
-        const legacySupportApply = (initialConfig as any).filterBehavior === 'Apply Button'
-        const hasApplyBehavior = hasDashboardApplyBehavior(initialConfig.visualizations) || legacySupportApply
-        const data = await processData(initialConfig.datasets[key], !hasApplyBehavior)
+        const activeDashboard = (initialConfig as MultiDashboardConfig).activeDashboard
+        const activeConfig =
+          activeDashboard !== undefined
+            ? (initialConfig as MultiDashboardConfig).multiDashboards[activeDashboard]
+            : initialConfig
+        const data = await processData(initialConfig.datasets[key], shouldLoadUnfilteredDataset(activeConfig, key))
         datasets[key] = data || []
       })
     )

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -101,58 +101,56 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
         const formGroupClass = `form-group mr-3 mb-1${loading ? ' loading-filter' : ''}`
 
         return (
-          <>
-            <div className={formGroupClass} key={`${label}-filtersection-${filterIndex}`}>
-              {label && (
-                <label className='font-weight-bold mt-1 mb-0' htmlFor={`filter-${filterIndex}`}>
-                  {label}
-                </label>
-              )}
-              {filter.filterStyle === FILTER_STYLE.multiSelect ? (
-                <MultiSelect
-                  label={label}
-                  options={multiValues}
-                  fieldName={filterIndex}
-                  updateField={updateField}
-                  selected={filter.active as string[]}
-                  limit={filter.selectLimit || 5}
-                  loading={loading}
-                />
-              ) : filter.filterStyle === FILTER_STYLE.nestedDropdown ? (
-                <NestedDropdown
-                  activeGroup={filter.active as string}
-                  activeSubGroup={filter.subGrouping?.active}
-                  filterIndex={filterIndex}
-                  options={getNestedDropdownOptions(apiFilterDropdowns[_key])}
-                  listLabel={label}
-                  handleSelectedItems={value => updateField(null, null, filterIndex, value)}
-                  loading={loading}
-                />
-              ) : (
-                <>
-                  <select
-                    id={`filter-${filterIndex}`}
-                    className='cove-form-select'
-                    data-index='0'
-                    value={loading ? 'Loading...' : filter.queuedActive || filter.active}
-                    onChange={val => {
-                      handleOnChange(filterIndex, val.target.value)
-                    }}
-                    disabled={loading ? true : values.length === 1 && !nullVal(filter)}
-                  >
-                    {loading && <option value='Loading...'>Loading...</option>}
-                    {nullVal(filter) && (
-                      <option key={`select`} value=''>
-                        {filter.resetLabel || '- Select -'}
-                      </option>
-                    )}
-                    {values}
-                  </select>
-                  {loading && <Loader spinnerType={'text-secondary'} />}
-                </>
-              )}
-            </div>
-          </>
+          <div className={formGroupClass} key={`${label}-filtersection-${filterIndex}`}>
+            {label && (
+              <label className='text-capitalize font-weight-bold mt-1 mb-0' htmlFor={`filter-${filterIndex}`}>
+                {label}
+              </label>
+            )}
+            {filter.filterStyle === FILTER_STYLE.multiSelect ? (
+              <MultiSelect
+                label={label}
+                options={multiValues}
+                fieldName={filterIndex}
+                updateField={updateField}
+                selected={filter.active as string[]}
+                limit={filter.selectLimit || 5}
+                loading={loading}
+              />
+            ) : filter.filterStyle === FILTER_STYLE.nestedDropdown ? (
+              <NestedDropdown
+                activeGroup={filter.active as string}
+                activeSubGroup={filter.subGrouping?.active}
+                filterIndex={filterIndex}
+                options={getNestedDropdownOptions(apiFilterDropdowns[_key])}
+                listLabel={label}
+                handleSelectedItems={value => updateField(null, null, filterIndex, value)}
+                loading={loading}
+              />
+            ) : (
+              <>
+                <select
+                  id={`filter-${filterIndex}`}
+                  className='cove-form-select'
+                  data-index='0'
+                  value={loading ? 'Loading...' : filter.queuedActive || filter.active}
+                  onChange={val => {
+                    handleOnChange(filterIndex, val.target.value)
+                  }}
+                  disabled={loading ? true : values.length === 1 && !nullVal(filter)}
+                >
+                  {loading && <option value='Loading...'>Loading...</option>}
+                  {nullVal(filter) && (
+                    <option key={`select`} value=''>
+                      {filter.resetLabel || '- Select -'}
+                    </option>
+                  )}
+                  {values}
+                </select>
+                {loading && <Loader spinnerType={'text-secondary'} />}
+              </>
+            )}
+          </div>
         )
       })}
       {showSubmit && (

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -363,20 +363,23 @@ const FilterEditor: React.FC<FilterEditorProps> = ({ filter, config, updateFilte
               {isNestedDropDown && <APIInputs isSubgroup={true} />}
 
               {!!parentFilters.length && (
-                <MultiSelect
-                  label='Parent Filter(s): '
-                  options={parentFilters.map(key => ({ value: key, label: key }))}
-                  fieldName='parents'
-                  selected={filter.parents}
-                  updateField={(_section, _subsection, _fieldname, newItems) => {
-                    updateFilterProp('parents', newItems)
-                  }}
-                />
+                <label>
+                  <span className='edit-label column-heading mt-1'>Used By: </span>
+                  <MultiSelect
+                    label='Parent Filter(s): '
+                    options={parentFilters.map(key => ({ value: key, label: key }))}
+                    fieldName='parents'
+                    selected={filter.parents}
+                    updateField={(_section, _subsection, _fieldname, newItems) => {
+                      updateFilterProp('parents', newItems)
+                    }}
+                  />
+                </label>
               )}
 
-              <MultiSelect
-                label='Used By: (optional)'
-                tooltip={
+              <label>
+                <span className='edit-label column-heading mt-1'>
+                  Used By: (optional)
                   <Tooltip style={{ textTransform: 'none' }}>
                     <Tooltip.Target>
                       <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -388,17 +391,19 @@ const FilterEditor: React.FC<FilterEditorProps> = ({ filter, config, updateFilte
                       </p>
                     </Tooltip.Content>
                   </Tooltip>
-                }
-                options={[...usedByOptions, ...(filter.usedBy || [])].map(opt => ({
-                  value: opt,
-                  label: usedByNameLookup[opt]
-                }))}
-                fieldName='usedBy'
-                selected={filter.usedBy}
-                updateField={(_section, _subsection, _fieldname, newItems) => {
-                  updateFilterProp('usedBy', newItems)
-                }}
-              />
+                </span>
+                <MultiSelect
+                  options={usedByOptions.map(opt => ({
+                    value: opt,
+                    label: usedByNameLookup[opt]
+                  }))}
+                  fieldName='usedBy'
+                  selected={filter.usedBy}
+                  updateField={(_section, _subsection, _fieldname, newItems) => {
+                    updateFilterProp('usedBy', newItems)
+                  }}
+                />
+              </label>
 
               <TextField
                 label='Reset Label: '

--- a/packages/dashboard/src/helpers/apiFilterHelpers.ts
+++ b/packages/dashboard/src/helpers/apiFilterHelpers.ts
@@ -135,7 +135,10 @@ export const setAutoLoadDefaultValue = (
   const sharedFiltersCopy = _.cloneDeep(sharedFilters)
   const sharedFilter = _.cloneDeep(sharedFiltersCopy[sharedFilterIndex])
   if (!autoLoadFilterIndexes.length || !dropdownOptions?.length) return sharedFilter // no autoLoading happening
-  if (autoLoadFilterIndexes.includes(sharedFilterIndex) || sharedFilter.setByQueryParameter) {
+  const hasQueryParameter = sharedFilter.setByQueryParameter
+    ? Boolean(getQueryParam(sharedFilter.setByQueryParameter))
+    : false
+  if (autoLoadFilterIndexes.includes(sharedFilterIndex) || hasQueryParameter) {
     const filterParents = sharedFiltersCopy.filter(f => sharedFilter.parents?.includes(f.key))
     const notAllParentFiltersSelected = filterParents.some(p => !(p.active || p.queuedActive))
     if (filterParents && notAllParentFiltersSelected) return sharedFilter

--- a/packages/dashboard/src/helpers/shouldLoadAllFilters.ts
+++ b/packages/dashboard/src/helpers/shouldLoadAllFilters.ts
@@ -4,12 +4,12 @@ import { Visualization } from '@cdc/core/types/Visualization'
 export const shouldLoadAllFilters = (config): boolean => {
   const autoLoad = Boolean(getQueryParam('cove-auto-load'))
   if (autoLoad) {
-    const currentDashboardVisualizations = config.multiDashboards
-      ? config.multiDashboards[config.activeDashboard].visualizations
-      : config.visualizations
-    const dataKeys = Object.values(currentDashboardVisualizations)
+    const activeConfig = config.multiDashboards ? config.multiDashboards[config.activeDashboard] : config
+    const rowDataSetKeys = activeConfig.rows.map(row => row.dataKey).filter(Boolean)
+    const dataKeys = Object.values(activeConfig.visualizations)
       .map((visualization: Visualization) => visualization.dataKey)
       .filter(Boolean)
+      .concat(rowDataSetKeys)
     const missingData = dataKeys.find(dataset => !config.datasets[dataset].data?.length)
     return Boolean(missingData)
   }

--- a/packages/dashboard/src/helpers/shouldLoadUnfilteredDataset.ts
+++ b/packages/dashboard/src/helpers/shouldLoadUnfilteredDataset.ts
@@ -1,0 +1,24 @@
+import { AnyVisualization } from '@cdc/core/types/Visualization'
+import { MultiDashboard } from '../types/MultiDashboard'
+import { hasDashboardApplyBehavior } from './hasDashboardApplyBehavior'
+import _ from 'lodash'
+import { DashboardConfig } from '../types/DashboardConfig'
+
+export const shouldLoadUnfilteredDataset = (config: MultiDashboard | DashboardConfig, datasetKey: string) => {
+  const legacySupportApply = (config as any).filterBehavior === 'Apply Button'
+  const hasApplyBehavior = hasDashboardApplyBehavior(config.visualizations) || legacySupportApply
+  const datasetUsedByVisualizations = Object.keys(config.visualizations).filter(vizKey => {
+    const viz = config.visualizations[vizKey] as AnyVisualization
+    return viz.dataKey === datasetKey
+  })
+  const datasetUsedByRows = config.rows.reduce((acc, row, index) => {
+    if (row.dataKey === datasetKey) acc.push(index)
+    return acc
+  }, [])
+  const datasetIsUsedByCurrentTab = Boolean(datasetUsedByVisualizations.length || datasetUsedByRows.length)
+
+  const datasetIsNotFiltered = !config.dashboard.sharedFilters.find(
+    filter => _.intersection(filter.usedBy, [...datasetUsedByVisualizations, ...datasetUsedByRows]).length
+  )
+  return !hasApplyBehavior && datasetIsUsedByCurrentTab && datasetIsNotFiltered
+}

--- a/packages/dashboard/src/helpers/tests/shouldLoadAllFilters.test.ts
+++ b/packages/dashboard/src/helpers/tests/shouldLoadAllFilters.test.ts
@@ -1,11 +1,10 @@
-import { MultiDashboardConfig } from '../../types/MultiDashboard'
 import { shouldLoadAllFilters } from '../shouldLoadAllFilters'
 
 describe('shouldLoadAllFilters', () => {
   it('returns false if not autoloading', () => {
     delete window.location
     window.location = new URL('https://www.example.com')
-    expect(shouldLoadAllFilters({})).toBe(false)
+    expect(shouldLoadAllFilters({ rows: [] })).toBe(false)
   })
   it('returns true if missing data', () => {
     delete window.location
@@ -16,6 +15,7 @@ describe('shouldLoadAllFilters', () => {
           dataKey: 'abcd'
         }
       },
+      rows: [],
       datasets: {
         abcd: {
           data: []
@@ -31,6 +31,7 @@ describe('shouldLoadAllFilters', () => {
               dataKey: 'abcd'
             }
           },
+          rows: [],
           datasets: {
             abcd: {
               data: []
@@ -56,6 +57,7 @@ describe('shouldLoadAllFilters', () => {
           datakey: 'abcd'
         }
       },
+      rows: [],
       datasets: {
         abcd: {
           data: [{}]

--- a/packages/dashboard/src/helpers/tests/shouldLoadUnfilteredDataset.test.ts
+++ b/packages/dashboard/src/helpers/tests/shouldLoadUnfilteredDataset.test.ts
@@ -1,0 +1,80 @@
+import { shouldLoadUnfilteredDataset } from '../shouldLoadUnfilteredDataset'
+import { MultiDashboard } from '../../types/MultiDashboard'
+import { DashboardConfig } from '../../types/DashboardConfig'
+import { AnyVisualization } from '@cdc/core/types/Visualization'
+
+describe('shouldLoadUnfilteredDataset', () => {
+  it('should return false when hasApplyBehavior is true', () => {
+    const config: MultiDashboard | DashboardConfig = {
+      filterBehavior: 'Apply Button',
+      visualizations: {},
+      rows: [],
+      dashboard: { sharedFilters: [] }
+    }
+    const datasetKey = 'dataset1'
+
+    const result = shouldLoadUnfilteredDataset(config, datasetKey)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true when the dataset is used by visualizations and not filtered', () => {
+    const config: MultiDashboard | DashboardConfig = {
+      visualizations: {
+        viz1: { dataKey: 'dataset1' } as AnyVisualization
+      },
+      rows: [],
+      dashboard: { sharedFilters: [] }
+    }
+    const datasetKey = 'dataset1'
+
+    const result = shouldLoadUnfilteredDataset(config, datasetKey)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return true when the dataset is used by rows and not filtered', () => {
+    const config: MultiDashboard | DashboardConfig = {
+      visualizations: {},
+      rows: [{ dataKey: 'dataset1' }],
+      dashboard: { sharedFilters: [] }
+    }
+    const datasetKey = 'dataset1'
+
+    const result = shouldLoadUnfilteredDataset(config, datasetKey)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false when the dataset is filtered', () => {
+    const config: MultiDashboard | DashboardConfig = {
+      visualizations: {
+        viz1: { dataKey: 'dataset1' } as AnyVisualization
+      },
+      rows: [],
+      dashboard: {
+        sharedFilters: [{ usedBy: ['viz1'] }]
+      }
+    }
+    const datasetKey = 'dataset1'
+
+    const result = shouldLoadUnfilteredDataset(config, datasetKey)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false when the dataset is not used by current tab', () => {
+    const config: MultiDashboard | DashboardConfig = {
+      visualizations: {
+        viz1: { dataKey: 'dataset2' } as AnyVisualization
+      },
+      rows: [{ dataKey: 'dataset2' }],
+      dashboard: { sharedFilters: [] }
+    }
+    const datasetKey = 'dataset1'
+
+    const result = shouldLoadUnfilteredDataset(config, datasetKey)
+
+    expect(result).toBe(false)
+  })
+})


### PR DESCRIPTION
## DEV-9951
https://websupport.cdc.gov/browse/DEV-9951

Used By section has a title 
the rows are not repeating
dropdown to select the rows is appearing 
rows can be added and deleted

## Testing Steps

Scenario: Upload [dev-9951-config.json](https://github.com/user-attachments/files/18081715/dev-9951-config.json) and open the Configuration tab. Then click on the tools icon on the Filter Dropdowns.
Expected: There is a Quarter filter.

1. Open the Filters section in the Accordion
2. Open the Quarter filter
3. Scroll down to the Used By section
Expected:
1. There is a "USED BY: (OPTIONAL)" Title
2. In the Used By selection area, there are Rows 2, 3, 5, 6, and 7. And they do not have duplicates.
3. Clicking on the down arrow in will create a dropdown with options of Rows to select from.

## Self Review

- I have added testing steps for reviewers
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
