### PR TITLE
Fix/Dev-10076 Parent filter section labeled incorrectly

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -364,7 +364,7 @@ const FilterEditor: React.FC<FilterEditorProps> = ({ filter, config, updateFilte
 
               {!!parentFilters.length && (
                 <label>
-                  <span className='edit-label column-heading mt-1'>Used By: </span>
+                  <span className='edit-label column-heading mt-1'>Parent Filter(s): </span>
                   <MultiSelect
                     label='Parent Filter(s): '
                     options={parentFilters.map(key => ({ value: key, label: key }))}


### PR DESCRIPTION
## Dev-10076

Correctly labeled Parent Filter

## Testing Steps

Scenario: Upload [dev-10076-config.json](https://github.com/user-attachments/files/18102591/dev-10076-config.json) and open Configuration. Click the tools icon on the second Filter Dropdowns
Expected: Dashboard filter with the title New Dashboard Filter 5

1. Click on Filters and open the filter
Expected: Scrolling down there is a Parent Filter(s) dropdown

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
