### PR TITLE
Enhancement/Fix - Dev-10060-Footnotes are showing in Data Reset Scenario

### DIFF
--- a/packages/dashboard/src/components/VisualizationRow.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.tsx
@@ -315,7 +315,7 @@ const VisualizationRow: React.FC<VizRowProps> = ({
         }
         return <React.Fragment key={`vis__${index}__${colIndex}`}></React.Fragment>
       })}
-      {row.footnotesId ? (
+      {row.footnotesId && !inNoDataState ? (
         <FootnotesStandAlone
           isEditor={false}
           visualizationKey={row.footnotesId}


### PR DESCRIPTION
## Dev-10060

Footnotes hide on Data Reset Scenario

## Testing Steps

Scenario: Upload [Footnotes-remain-on-data-reset.json](https://github.com/user-attachments/files/18100125/Footnotes-remain-on-data-reset.json) and open Dashboard Preview
Expected: 4 Dashboard filters with no selections made. The "Please complete your selection to continue." message is in place of the visualizations.

1. Make a selection for all 4 filters and click View Results
Expectation: The visualizations show and when the tester scrolls down they will find the footnotes that start with "** Median value reported with no confidence intervals..."

2. Change a filter selection without pressing View Results
Expectation: The "Please complete your selection to continue." message is in place of the visualizations including the Footnotes.

## Self Review

- I have added testing steps for reviewers
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
