### PR TITLE
Enhancement [DEV-10198] make generic defaultSortBy for datatable

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -140,6 +140,10 @@ const CdcChart: React.FC<CdcChartProps> = ({
   const { lineDatapointClass, contentClasses, sparkLineStyles } = useDataVizClasses(config)
   const legendId = useId()
 
+  const hasDateAxis =
+    (config.xAxis || config.yAxis) && ['date-time', 'date'].includes((config.xAxis || config.yAxis).type)
+  const dataTableDefaultSortBy = hasDateAxis && config.xAxis.dataKey
+
   const checkLineToBarGraph = () => {
     return isConvertLineToBarGraph(config.visualizationType, filteredData, config.allowLineToBarGraph)
   }
@@ -973,6 +977,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
                     runtimeData={getTableRuntimeData()}
                     expandDataTable={config.table.expanded}
                     columns={config.columns}
+                    defaultSortBy={dataTableDefaultSortBy}
                     displayGeoName={name => name}
                     applyLegendToRow={applyLegendToRow}
                     tableTitle={config.table.label}

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -30,6 +30,7 @@ export type DataTableProps = {
   columns?: Record<string, Column>
   config: TableConfig
   dataConfig?: Object
+  defaultSortBy?: string
   displayGeoName?: Function
   expandDataTable: boolean
   formatLegendLocation?: Function
@@ -58,6 +59,7 @@ const DataTable = (props: DataTableProps) => {
   const {
     config,
     dataConfig,
+    defaultSortBy,
     tableTitle,
     vizTitle,
     rawData,
@@ -87,9 +89,6 @@ const DataTable = (props: DataTableProps) => {
   }, [parentRuntimeData, config.table.pivot?.columnName, config.table.pivot?.valueColumn])
 
   const [expanded, setExpanded] = useState(expandDataTable)
-  const hasDateAxis =
-    _.get(config, 'type') === 'chart' && _.includes(['date-time', 'date'], _.get(config, 'xAxis.type'))
-  const defaultSortBy = hasDateAxis && _.get(config, 'xAxis.dataKey')
   const [sortBy, setSortBy] = useState<any>({
     column: defaultSortBy || '',
     asc: false,


### PR DESCRIPTION
## [DEV-10198](https://websupport-cdc.msappproxy.net/browse/DEV-10198)

make generic defaultSortBy for datatable

## Testing Steps

1. Open chart with date axis
2. confirm sorting is newest to oldest

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
