### PR TITLE
Enchancement/Fix Dev-9448 Hide Toggle on Data Reset Scenario

### DIFF
--- a/packages/dashboard/src/components/VisualizationRow.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.tsx
@@ -122,9 +122,6 @@ const VisualizationRow: React.FC<VizRowProps> = ({
   }
   return (
     <div className={`row${row.equalHeight ? ' equal-height' : ''}${row.toggle ? ' toggle' : ''}`} key={`row__${index}`}>
-      {row.toggle && (
-        <Toggle row={row} visualizations={config.visualizations} active={show.indexOf(true)} setToggled={setToggled} />
-      )}
       {row.columns.map((col, colIndex) => {
         if (col.width) {
           if (!col.widget) return <div key={`row__${index}__col__${colIndex}`} className={`col col-${col.width}`}></div>
@@ -163,6 +160,14 @@ const VisualizationRow: React.FC<VizRowProps> = ({
                 hideVisualization ? ' hide-parent-visualization' : ' mt-5 p-1'
               }`}
             >
+              {row.toggle && !hideVisualization && (
+                <Toggle
+                  row={row}
+                  visualizations={config.visualizations}
+                  active={show.indexOf(true)}
+                  setToggled={setToggled}
+                />
+              )}
               <VisualizationWrapper
                 allExpanded={allExpanded}
                 currentViewport={currentViewport}


### PR DESCRIPTION
## No new ticket - Based off Dev-9448
https://websupport.cdc.gov/browse/DEV-9448

Hide the toggle buttons on in no Data scenario

## Testing Steps

Scenario: Upload [dev-9448-Hide-Toggle-config.json](https://github.com/user-attachments/files/18082867/dev-9448-Hide-Toggle-config.json) and open Dashboard Preview
Expected: There are 2 dashboard filter with no selections made. The "Please complete your selection to continue." message is shown with no results
1. Make selections for both filters
2. Press View Results

Expected: There is a table with toggles of "Table" and "Chart" that were no showing when there was no data.

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
