### PR TITLE
[DEV-9163] Keep Scatter Plot downloaded image dots in view of the scr…

### DIFF
--- a/packages/chart/src/hooks/useMinMax.ts
+++ b/packages/chart/src/hooks/useMinMax.ts
@@ -240,6 +240,10 @@ const useMinMax = ({ config, minValue, maxValue, existPositiveValue, data, isAll
     min = 0
   }
 
+  if (config.visualizationType === 'Scatter Plot') {
+    max = max * 1.1
+  }
+
   return { min, max, leftMax, rightMax }
 }
 export default useMinMax


### PR DESCRIPTION
…eenshot

- html2canvas: the overflow property is ignored. I tried various workarounds to get the circles to render without luck
- dom-to-image: the overflow property doesn't seem to be respected here as well and the image is rendered at the very top.

## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
