### PR TITLE
Fix/Dev-9866 Nested Dropdowns on Viz level Filters on  Maps

### DIFF
--- a/packages/core/helpers/addValuesToFilters.ts
+++ b/packages/core/helpers/addValuesToFilters.ts
@@ -136,12 +136,11 @@ export const addValuesToFilters = (filters: VizFilter[], data: any[] | MapData):
         values: filterCopy.subGrouping.valuesLookup[groupName].values
       }
       const queryStringFilterValue = getQueryStringFilterValue(subGroupingFilter)
-      const groupActive = filterCopy.active || filterCopy.values[0]
+      const groupActive = groupName || filterCopy.values[0]
       const defaultValue = filterCopy.subGrouping.valuesLookup[groupActive as string].values[0]
       // if the value doesn't exist in the subGrouping then return the default
-      const filteredLookupValues = Object.values(filterCopy.subGrouping.valuesLookup).flatMap(v => v.values)
       const activeValue = queryStringFilterValue || filterCopy.subGrouping.active
-      filterCopy.subGrouping.active = filteredLookupValues.includes(activeValue) ? activeValue : defaultValue
+      filterCopy.subGrouping.active = activeValue || defaultValue
     }
     return filterCopy
   })

--- a/packages/core/helpers/tests/addValuesToFilters.test.ts
+++ b/packages/core/helpers/tests/addValuesToFilters.test.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { VizFilter } from '../../types/VizFilter'
 import { addValuesToFilters } from '../addValuesToFilters'
 import { describe, it, expect, vi } from 'vitest'
+import { FILTER_STYLE } from '@cdc/dashboard/src/types/FilterStyles'
 
 describe('addValuesToFilters', () => {
   const parentFilter = { columnName: 'parentColumn', id: 11, active: 'apple', values: [] } as VizFilter
@@ -36,7 +37,11 @@ describe('addValuesToFilters', () => {
     //expect(newFilters[1].values).toEqual([])
   })
   it('works for nested dropdowns', () => {
-    const nestedParentFilter = { ...parentFilter, subGrouping: { columnName: 'childColumn' } }
+    const nestedParentFilter = {
+      ...parentFilter,
+      filterStyle: FILTER_STYLE.nestedDropdown,
+      subGrouping: { columnName: 'childColumn' }
+    }
     const newFilters = addValuesToFilters([nestedParentFilter], data)
     expect(newFilters[0].values).toEqual(['apple', 'pear'])
     expect(newFilters[0].subGrouping.valuesLookup).toEqual({ apple: { values: ['a', 'b'] }, pear: { values: ['c'] } })


### PR DESCRIPTION
## Dev-9866

Nested dropdown Filters are working on the Viz Level Maps

## Testing Steps

Scenario: Upload [dev-9866-config.json](https://websupport.cdc.gov/secure/attachment/73170/73170_dev-9866-config.json) open the Configuration tab, and open the map editor

Expected: There is a Map of the US with no filters. 

1. Open the Filters Accordion
2. Add Filter
3. Select Nested Dropdown from the Filter Style
4. Select STATE as the Grouping and Rate as the Subgrouping
5. Make selections in the Nested Dropdown

Expected: The Map will highlight the state with the correct data.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

I named the branch patch-fix/dev-9866-nested-dropdown-maps since there was already a fix/dev-9866... branch
