### PR TITLE
FIX : [DEV-10331]-Reverse Legend Labels - Right and Left

### DIFF
--- a/packages/chart/src/components/Legend/Legend.tsx
+++ b/packages/chart/src/components/Legend/Legend.tsx
@@ -20,7 +20,6 @@ const Legend = forwardRef((props, ref) => {
     getTextWidth
   } = useContext(ConfigContext)
   if (!config.legend) return null
-  // create fn to reverse labels while legend is Bottom.  Legend-right , legend-left works by default.
 
   const createLegendLabels = createFormatLabels(config, tableData, data, colorScale)
 

--- a/packages/chart/src/components/Legend/helpers/createFormatLabels.tsx
+++ b/packages/chart/src/components/Legend/helpers/createFormatLabels.tsx
@@ -16,10 +16,7 @@ export const createFormatLabels =
           })
         : labels
     const reverseLabels = labels => {
-      return config.legend.reverseLabelOrder &&
-        (config.legend?.position === 'bottom' || config.legend?.position === 'top')
-        ? sortVertical(labels).reverse()
-        : sortVertical(labels)
+      return config.legend.reverseLabelOrder ? sortVertical(labels).reverse() : sortVertical(labels)
     }
     const colorCode = config.legend?.colorCode
     if (visualizationType === 'Deviation Bar') {

--- a/packages/chart/src/scss/main.scss
+++ b/packages/chart/src/scss/main.scss
@@ -190,10 +190,6 @@
           flex-basis: auto;
         }
       }
-
-      &.double-column.reverse-items div.legend-item:last-child {
-        margin-bottom: 0.2rem !important;
-      }
     }
 
     .legend-item {


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
legend reverse labels feature in the legend has been corrected so that it works with top and bottom legends, but now it is not working in the right and left orientation.
<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
