### PR TITLE
PATCH Enhancement [dev-9990] filter order column

### DIFF
--- a/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
@@ -241,6 +241,17 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
                           handleFilterOrder={(index1, index2) => handleFilterOrder(index1, index2, filterIndex)}
                         />
                       )}
+                      {filter.order === 'column' && (
+                        <Select
+                          value={filter.orderColumn}
+                          fieldName='orderColumn'
+                          label='Order Column'
+                          updateField={(_section, _subSection, _field, value) =>
+                            updateFilterProp('orderColumn', filterIndex, value)
+                          }
+                          options={dataColumns}
+                        />
+                      )}
                     </>
                   ) : (
                     <NestedDropdownEditor

--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -41,7 +41,8 @@ export const filterOrderOptions: { label: string; value: OrderBy }[] = [
   {
     label: 'Custom',
     value: 'cust'
-  }
+  },
+  { label: 'Order By Data Column', value: 'column' }
 ]
 
 const hasStandardFilterBehavior = ['chart', 'table']

--- a/packages/core/components/Filters/helpers/handleSorting.ts
+++ b/packages/core/components/Filters/helpers/handleSorting.ts
@@ -7,6 +7,11 @@ export const handleSorting = singleFilter => {
     return singleFilter
   }
 
+  if (singleFilter.order === 'column') {
+    // sorting is done in the generateValuesForFilter function
+    return singleFilter
+  }
+
   const sort = (a, b) => {
     const asc = singleFilter.order !== 'desc'
     return String(asc ? a : b).localeCompare(String(asc ? b : a), 'en', { numeric: true })

--- a/packages/core/helpers/addValuesToFilters.ts
+++ b/packages/core/helpers/addValuesToFilters.ts
@@ -28,13 +28,16 @@ const cleanLookup = (lookup: Record<string, { values: string[]; orderedValues?: 
 // Gets filter values from dataset
 const generateValuesForFilter = (filter: VizFilter, data: any[] | MapData) => {
   const columnName = filter.columnName
+  const orderColumn = filter.orderColumn
   const values: string[] = []
+  const valuesWithOrders: [string, string][] = []
   const subGroupingColumn = filter.subGrouping?.columnName
   const subValues = cleanLookup(filter.subGrouping?.valuesLookup)
   if (Array.isArray(data)) {
     data.forEach(row => {
-      const value = row[columnName]
+      const value: string = row[columnName]
       if (value !== undefined && !values.includes(value)) {
+        if (orderColumn) valuesWithOrders.push([value, row[orderColumn]])
         values.push(value)
       }
       if (subGroupingColumn) {
@@ -57,12 +60,17 @@ const generateValuesForFilter = (filter: VizFilter, data: any[] | MapData) => {
       rows.forEach(row => {
         const value = row[columnName]
         if (value !== undefined && !values.includes(value)) {
+          if (orderColumn) valuesWithOrders.push([value, row[orderColumn]])
           values.push(value)
         }
       })
     })
   }
-  filter.values = values
+  if (orderColumn) {
+    filter.values = valuesWithOrders.sort((a, b) => a[1].localeCompare(b[1])).map(([value]) => value)
+  } else {
+    filter.values = values
+  }
   if (subGroupingColumn) {
     filter.subGrouping.valuesLookup = subValues
   }

--- a/packages/core/types/VizFilter.ts
+++ b/packages/core/types/VizFilter.ts
@@ -1,4 +1,4 @@
-export type OrderBy = 'asc' | 'desc' | 'cust'
+export type OrderBy = 'asc' | 'desc' | 'cust' | 'column'
 
 export type FilterBase = {
   columnName: string
@@ -23,6 +23,7 @@ export type GeneralFilter = FilterBase & {
   filterStyle: VizFilterStyle
   label: string
   order: OrderBy
+  orderColumn?: string
   orderedValues?: string[] // should only exist if the order is 'cust'
   queryParameter: string
   setByQueryParameter: string


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: Upload [dev-9990.json](https://websupport.cdc.gov/secure/attachment/72969/72969_dev-9990.json) and navigate to the visualization panel.

1) click on the tools icon next to the table widget.

Expected: data should appear unordered in the table.

2) under the filters accordion add a new filter.
3) select 'Text' as the filter.

Expected: by default the filter options will be sorted alphabetically

4) change Filter Order to "Order by Data Column"
5) Select OrderCol as the Order Column.

Expected: The filter options should now be in the order: this, is, the, order.

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
