### PR TITLE
FIX:[DEV-9666] New widget can't be add to a visualization box after an old widget is deleted

### DIFF
--- a/packages/dashboard/src/components/Widget.tsx
+++ b/packages/dashboard/src/components/Widget.tsx
@@ -74,9 +74,10 @@ const Widget = ({ widgetConfig, addVisualization, type }: WidgetProps) => {
 
   const deleteWidget = () => {
     if (!widgetConfig) return
+
     dispatch({
       type: 'DELETE_WIDGET',
-      payload: { rowIdx: widgetConfig.rowIdx, colIdx: widgetConfig.colIdx, uid: widgetConfig.uid }
+      payload: { uid: widgetConfig.uid as string }
     })
   }
 
@@ -102,7 +103,10 @@ const Widget = ({ widgetConfig, addVisualization, type }: WidgetProps) => {
 
   const editWidget = () => {
     if (!widgetConfig) return
-    dispatch({ type: 'UPDATE_VISUALIZATION', payload: { vizKey: widgetConfig.uid, configureData: { editing: true } } })
+    dispatch({
+      type: 'UPDATE_VISUALIZATION',
+      payload: { vizKey: widgetConfig.uid as string, configureData: { editing: true } }
+    })
     loadSampleData()
   }
 

--- a/packages/dashboard/src/store/dashboard.actions.ts
+++ b/packages/dashboard/src/store/dashboard.actions.ts
@@ -9,7 +9,7 @@ import { SharedFilter } from '../types/SharedFilter'
 type ADD_FOOTNOTE = Action<'ADD_FOOTNOTE', { id: string; rowIndex: number; config: Footnotes }>
 type ADD_VISUALIZATION = Action<'ADD_VISUALIZATION', { rowIdx: number; colIdx: number; newViz: AnyVisualization }>
 type APPLY_CONFIG = Action<'APPLY_CONFIG', [Config, Object?]>
-type DELETE_WIDGET = Action<'DELETE_WIDGET', { rowIdx: number; colIdx: number; uid: string }>
+type DELETE_WIDGET = Action<'DELETE_WIDGET', { uid: string }>
 type MOVE_VISUALIZATION = Action<
   'MOVE_VISUALIZATION',
   { rowIdx: number; colIdx: number; widget: AnyVisualization & { rowIdx: number; colIdx: number } }

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -203,11 +203,9 @@ const reducer = (state: DashboardState, action: DashboardActions): DashboardStat
       return { ...state, config: { ...state.config, rows: newRows } }
     }
     case 'DELETE_WIDGET': {
-      const { rowIdx, colIdx, uid } = action.payload
+      const { uid } = action.payload
       const newRows = _.cloneDeep(state.config.rows)
-      newRows[rowIdx].columns[colIdx].widget = null
       const newVisualizations = _.cloneDeep(state.config.visualizations)
-      delete newVisualizations[uid]
       const newSharedFilters = _.cloneDeep(state.config.dashboard.sharedFilters)
       if (newSharedFilters && newSharedFilters.length > 0) {
         newSharedFilters.forEach(sharedFilter => {
@@ -216,13 +214,19 @@ const reducer = (state: DashboardState, action: DashboardActions): DashboardStat
           }
         })
       }
+
+      const filteredRows = _.map(newRows, row => ({
+        ...row,
+        columns: _.filter(row.columns, column => column.widget !== uid)
+      }))
+
       return {
         ...state,
         config: {
           ...state.config,
           dashboard: { ...state.config.dashboard, sharedFilters: newSharedFilters },
           visualizations: newVisualizations,
-          rows: newRows
+          rows: filteredRows
         }
       }
     }


### PR DESCRIPTION
## [Replace With Ticket Number]
<img width="1495" alt="Screenshot 2024-12-17 at 18 52 15" src="https://github.com/user-attachments/assets/02af90f4-ef1a-40b1-8dac-65c6394c5a0c" />

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Open dashbpard. add Bar chart or line chart widgets, setup bars and come back to default page. remove widget and try to add new widget to the removed space.
Before fix: New widget cannot be added if old widget removed
After Fix: new widget can be added after removing old one.
<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
