### PR TITLE
FIX:[DEV-9666a] Dashboard Reset Label: When present in the data set shouldn't appear twice

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -91,18 +91,23 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
           // Data Filter
           filter.values?.forEach((filterOption, index) => {
             const labeledOpt = filter.labels && filter.labels[filterOption]
-            values.push(
+            const shouldUnshift = (filterOption || labeledOpt) === filter.resetLabel
+            // add label to the front of list if it matches with reset label
+            values.splice(
+              shouldUnshift ? 0 : values.length,
+              0,
               <option key={`${filter.key}-option-${index}`} value={filterOption}>
                 {labeledOpt || filterOption}
               </option>
             )
+
             multiValues.push({ value: filterOption, label: labeledOpt || filterOption })
           })
         }
 
         const isDisabled = !values.length
-
-        if (filter.resetLabel) {
+        // push reset lanbel only if it does not includes in filter values  options
+        if (filter.resetLabel && !filter.values?.includes(filter?.resetLabel)) {
           values.unshift(
             <option key={`${filter.resetLabel}-option`} value={filter.resetLabel}>
               {filter.resetLabel}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -91,15 +91,22 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
           // Data Filter
           filter.values?.forEach((filterOption, index) => {
             const labeledOpt = filter.labels && filter.labels[filterOption]
-            const shouldUnshift = (filterOption || labeledOpt) === filter.resetLabel
-            // add label to the front of list if it matches with reset label
-            values.splice(
-              shouldUnshift ? 0 : values.length,
-              0,
-              <option key={`${filter.key}-option-${index}`} value={filterOption}>
-                {labeledOpt || filterOption}
-              </option>
-            )
+            const resetLabelHasMatch = (filterOption || labeledOpt) === filter.resetLabel
+
+            if (!resetLabelHasMatch) {
+              values.push(
+                <option key={`${filter.key}-option-${index}`} value={filterOption}>
+                  {labeledOpt || filterOption}
+                </option>
+              )
+            } else {
+              // add label to the front of list if it matches with reset label
+              values.unshift(
+                <option key={`${filter.key}-option-${index}`} value={filterOption}>
+                  {labeledOpt || filterOption}
+                </option>
+              )
+            }
 
             multiValues.push({ value: filterOption, label: labeledOpt || filterOption })
           })
@@ -107,7 +114,7 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
 
         const isDisabled = !values.length
         // push reset lanbel only if it does not includes in filter values  options
-        if (filter.resetLabel && !filter.values?.includes(filter?.resetLabel)) {
+        if (filter.resetLabel && !filter.values.includes(filter.resetLabel)) {
           values.unshift(
             <option key={`${filter.resetLabel}-option`} value={filter.resetLabel}>
               {filter.resetLabel}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -113,7 +113,7 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
         }
 
         const isDisabled = !values.length
-        // push reset lanbel only if it does not includes in filter values  options
+        // push reset label only if it does not includes in filter values  options
         if (filter.resetLabel && !filter.values.includes(filter.resetLabel)) {
           values.unshift(
             <option key={`${filter.resetLabel}-option`} value={filter.resetLabel}>

--- a/packages/dashboard/src/helpers/filterData.ts
+++ b/packages/dashboard/src/helpers/filterData.ts
@@ -24,7 +24,7 @@ function getMaxTierAndSetFilterTiers(filters: SharedFilter[]): number {
 }
 
 function filter(data = [], filters: SharedFilter[], condition) {
-  const activeFilters = filters.filter(f => f.resetLabel !== f.active)
+  const activeFilters = _.filter(filters, f => (f.resetLabel === f.active ? f.values?.includes(f.resetLabel) : true))
   return data.filter(row => {
     const foundMatchingFilter = activeFilters.find(filter => {
       const currentValue = row[filter.columnName]


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
 If reset label example "Florida" is exist in the list of filter values it should not be duplicated in the list.
see attached image. Reset label is Florida. from the list I removed second Florida.

<img width="1029" alt="Screenshot 2024-12-11 at 20 34 51" src="https://github.com/user-attachments/assets/f803baf9-a352-4a5f-b59b-c4be799c4120" />

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
