### PR TITLE
enhancement [DEV-10068] Mobile font sizes for charts

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -27,7 +27,7 @@ import CategoricalYAxis from './Axis/Categorical.Axis'
 
 // Helpers
 import { isConvertLineToBarGraph } from '../helpers/isConvertLineToBarGraph'
-import { isLegendWrapViewport } from '@cdc/core/helpers/viewports'
+import { isLegendWrapViewport, isMobileHeightViewport } from '@cdc/core/helpers/viewports'
 import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 import { calcInitialHeight } from '../helpers/sizeHelpers'
 
@@ -53,8 +53,10 @@ const X_TICK_LABEL_PADDING = 4.5
 const DEFAULT_TICK_LENGTH = 8
 const MONTH_AS_MS = 1000 * 60 * 60 * 24 * 30
 const TICK_LABEL_FONT_SIZE = 16
+const TICK_LABEL_FONT_SIZE_SMALL = 13
+const AXIS_LABEL_FONT_SIZE = 18
+const AXIS_LABEL_FONT_SIZE_SMALL = 14
 const TICK_LABEL_MARGIN_RIGHT = 4.5
-const GET_TEXT_WIDTH_FONT = `normal ${TICK_LABEL_FONT_SIZE}px Nunito, sans-serif`
 
 const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, parentWidth }, svgRef) => {
   // prettier-ignore
@@ -131,6 +133,9 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   const labelsOverflow = onlyShowTopPrefixSuffix && !suffixHasNoSpace
   const padding = orientation === 'horizontal' ? Number(config.xAxis.size) : Number(config.yAxis.size)
   const yLabelOffset = isNaN(parseInt(`${runtime.yAxis.labelOffset}`)) ? 0 : parseInt(`${runtime.yAxis.labelOffset}`)
+  const tickLabelFontSize = isMobileHeightViewport(currentViewport) ? TICK_LABEL_FONT_SIZE_SMALL : TICK_LABEL_FONT_SIZE
+  const axisLabelFontSize = isMobileHeightViewport(currentViewport) ? AXIS_LABEL_FONT_SIZE_SMALL : AXIS_LABEL_FONT_SIZE
+  const GET_TEXT_WIDTH_FONT = `normal ${tickLabelFontSize}px Nunito, sans-serif`
 
   // zero if not forest plot
   const forestRowsHeight = isForestPlot ? config.data.length * config.forestPlot.rowHeight : 0
@@ -504,7 +509,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                           angle={-angle}
                           verticalAnchor={angle ? 'middle' : 'start'}
                           textAnchor={textAnchor}
-                          fontSize={TICK_LABEL_FONT_SIZE}
+                          fontSize={tickLabelFontSize}
                         >
                           {formatNumber(tick.value, 'left')}
                         </Text>
@@ -552,7 +557,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             angle={-angle}
                             verticalAnchor={angle ? 'middle' : 'start'}
                             textAnchor={textAnchor}
-                            fontSize={TICK_LABEL_FONT_SIZE}
+                            fontSize={tickLabelFontSize}
                           >
                             {formatNumber(tick.value, 'left')}
                           </Text>
@@ -570,6 +575,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                     stroke='#333'
                     textAnchor={'middle'}
                     verticalAnchor='start'
+                    fontSize={axisLabelFontSize}
                   >
                     {runtime.xAxis.label}
                   </Text>
@@ -646,6 +652,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       transform={`translate(${-1 * runtime.yAxis.size + yLabelOffset}, ${axisCenter}) rotate(-90)`}
                       fontWeight='bold'
                       fill={config.yAxis.labelColor}
+                      fontSize={axisLabelFontSize}
                     >
                       {props.label}
                     </Text>
@@ -1056,7 +1063,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                               to={isLogarithmicAxis ? to : tick.to}
                               stroke={config.yAxis.tickColor}
                               display={orientation === 'horizontal' ? 'none' : 'block'}
-                              fontSize={TICK_LABEL_FONT_SIZE}
+                              fontSize={tickLabelFontSize}
                             />
                           )}
 
@@ -1074,7 +1081,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                 }) rotate(-${config.runtime.horizontal ? config.runtime.yAxis.tickRotation || 0 : 0})`}
                                 verticalAnchor={'start'}
                                 textAnchor={'end'}
-                                fontSize={TICK_LABEL_FONT_SIZE}
+                                fontSize={tickLabelFontSize}
                               >
                                 {tick.formattedValue}
                               </Text>
@@ -1090,7 +1097,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                 }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
                                 verticalAnchor={'start'}
                                 textAnchor={'end'}
-                                fontSize={TICK_LABEL_FONT_SIZE}
+                                fontSize={tickLabelFontSize}
                               >
                                 {tick.formattedValue}
                               </Text>
@@ -1105,7 +1112,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                 }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
                                 textAnchor={'end'}
                                 verticalAnchor='middle'
-                                fontSize={TICK_LABEL_FONT_SIZE}
+                                fontSize={tickLabelFontSize}
                               >
                                 {tick.formattedValue}
                               </Text>
@@ -1121,7 +1128,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                 }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
                                 textAnchor={'end'}
                                 verticalAnchor='middle'
-                                fontSize={TICK_LABEL_FONT_SIZE}
+                                fontSize={tickLabelFontSize}
                               >
                                 {tick.formattedValue}
                               </Text>
@@ -1140,7 +1147,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                   verticalAnchor={config.runtime.horizontal ? 'start' : 'middle'}
                                   textAnchor={config.runtime.horizontal ? 'start' : 'end'}
                                   fill={config.yAxis.tickLabelColor}
-                                  fontSize={TICK_LABEL_FONT_SIZE}
+                                  fontSize={tickLabelFontSize}
                                 >
                                   {config.runtime.seriesLabelsAll[tick.formattedValue - 1]}
                                 </Text>
@@ -1183,7 +1190,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                     paintOrder={'stroke'} // keeps stroke under fill
                                     strokeLinejoin='round'
                                     style={{ whiteSpace: 'pre-wrap' }} // prevents leading spaces from being trimmed
-                                    fontSize={TICK_LABEL_FONT_SIZE}
+                                    fontSize={tickLabelFontSize}
                                   >
                                     {suffix}
                                   </BlurStrokeText>
@@ -1205,7 +1212,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                   strokeLinejoin='round'
                                   paintOrder={'stroke'} // keeps stroke under fill
                                   style={{ whiteSpace: 'pre-wrap' }} // prevents leading spaces from being trimmed
-                                  fontSize={TICK_LABEL_FONT_SIZE}
+                                  fontSize={tickLabelFontSize}
                                 >
                                   {`${tick.formattedValue}${combineDomSuffixWithValue ? suffix : ''}`}
                                 </BlurStrokeText>
@@ -1221,6 +1228,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       transform={`translate(${-1 * runtime.yAxis.size + yLabelOffset}, ${axisCenter}) rotate(-90)`}
                       fontWeight='bold'
                       fill={config.yAxis.labelColor}
+                      fontSize={axisLabelFontSize}
                     >
                       {props.label}
                     </Text>
@@ -1283,7 +1291,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                               verticalAnchor={runtime.horizontal ? 'start' : 'middle'}
                               textAnchor={'start'}
                               fill={config.yAxis.rightAxisTickLabelColor}
-                              fontSize={TICK_LABEL_FONT_SIZE}
+                              fontSize={tickLabelFontSize}
                             >
                               {tick.formattedValue}
                             </Text>
@@ -1303,6 +1311,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       }, ${axisCenter}) rotate(-90)`}
                       fontWeight='bold'
                       fill={config.yAxis.rightAxisLabelColor}
+                      fontSize={axisLabelFontSize}
                     >
                       {props.label}
                     </Text>
@@ -1481,7 +1490,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                   : undefined
                               }
                               fill={config.xAxis.tickLabelColor}
-                              fontSize={TICK_LABEL_FONT_SIZE}
+                              fontSize={tickLabelFontSize}
                             >
                               {tick.formattedValue}
                             </Text>
@@ -1499,6 +1508,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       verticalAnchor='start'
                       fontWeight='bold'
                       fill={config.xAxis.labelColor}
+                      fontSize={axisLabelFontSize}
                     >
                       {props.label}
                     </Text>


### PR DESCRIPTION
## [DEV-10068](https://websupport-cdc.msappproxy.net/browse/DEV-10068)

specs from [Fonts, Spacing, and Elements in Charts [UX-1249]](https://uxpreview.cdc.gov/3GE5EW/?id=6cg4ol&p=fonts__spacing__and_elements_in_charts__ux-1249_&sc=3&g=15)

## Testing Steps
1. open linear chart in mobile view
2. confirm tick labels are 13px
3. confirm axis labels are 14px

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

