### PR TITLE
Fix/Dev Datasets saved in footnote's config

### DIFF
--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -491,11 +491,12 @@ export default function CdcDashboard({ initialState, isEditor = false, isDebug =
             body = (
               <>
                 <Header visualizationKey={visualizationKey} subEditor='Footnotes' />
+                {/* Datasets are passed in just for reference and need to be removed */}
                 <FootnotesStandAlone
                   visualizationKey={visualizationKey}
                   config={{ ...visualizationConfig, datasets: state.config.datasets }}
                   isEditor={true}
-                  updateConfig={_updateConfig}
+                  updateConfig={conf => _updateConfig(_.omit(conf, 'datasets'))}
                 />
               </>
             )


### PR DESCRIPTION
## Dev-10048
https://websupport.cdc.gov/browse/DEV-10048

Datasets are not saved in footnote's config

## Testing Steps

Scenario: Upload [dev-10048-config.json](https://github.com/user-attachments/files/18117875/dev-10048-config.json) and open the Configuration Tab. 
Expected: There is a single Bar visualization

1. Click on Add Footnotes on the Bar Visualization
2. Select valid-data-chart.csv from the Select a footnote dataset
3. Click Back to Dashboard
4. Click Advanced Options
5. Scroll down to Visualizations and then footnotes1734040286223
Expected: The footnotes config does not have datasets saved in it's config

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
