### PR TITLE
Fix [DEV-10338] Superscript styles being overridden

### DIFF
--- a/packages/core/components/ui/Title/Title.scss
+++ b/packages/core/components/ui/Title/Title.scss
@@ -4,12 +4,13 @@
   margin: 0;
   color: var(--white);
 
-  sup {
+  h3 {
     font-size: var(--superTitle-font-size);
     font-family: var(--app-font-secondary);
     font-weight: 500;
     text-transform: uppercase;
     top: 0;
+    color: var(--white);
   }
 
   h2 {

--- a/packages/core/components/ui/Title/index.tsx
+++ b/packages/core/components/ui/Title/index.tsx
@@ -22,7 +22,7 @@ const Title = (props: HeaderProps) => {
     title &&
     showTitle && (
       <header className={updatedClasses.join(' ')} style={props.style}>
-        {superTitle && <sup>{parse(superTitle)}</sup>}
+        {superTitle && <h3>{parse(superTitle)}</h3>}
         <h2>
           {parse(title)} {isDashboard}
         </h2>


### PR DESCRIPTION
## [DEV-10338](https://websupport-cdc.msappproxy.net/browse/DEV-10338)

`<sup>` html markup should work in supertitle

## Testing Steps

1. Create or open chart
2. Add superscript tag to superTitle
3. Observe superscript shows up correctly

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)
<img width="805" alt="Screenshot 2025-01-21 at 3 16 12 PM" src="https://github.com/user-attachments/assets/9e6aa5c0-db98-4359-bcec-c8a373a5db0b" />
