### PR TITLE
[DEV-9281] Bar charts with no labels or borders fail non-text contrast

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.General.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.General.tsx
@@ -210,6 +210,10 @@ const PanelGeneral: FC<PanelProps> = props => {
                   </Tooltip.Target>
                   <Tooltip.Content>
                     <p>
+                      Recommended set to display for Section 508 compliance.
+                    </p>
+                    <hr/>
+                    <p>
                       Selecting this option will <i> not </i> hide the display of "zero value", "suppressed data", or
                       "missing data" indicators on the chart (if applicable).
                     </p>

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
@@ -138,6 +138,21 @@ const PanelVisual: FC<PanelProps> = props => {
         )}
         {visHasBarBorders() && (
           <Select
+            tooltip={
+              <Tooltip style={{ textTransform: 'none' }}>
+                <Tooltip.Target>
+                  <Icon
+                    display='question'
+                    style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
+                  />
+                </Tooltip.Target>
+                <Tooltip.Content>
+                  <p>
+                  Recommended set to display for Section 508 compliance.
+                  </p>
+                </Tooltip.Content>
+              </Tooltip>
+            }
             value={config.barHasBorder}
             fieldName='barHasBorder'
             label='Bar Borders'

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -13,7 +13,7 @@ export default {
   animate: false,
   lineDatapointStyle: 'hover',
   lineDatapointColor: 'Same as Line',
-  barHasBorder: 'false',
+  barHasBorder: 'true',
   isLollipopChart: false,
   lollipopShape: 'circle',
   lollipopColorStyle: 'two-tone',
@@ -188,7 +188,7 @@ export default {
     palette: 'monochrome-1',
     isPaletteReversed: false
   },
-  labels: false,
+  labels: true,
   dataFormat: {
     commas: false,
     prefix: '',


### PR DESCRIPTION
## [DEV-9281]

Bar chart labels and outline enabled by default, add tooltips recommending to remain enabled.

## Testing Steps

- Create a new bar chart or use a config that does not specify `barHasBorder` or `labels` (boolean)
  - Bar chart should have border and text labels by default
- Check editor for both options for tooltip that recommends the options be enabled

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

n/a

## Additional Notes

n/a
