### PR TITLE
FIX:[DEV-10195]   Pie chart: Hover showing wrong decimals

### DIFF
--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -143,11 +143,19 @@ export const useTooltip = props => {
       })
 
       if (visualizationType === 'Pie') {
+        const roundTo = Number(config.dataFormat.roundTo) || 0
+
+        const degrees = ((arc.endAngle - arc.startAngle) * 180) / Math.PI
+
+        // Calculate the percentage of the full circle (360 degrees)
+        const percentageOfCircle = (degrees / 360) * 100
+        const roundedPercentage = percentageOfCircle.toFixed(roundTo)
+
         tooltipItems.push(
           // ignore
           [config.xAxis.dataKey, pieChartData],
           [config.runtime.yAxis.dataKey, formatNumber(arc?.data[config.runtime.yAxis.dataKey])],
-          ['Percent', `${Math.round((((arc?.endAngle - arc?.startAngle) * 180) / Math.PI / 360) * 100) + '%'}`]
+          ['Percent', `${roundedPercentage + '%'}`]
         )
       }
 


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Open Pie Chart
Update decimal point to 1 and hover on Pie, 
the tooltips should follow decimal point updates.
See attached image resul:
<img width="973" alt="Screenshot 2025-01-06 at 09 22 08" src="https://github.com/user-attachments/assets/edf1d3d2-f6e8-41de-a271-0d429171c34c" />

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
