### PR TITLE
Fix/Dev-9978 MMRIA issues footnotes not filtering

### DIFF
--- a/packages/dashboard/src/components/VisualizationRow.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.tsx
@@ -96,7 +96,10 @@ const VisualizationRow: React.FC<VizRowProps> = ({
         // the multiViz filtering filtering is applied after the dashboard filters
         const categoryFootnote = footnoteConfig.formattedData.filter(d => d[row.multiVizColumn] === vizCategory)
         footnoteConfig.formattedData = categoryFootnote
+      } else {
+        footnoteConfig.formattedData = dashboardFilteredData[row.footnotesId]
       }
+
       return footnoteConfig
     }
     return null


### PR DESCRIPTION
## Dev-9978
https://websupport.cdc.gov/browse/DEV-9978

Footnotes filter based off dashboard filter

## Testing Steps

Scenario: Upload [dev-9978-config.json](https://github.com/user-attachments/files/18100671/dev-9978-config.json) and open Dashboard Preview
Expected: There is a Year filter and scrolling down there are Footnotes that start with "*In 2017–2019, race or ethnicity was..."

1. Select the year 2020 in the Year filter. 
Expected: The Footnotes have changed and now start with "*In 2020, race or ethnicity was missing..."

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
