### PR TITLE
[Bug] Resolve build issue due to duplicate declaration of currentView

### DIFF
--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -111,7 +111,6 @@ const CdcMap = ({
   const [isDraggingAnnotation, setIsDraggingAnnotation] = useState(false)
   const [loading, setLoading] = useState(true)
   const [displayPanel, setDisplayPanel] = useState(true)
-  const [currentViewport, setCurrentViewport] = useState<ViewPort>('lg')
   const [topoData, setTopoData] = useState<{}>({})
   const [runtimeFilters, setRuntimeFilters] = useState([])
   const [runtimeData, setRuntimeData] = useState({ init: true })


### PR DESCRIPTION
## <No Ticket>

Resolve `lerna build` error in maps due to duplicate declaration of `currentViewport`

## Testing Steps

- Run `lerna build` at cmd

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

n/a

## Additional Notes

It looks like the existing `currentViewport` observes screensize, whereas the new one was set to `lg` -- Any issue potential issue letting it continue to change size if needed?
