### PR TITLE
PATCH fix [dev-10273] viz filter editor not showing selected parents

### DIFF
--- a/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/VizFilterEditor.tsx
@@ -285,6 +285,7 @@ const VizFilterEditor: React.FC<VizFilterProps> = ({ config, updateField, rawDat
                         updateFilterProp('parents', filterIndex, value)
                       }}
                       options={getParentFilterOptions(filterIndex)}
+                      selected={config.filters[filterIndex].parents}
                     />
                   </label>
                 </FieldSetWrapper>


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

1) upload 
[explore-by-topic-2025-01-09.json](https://github.com/user-attachments/files/18398614/explore-by-topic-2025-01-09.json)
2) navigate to the filter accordion for the first map visualization editor.
3) expand the second filter accordion.

Expected: you should see an item under the "filter parents" selection.

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
