### PR TITLE
[DEV-9281] Revert inititial chart label state

### DIFF
--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -188,7 +188,7 @@ export default {
     palette: 'monochrome-1',
     isPaletteReversed: false
   },
-  labels: true,
+  labels: false,
   dataFormat: {
     commas: false,
     prefix: '',


### PR DESCRIPTION
## [DEV-9281]

Revert to default labels off on all charts, including bar graphs, after concerns with text overlaps on most data per recent meeting.

## Testing Steps

- Create a new chart, or use a config that does not specify a `labels` option.
  - Charts should no longer display labels by default
  - Bar charts should continue to default to have borders on

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

n/a

## Additional Notes

n/a
