### PR TITLE
Fix [Auto Padding] insufficient auto padding added

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -428,7 +428,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     const calculatedPadding = (nextTick - maxValue) / divideBy
 
     // if auto padding is too close to next tick, add one more ticks worth of padding
-    const PADDING_THRESHOLD = 0.024
+    const PADDING_THRESHOLD = 0.025
     const newPadding =
       calculatedPadding > PADDING_THRESHOLD ? calculatedPadding : calculatedPadding + tickGap / divideBy
 

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -437,7 +437,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   // Render Functions
   const generatePairedBarAxis = () => {
     const axisMaxHeight = bottomLabelStart + BOTTOM_LABEL_PADDING
-    // insufficient
     const getTickPositions = (ticks, xScale) => {
       if (!ticks.length) return false
       // filter out first index

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -426,10 +426,9 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     const nextTick = Math.max(...yScale.ticks(handleNumTicks)) + tickGap
     const divideBy = minValue < 0 ? maxValue / 2 : maxValue
     const calculatedPadding = (nextTick - maxValue) / divideBy
-    console.log('🧙‍♂️ ✨ useEffect ✨ calculatedPadding:', calculatedPadding)
 
     // if auto padding is too close to next tick, add one more ticks worth of padding
-    const PADDING_THRESHOLD = 0.02
+    const PADDING_THRESHOLD = 0.024
     const newPadding =
       calculatedPadding > PADDING_THRESHOLD ? calculatedPadding : calculatedPadding + tickGap / divideBy
 

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -127,7 +127,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   const isDateTime = config.xAxis.type === 'date-time'
   const suffixHasNoSpace = !suffix.includes(' ')
   const labelsOverflow = onlyShowTopPrefixSuffix && !suffixHasNoSpace
-  console.log('🧙‍♂️ ✨ LinearChart ✨ labelsOverflow:', labelsOverflow)
   const padding = orientation === 'horizontal' ? Number(config.xAxis.size) : Number(config.yAxis.size)
   const yLabelOffset = isNaN(parseInt(`${runtime.yAxis.labelOffset}`)) ? 0 : parseInt(`${runtime.yAxis.labelOffset}`)
 

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -127,6 +127,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   const isDateTime = config.xAxis.type === 'date-time'
   const suffixHasNoSpace = !suffix.includes(' ')
   const labelsOverflow = onlyShowTopPrefixSuffix && !suffixHasNoSpace
+  console.log('🧙‍♂️ ✨ LinearChart ✨ labelsOverflow:', labelsOverflow)
   const padding = orientation === 'horizontal' ? Number(config.xAxis.size) : Number(config.yAxis.size)
   const yLabelOffset = isNaN(parseInt(`${runtime.yAxis.labelOffset}`)) ? 0 : parseInt(`${runtime.yAxis.labelOffset}`)
 
@@ -425,13 +426,16 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     const nextTick = Math.max(...yScale.ticks(handleNumTicks)) + tickGap
     const divideBy = minValue < 0 ? maxValue / 2 : maxValue
     const calculatedPadding = (nextTick - maxValue) / divideBy
+    console.log('🧙‍♂️ ✨ useEffect ✨ calculatedPadding:', calculatedPadding)
 
     // if auto padding is too close to next tick, add one more ticks worth of padding
     const PADDING_THRESHOLD = 0.02
     const newPadding =
       calculatedPadding > PADDING_THRESHOLD ? calculatedPadding : calculatedPadding + tickGap / divideBy
 
-    setYAxisAutoPadding(newPadding * 100)
+    /* sometimes even though the padding is getting to the next tick exactly,
+    d3 still doesn't show the tick. we add 0.1 to ensure to tip it over the edge */
+    setYAxisAutoPadding(newPadding * 100 + 0.1)
   }, [maxValue, labelsOverflow, yScale, handleNumTicks])
 
   // Render Functions

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -437,6 +437,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   // Render Functions
   const generatePairedBarAxis = () => {
     const axisMaxHeight = bottomLabelStart + BOTTOM_LABEL_PADDING
+
     const getTickPositions = (ticks, xScale) => {
       if (!ticks.length) return false
       // filter out first index


### PR DESCRIPTION
## No Ticket

Problem: data was still overflowing despite auto-padding
cause: padding percentage was so minuscule that the js decimal math was throwing it off enough it wasn't enough to reach the next tick - and even if it did, since it was so close to the next tick the text would still overlap the data

solution: if the auto padding percentage is below a certain threshold (0.02), then add 1 tick worth of EXTRA padding to take it to the next tick.

## Testing Steps
1. Open 
[Respiratory-Virus-Activity-Age_relative.json](https://github.com/user-attachments/files/18212798/Respiratory-Virus-Activity-Age_relative.json) and click the "Influenza" tab
2. Observe that the data should not overflow the top tick and the text should not cover the data

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
