### PR TITLE
[DEV-6661] Update US Territories and Freely Associated States on Stat…

### DIFF
--- a/packages/core/helpers/coveUpdateWorker.ts
+++ b/packages/core/helpers/coveUpdateWorker.ts
@@ -10,6 +10,7 @@ import update_4_24_7 from './ver/4.24.7'
 import update_4_24_9 from './ver/4.24.9'
 import versionNeedsUpdate from './ver/versionNeedsUpdate'
 import update_4_24_10 from './ver/4.24.10'
+import update_4_25_1 from './ver/4.25.1'
 
 export const coveUpdateWorker = config => {
   let genConfig = config
@@ -20,7 +21,8 @@ export const coveUpdateWorker = config => {
     ['4.24.5', update_4_24_5],
     ['4.24.7', update_4_24_7, true],
     ['4.24.9', update_4_24_9],
-    ['4.24.10', update_4_24_10]
+    ['4.24.10', update_4_24_10],
+    ['4.25.1', update_4_25_1]
   ]
 
   versions.forEach(([version, updateFunction, alwaysRun]: [string, UpdateFunction, boolean?]) => {

--- a/packages/core/helpers/ver/4.25.1.ts
+++ b/packages/core/helpers/ver/4.25.1.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 const removeTerritoriesLabel = config => {
-  if (config.general.territoriesLabel) {
+  if (config.general?.territoriesLabel) {
     delete config.general.territoriesLabel
   }
   return config

--- a/packages/core/helpers/ver/4.25.1.ts
+++ b/packages/core/helpers/ver/4.25.1.ts
@@ -1,0 +1,18 @@
+import _ from 'lodash'
+
+const removeTerritoriesLabel = config => {
+  if (config.general.territoriesLabel) {
+    delete config.general.territoriesLabel
+  }
+  return config
+}
+
+const update_4_25_1 = config => {
+  const ver = '4.25.1'
+  const newConfig = _.cloneDeep(config)
+  removeTerritoriesLabel(config)
+  newConfig.version = ver
+  return newConfig
+}
+
+export default update_4_25_1

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -1686,16 +1686,6 @@ const EditorPanel = ({ columnsRequiredChecker }) => {
                 }
               />
               {'us' === state.general.geoType && (
-                <TextField
-                  value={general.territoriesLabel}
-                  updateField={updateField}
-                  section='general'
-                  fieldName='territoriesLabel'
-                  label='Territories Label'
-                  placeholder='Territories'
-                />
-              )}
-              {'us' === state.general.geoType && (
                 <label className='checkbox'>
                   <input
                     type='checkbox'

--- a/packages/map/src/components/UsaMap/components/TerritoriesSection.tsx
+++ b/packages/map/src/components/UsaMap/components/TerritoriesSection.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+
+type TerritoriesSectionProps = {
+  territories: JSX.Element[]
+  logo: string
+  config: any
+}
+
+const TerritoriesSection: React.FC<TerritoriesSectionProps> = ({ territories, logo, config }) => {
+  const usTerritories = territories
+    .filter(territory => {
+      return ['US-AS', 'US-GU', 'US-MP', 'US-PR', 'US-VI'].includes(territory.props.territory)
+    })
+    .sort((a, b) => {
+      return a.props.territory.localeCompare(b.props.territory)
+    })
+
+  const freelyAssociatedStates = territories
+    .filter(territory => {
+      return ['US-FM', 'US-MH', 'US-PW'].includes(territory.props.territory)
+    })
+    .sort((a, b) => {
+      return a.props.territory.localeCompare(b.props.territory)
+    })
+
+  return (
+    territories.length > 0 && (
+      <>
+        {/* Temporarily make the max width fit the image width */}
+        <div>
+          <div className='d-flex mt-4'>
+            {'data' === config.general.type && logo && (
+              <img src={logo} alt='' className='map-logo' style={{ maxWidth: '50px' }} />
+            )}
+          </div>
+          <div>
+            {usTerritories.length > 0 && (
+              <>
+                <h5>US Territories:</h5>
+                <span className='mt-1 mb-2 d-flex flex-wrap territories'>{usTerritories}</span>
+              </>
+            )}
+            {freelyAssociatedStates.length > 0 && (
+              <>
+                <h5>Freely Associated States:</h5>
+                <span className='mt-1 mb-2 d-flex flex-wrap territories'>{freelyAssociatedStates}</span>
+              </>
+            )}
+          </div>
+        </div>
+      </>
+    )
+  )
+}
+
+export default TerritoriesSection

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -27,6 +27,7 @@ import { checkColorContrast, getContrastColor } from '@cdc/core/helpers/cove/acc
 import { getGeoFillColor, getGeoStrokeColor } from '../../../helpers/colors'
 import { handleMapAriaLabels } from '../../../helpers/handleMapAriaLabels'
 import { titleCase } from '../../../helpers/titleCase'
+import TerritoriesSection from './TerritoriesSection'
 
 const { features: unitedStates } = feature(topoJSON, topoJSON.objects.states)
 const { features: unitedStatesHex } = feature(hexTopoJSON, hexTopoJSON.objects.states)
@@ -586,22 +587,7 @@ const UsaMap = () => {
         {annotations.length > 0 && <Annotation.Draggable onDragStateChange={handleDragStateChange} />}
       </svg>
 
-      {territories.length > 0 && (
-        <>
-          {/* Temporarily make the max width fit the image width */}
-          <div>
-            <div className='d-flex mt-2'>
-              <h5>{general.territoriesLabel}</h5>
-              {'data' === general.type && logo && (
-                <img src={logo} alt='' className='map-logo' style={{ maxWidth: '50px' }} />
-              )}
-            </div>
-            <div>
-              <span className='mt-1 mb-2 d-flex flex-wrap territories'>{territories}</span>
-            </div>
-          </div>
-        </>
-      )}
+      <TerritoriesSection territories={territories} logo={logo} config={state} />
     </ErrorBoundary>
   )
 }

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -12,7 +12,6 @@ export default {
     showDownloadMediaButton: false,
     displayAsHex: false,
     displayStateLabels: false,
-    territoriesLabel: 'Territories',
     territoriesAlwaysShow: false,
     language: 'en',
     geoType: 'single-state',


### PR DESCRIPTION
## [DEV-6661]
The map key should be updated to accurately distinguish between US territories and freely associated states. There is a [CDC style](https://www.cdc.gov/island-affairs/about/index.html) from the Office of Island Affairs that could be helpful in either consolidating or accurately dividing the two groups. This is critical to ensure equal representation among these jurisdictions and the 50 states. 

**US Territories:**

- American Samoa (AS)
- Commonwealth of the Northern Mariana Islands (CNMI)
- Guam (GU)
- Puerto Rico (PR)
- US Virgin Islands (USVI)

**Freely Associated States:**

- Federated States of Micronesia (FM)
- Republic of the Marshall Islands (RMI)
- Republic of Palau (PW)

## Testing Steps
- [ ] yarn storybook
- [ ] Open (local link)[http://localhost:6006/?path=/story/components-templates-map--equal-interval-map]

## Self Review
- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
