### PR TITLE
Fix[Auto Padding]: auto padding breaking when only one tick

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -420,8 +420,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     const maxValueIsGreaterThanTopGridLine = maxValue > Math.max(...yScale.ticks(handleNumTicks))
 
     if (!maxValueIsGreaterThanTopGridLine || !labelsOverflow) return
-
-    const tickGap = yScale.ticks(handleNumTicks)[1] - yScale.ticks(handleNumTicks)[0]
+    const ticks = yScale.ticks(handleNumTicks)
+    const tickGap = ticks.length === 1 ? ticks[0] : ticks[1] - ticks[0]
     const nextTick = Math.max(...yScale.ticks(handleNumTicks)) + tickGap
     const divideBy = minValue < 0 ? maxValue / 2 : maxValue
     const calculatedPadding = (nextTick - maxValue) / divideBy


### PR DESCRIPTION
## No Ticket

Chart breaking when auto padding on and only 1 tick is generated

## Testing Steps
1. use [trends-nhsn.json](https://github.com/user-attachments/files/18232852/trends-nhsn.json)
2. Select Arkansas
3. Observe it doesn't break

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
