### PR TITLE
Fix [linearChart] auto padding adjustment

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -426,25 +426,14 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     if (orientation === 'horizontal') return
     if (!labelsOverflow) return
 
-    /* We need to add enough padding to render the next tick
-    IF the max value is greater than the top grid line,
-    OR IF the max value is too close to the top grid line */
-
     // minimum percentage of the max value that the distance should be from the top grid line
     const MINIMUM_DISTANCE_PERCENTAGE = 0.025
 
-    // "max value is greater than the top grid line"
     const topGridLine = Math.max(...yScale.ticks(handleNumTicks))
-    const maxValueIsGreaterThanTopGridLine = maxValue > topGridLine
+    const needsPaddingThreshold = topGridLine - maxValue * MINIMUM_DISTANCE_PERCENTAGE
+    const maxValueIsGreaterThanThreshold = maxValue > needsPaddingThreshold
 
-    // "max value is too close to the top grid line"
-    const divideBy = minValue < 0 ? maxValue / 2 : maxValue
-    const distanceFromTopGridLine = (topGridLine - maxValue) / divideBy
-    const maxValueTooCloseToTopGridLine =
-      !maxValueIsGreaterThanTopGridLine && distanceFromTopGridLine < MINIMUM_DISTANCE_PERCENTAGE
-
-    const needsAutoPadding = maxValueIsGreaterThanTopGridLine || maxValueTooCloseToTopGridLine
-    if (!needsAutoPadding) return
+    if (!maxValueIsGreaterThanThreshold) return
 
     const ticks = yScale.ticks(handleNumTicks)
     const tickGap = ticks.length === 1 ? ticks[0] : ticks[1] - ticks[0]

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -438,6 +438,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     const ticks = yScale.ticks(handleNumTicks)
     const tickGap = ticks.length === 1 ? ticks[0] : ticks[1] - ticks[0]
     const nextTick = Math.max(...yScale.ticks(handleNumTicks)) + tickGap
+    const divideBy = minValue < 0 ? maxValue / 2 : maxValue
     const calculatedPadding = (nextTick - maxValue) / divideBy
 
     // if auto padding is too close to next tick, add one more ticks worth of padding


### PR DESCRIPTION
## [No Ticket]

If maxValue is too close to last tick add enough padding to render next tick

## Testing Steps
1. Open:
[test-in-percent-test-positivity-in-usa.json](https://github.com/user-attachments/files/18564526/test-in-percent-test-positivity-in-usa.json)

2. Confirm line does not go all the way to top

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

