### PR TITLE
enhancement [DEV-10198] remount data table if default sort changes

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -966,6 +966,9 @@ const CdcChart: React.FC<CdcChartProps> = ({
                   config.visualizationType !== 'Sankey') ||
                   (config.visualizationType === 'Sankey' && config.table.show)) && (
                   <DataTable
+                    /* changing the "key" will force the table to re-render
+                    when the default sort changes while editing */
+                    key={dataTableDefaultSortBy}
                     config={pivotDynamicSeries(config)}
                     rawData={
                       config.visualizationType === 'Sankey'


### PR DESCRIPTION
## [DEV-10198](https://websupport-cdc.msappproxy.net/browse/DEV-10198)

Problem: Time axis default sort not showing when changing from categorical in the editor
Solution: Remount datatable when default sort changes

## Testing Steps

1. create or open table
2. toggle between categorical and date axis
3. datatable should be sorting by date when date axis and should have no sort when categorical

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing