### PR TITLE
Fix/Dev-9988 Apply button can be clicked with empty filters

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -166,7 +166,17 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
         )
       })}
       {showSubmit && (
-        <button className='btn btn-primary mb-1' onClick={applyFilters}>
+        <button
+          className='btn btn-primary mb-1'
+          onClick={applyFilters}
+          disabled={show.some(filterIndex => {
+            const emptyFilterValues = [undefined, '', '- Select -']
+            return (
+              emptyFilterValues.includes(sharedFilters[filterIndex].queuedActive) &&
+              emptyFilterValues.includes(sharedFilters[filterIndex].active)
+            )
+          })}
+        >
           {applyFiltersButtonText || 'GO!'}
         </button>
       )}


### PR DESCRIPTION
## Dev-9988
https://websupport.cdc.gov/browse/DEV-9988

The Apply button is disabled until all filters are filled out

## Testing Steps

Scenario: Upload [dev-9988-config.json](https://github.com/user-attachments/files/18085390/dev-9988-config.json) and open Dashboard Preview
Expected: 2 Dashboard Filters with no options selected. The "View Results" button is grayed out and disabled

1. Click the View Results button
Expected: Nothing happens

2. Select a Topic and Location
Expected: The View Results button in no longer grayed out and is enabled

3. Click the View Results button
Expected: Button works as expected

4. Change the Topic filter
Expected: the View Results button is grayed out and disabled until you choose a location.

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
