### PR TITLE
Fix/Dev-10215 Issue Opening Second Dashboard

### DIFF
--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -276,7 +276,7 @@ export default function CdcDashboard({ initialState, isEditor = false, isDebug =
     const loadAllFilters = shouldLoadAllFilters(config, isEditor && !isPreview)
     const sharedFiltersWithValues = addValuesToDashboardFilters(config.dashboard.sharedFilters, state.data)
 
-    loadAPIFilters(sharedFiltersWithValues, apiFilterDropdowns, loadAllFilters).then(newFilters => {
+    loadAPIFilters(sharedFiltersWithValues, apiFilterDropdowns, loadAllFilters)?.then(newFilters => {
       const allValuesSelected = newFilters.every(filter => {
         return filter.type === 'datafilter' || filter.active
       })

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/DashboardFiltersEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/DashboardFiltersEditor.tsx
@@ -40,7 +40,7 @@ const DashboardFiltersEditor: React.FC<DashboardFitlersEditorProps> = ({ vizConf
       Number
     )
     return config.dashboard.sharedFilters
-      .map<[number, string]>(({ key }, i) => [i, key])
+      ?.map<[number, string]>(({ key }, i) => [i, key])
       .filter(([filterIndex]) => !sharedFilterIndexes.includes(filterIndex)) // filter out already added filters
       .map(([filterIndex, filterName]) => (
         <option key={filterIndex} value={filterIndex}>{`${filterIndex} - ${filterName}`}</option>
@@ -274,9 +274,7 @@ const DashboardFiltersEditor: React.FC<DashboardFitlersEditorProps> = ({ vizConf
               </select>
             </label>
           ) : (
-
             <button onClick={() => setCanAddExisting(true)} className='btn btn-primary full-width mt-2'>
-
               Add Existing Dashboard Filter
             </button>
           )}

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -19,6 +19,7 @@ type BlankMultiConfig = {
 const createBlankDashboard: () => BlankMultiConfig = () => ({
   dashboard: {},
   rows: [{ columns: [{ width: 12 }] }],
+  sharedFilter: [],
   visualizations: {},
   table: {
     label: 'Data Table',

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -4,22 +4,21 @@ import { MultiDashboardConfig } from '../types/MultiDashboard'
 import DashboardActions from './dashboard.actions'
 import { devToolsWrapper } from '@cdc/core/helpers/withDevTools'
 import { Tab } from '../types/Tab'
-import { DashboardConfig } from '../types/DashboardConfig'
+import { Dashboard } from '../types/Dashboard'
 import { ConfigRow } from '../types/ConfigRow'
 import { AnyVisualization } from '@cdc/core/types/Visualization'
 import { initialState } from '../DashboardContext'
 
 type BlankMultiConfig = {
-  dashboard: Partial<DashboardConfig>
+  dashboard: Partial<Dashboard>
   rows: Partial<ConfigRow>[]
   visualizations: Record<string, Object>
   table: Object
 }
 
 const createBlankDashboard: () => BlankMultiConfig = () => ({
-  dashboard: {},
+  dashboard: { sharedFilters: [] },
   rows: [{ columns: [{ width: 12 }] }],
-  sharedFilter: [],
   visualizations: {},
   table: {
     label: 'Data Table',


### PR DESCRIPTION
## Dev-10215
https://websupport.cdc.gov/browse/DEV-10215

<!-- Provide a brief description of the changes made in this PR -->

Scenario: Upload [dev-10215-config.json](https://websupport.cdc.gov/secure/attachment/73456/73456_dev-10215-config.json) and open the configuration tab.

Expected: A multi-dashboard editor with only one dashboard

1. Click the + button next to New Dashboard 1 to create a second Dashboard
2. Click on the New Dashboard 2 tab

Expected: The Dashboard Editor for New Dashboard 2 opens with no errors

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

I am not putting a Milestone because I am not sure if this can be pushed through quickly
