### PR TITLE
Enhancement [DEV-10066] axis label character limit

### DIFF
--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1633,6 +1633,7 @@ const EditorPanel = () => {
                         fieldName='label'
                         label='Label '
                         updateField={updateField}
+                        maxLength={35}
                       />
                       {config.runtime.seriesKeys &&
                         config.runtime.seriesKeys.length === 1 &&
@@ -2306,6 +2307,7 @@ const EditorPanel = () => {
                     fieldName='rightLabel'
                     label='Label'
                     updateField={updateField}
+                    maxLength={35}
                   />
                   <TextField
                     value={config.yAxis.rightNumTicks}
@@ -2596,6 +2598,7 @@ const EditorPanel = () => {
                         fieldName='label'
                         label='Label'
                         updateField={updateField}
+                        maxLength={35}
                       />
 
                       {config.xAxis.type === 'continuous' && (


### PR DESCRIPTION
## [DEV-10066](https://websupport-cdc.msappproxy.net/browse/DEV-10066)

Add character limit to axis labels

## Testing Steps

1. Open editor
2. try and type more than 35 characters in the axis label field
3. confirm you are restricted from doing so

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
