### PR TITLE
PATCH FIX/dev-9866 Nested Dropdown filter availability - maps

### DIFF
--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -125,7 +125,7 @@ export const useFilters = props => {
         queryParams[newFilter?.subGrouping?.setByQueryParameter] = newFilter.subGrouping.active
         updateQueryString(queryParams)
       }
-      setFilteredData(newFilters[index])
+      setFilteredData(newFilters)
     }
 
     if (!visualizationConfig.dynamicSeries) {

--- a/packages/core/helpers/addValuesToFilters.ts
+++ b/packages/core/helpers/addValuesToFilters.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import { getQueryStringFilterValue } from '@cdc/core/helpers/queryStringUtils'
 import { VizFilter } from '../types/VizFilter'
+import { FILTER_STYLE } from '@cdc/dashboard/src/types/FilterStyles'
 
 type Filter = {
   columnName: string
@@ -80,7 +81,7 @@ const handleVizParents = (filter: VizFilter, data: any[] | MapData, filtersLooku
   let filteredData = Array.isArray(data) ? data : Object.values(data).flat(1)
   filter.parents.forEach(parentKey => {
     const parent = filtersLookup[parentKey]
-    if (parent?.filterStyle === 'nested-dropdown') {
+    if (parent?.filterStyle === FILTER_STYLE.nestedDropdown) {
       const { subGrouping } = parent as VizFilter
       if (subGrouping?.active) {
         filteredData = filteredData.filter(d => {
@@ -115,11 +116,11 @@ export const addValuesToFilters = (filters: VizFilter[], data: any[] | MapData):
       filteredData = handleVizParents(filter as VizFilter, data, filtersLookup)
     }
     generateValuesForFilter(filterCopy, filteredData)
-    if (filterCopy.values.length > 0) {
+    if (filterCopy.values?.length > 0) {
       const queryStringFilterValue = getQueryStringFilterValue(filterCopy)
       if (queryStringFilterValue) {
         filterCopy.active = queryStringFilterValue
-      } else if (filterCopy.filterStyle === 'multi-select') {
+      } else if (filterCopy.filterStyle === FILTER_STYLE.multiSelect) {
         const defaultValues = filterCopy.values
         const active = Array.isArray(filterCopy.active) ? filterCopy.active : [filterCopy.active]
         filterCopy.active = active.filter(val => includes(defaultValues, val))
@@ -129,19 +130,10 @@ export const addValuesToFilters = (filters: VizFilter[], data: any[] | MapData):
         filterCopy.active = includes(filterCopy.values, active) ? active : defaultValue
       }
     }
-    if (filterCopy.subGrouping) {
-      const groupName = filterCopy.active as string
-      const subGroupingFilter = {
-        ...filterCopy.subGrouping,
-        values: filterCopy.subGrouping.valuesLookup[groupName].values
-      }
-      const queryStringFilterValue = getQueryStringFilterValue(subGroupingFilter)
-      const groupActive = filterCopy.active || filterCopy.values[0]
-      const defaultValue = filterCopy.subGrouping.valuesLookup[groupActive as string].values[0]
-      // if the value doesn't exist in the subGrouping then return the default
-      const filteredLookupValues = Object.values(filterCopy.subGrouping.valuesLookup).flatMap(v => v.values)
-      const activeValue = queryStringFilterValue || filterCopy.subGrouping.active
-      filterCopy.subGrouping.active = filteredLookupValues.includes(activeValue) ? activeValue : defaultValue
+    if (filterCopy.subGrouping && filterCopy.filterStyle === FILTER_STYLE.nestedDropdown) {
+      const subGroupingDefault = filterCopy.subGrouping.valuesLookup[filterCopy.active as string].values[0]
+      const subGroupingActive = filterCopy.subGrouping.active
+      filter.subGrouping.active = subGroupingActive ? subGroupingActive : subGroupingDefault
     }
     return filterCopy
   })

--- a/packages/core/helpers/addValuesToFilters.ts
+++ b/packages/core/helpers/addValuesToFilters.ts
@@ -130,10 +130,18 @@ export const addValuesToFilters = (filters: VizFilter[], data: any[] | MapData):
         filterCopy.active = includes(filterCopy.values, active) ? active : defaultValue
       }
     }
-    if (filterCopy.subGrouping && filterCopy.filterStyle === FILTER_STYLE.nestedDropdown) {
-      const subGroupingDefault = filterCopy.subGrouping.valuesLookup[filterCopy.active as string].values[0]
-      const subGroupingActive = filterCopy.subGrouping.active
-      filter.subGrouping.active = subGroupingActive ? subGroupingActive : subGroupingDefault
+    if (filterCopy.subGrouping) {
+      const groupName = filterCopy.active as string
+      const subGroupingFilter = {
+        ...filterCopy.subGrouping,
+        values: filterCopy.subGrouping.valuesLookup[groupName].values
+      }
+      const queryStringFilterValue = getQueryStringFilterValue(subGroupingFilter)
+      const groupActive = groupName || filterCopy.values[0]
+      const defaultValue = filterCopy.subGrouping.valuesLookup[groupActive as string].values[0]
+      // if the value doesn't exist in the subGrouping then return the default
+      const activeValue = queryStringFilterValue || filterCopy.subGrouping.active
+      filterCopy.subGrouping.active = activeValue || defaultValue
     }
     return filterCopy
   })

--- a/packages/core/helpers/filterVizData.ts
+++ b/packages/core/helpers/filterVizData.ts
@@ -36,9 +36,9 @@ export const filterVizData = (filters: Filter[], data) => {
         }
         if (filter.filterStyle === 'nested-dropdown' && filter.subGrouping && add === true) {
           const subGroupActive = filter.subGrouping.active
-          const value = row[filter.subGrouping.columnName]
+          const subGroupValue = row[filter.subGrouping.columnName]
           if (subGroupActive === undefined) return
-          if (value != subGroupActive) {
+          if (subGroupValue != subGroupActive) {
             add = false
           }
         }

--- a/packages/core/helpers/tests/addValuesToFilters.test.ts
+++ b/packages/core/helpers/tests/addValuesToFilters.test.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { VizFilter } from '../../types/VizFilter'
 import { addValuesToFilters } from '../addValuesToFilters'
 import { describe, it, expect, vi } from 'vitest'
+import { FILTER_STYLE } from '@cdc/dashboard/src/types/FilterStyles'
 
 describe('addValuesToFilters', () => {
   const parentFilter = { columnName: 'parentColumn', id: 11, active: 'apple', values: [] } as VizFilter
@@ -36,7 +37,11 @@ describe('addValuesToFilters', () => {
     //expect(newFilters[1].values).toEqual([])
   })
   it('works for nested dropdowns', () => {
-    const nestedParentFilter = { ...parentFilter, subGrouping: { columnName: 'childColumn' } }
+    const nestedParentFilter = {
+      ...parentFilter,
+      filterStyle: FILTER_STYLE.nestedDropdown,
+      subGrouping: { columnName: 'childColumn' }
+    }
     const newFilters = addValuesToFilters([nestedParentFilter], data)
     expect(newFilters[0].values).toEqual(['apple', 'pear'])
     expect(newFilters[0].subGrouping.valuesLookup).toEqual({ apple: { values: ['a', 'b'] }, pear: { values: ['c'] } })

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -981,10 +981,10 @@ const CdcMap = ({
               }
             }
           }
-          // Don't add additional rows with same UID
-          if (result[row.uid] === undefined) {
-            result[row.uid] = row
-          }
+        }
+        // Don't add additional rows with same UID
+        if (result[row.uid] === undefined) {
+          result[row.uid] = row
         }
       })
       return result

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -78,6 +78,7 @@ import useTooltip from './hooks/useTooltip'
 import { isSolrCsv, isSolrJson } from '@cdc/core/helpers/isSolr'
 import SkipTo from '@cdc/core/components/elements/SkipTo'
 import { getGeoFillColor } from './helpers/colors'
+import { SubGrouping } from '@cdc/core/types/VizFilter'
 
 // Data props
 const stateKeys = Object.keys(supportedStates)
@@ -970,18 +971,16 @@ const CdcMap = ({
           for (let i = 0; i < filters.length; i++) {
             const { columnName, active, type } = filters[i]
             if (type !== 'url' && !String(active).includes(String(row[columnName]))) return false // Bail out, not part of filter
+          }
+        }
 
-            // Don't add additional rows with same UID
-            if (result[row.uid] === undefined) {
-              if (runtimeFilters[0]?.filterStyle !== 'nested-dropdown') {
-                return (result[row.uid] = row)
-              } else if (
-                state.filters[0].subGrouping &&
-                row[state.filters[0].subGrouping.columnName] == state.filters[0].subGrouping.active
-              ) {
-                return (result[row.uid] = row)
-              }
-            }
+        // Don't add additional rows with same UID
+        if (result[row.uid] === undefined) {
+          const isNotNestedDropdown = runtimeFilters[0]?.filterStyle !== 'nested-dropdown'
+          const subGrouping = state.filters[0].subGrouping || ({} as SubGrouping)
+          const rowIsSelected = row[subGrouping.columnName] == subGrouping.active
+          if (isNotNestedDropdown || rowIsSelected) {
+            result[row.uid] = row
           }
         }
       })

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -980,10 +980,10 @@ const CdcMap = ({
                 return false // Bail out, data doesn't match the subgroup selection
               }
             }
-            // Don't add additional rows with same UID
-            if (result[row.uid] === undefined) {
-              result[row.uid] = row
-            }
+          }
+          // Don't add additional rows with same UID
+          if (result[row.uid] === undefined) {
+            result[row.uid] = row
           }
         }
       })

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -1818,7 +1818,6 @@ const CdcMap = ({
                 <Filters
                   config={state}
                   setConfig={setState}
-                  excludedData={state.data}
                   filteredData={runtimeFilters}
                   setFilteredData={setRuntimeFilters}
                   dimensions={dimensions}


### PR DESCRIPTION
## Dev-9866

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: Upload [dev-9866.config.json](https://github.com/user-attachments/files/18412453/dev-9866.config.json) open the Configuration tab, and open the map editor

Expected: There is a Map of the US with no filters.

1. Open the Filters Accordion
2. Add Filter
3. Select Nested Dropdown from the Filter Style
4. Select STATE as the Grouping and Rate as the Subgrouping
5. Make selections in the Nested Dropdown

Expected: The Map will highlight the state with the correct data.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
