### PR TITLE
fix [dev-10241] shared filter keys repeating

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -37,6 +37,11 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
     handleOnChange(fieldName, value) // fieldName is the sharedFilterIndex
   }
 
+  const stripDuplicateLabelIncrement = (label: string): string => {
+    // converts 'Label (1)' to 'Label'
+    return label.replace(/\s\(\d+\)$/, '')
+  }
+
   const getNestedDropdownOptions = (options?: DropdownOptions): NestedOptions => {
     if (!options) return []
     const getValueTextTuple = (value: string, text?: string): ValueTextPair => (text ? [value, text] : [value])
@@ -50,13 +55,13 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
     <form className='d-flex flex-wrap'>
       {sharedFilters.map((filter, filterIndex) => {
         const urlFilterType = filter.type === 'urlfilter'
-        const label = filter.key
+        const label = stripDuplicateLabelIncrement(filter.key || '')
 
         if (
           (!urlFilterType && !filter.showDropdown && filter.filterStyle !== FILTER_STYLE.nestedDropdown) ||
           (show && !show.includes(filterIndex))
         )
-          return <React.Fragment key={`${label}-filtersection-${filterIndex}-option`} />
+          return <React.Fragment key={`${filter.key}-filtersection-${filterIndex}-option`} />
         const values: JSX.Element[] = []
 
         const _key = filter.apiFilter?.apiEndpoint
@@ -125,7 +130,7 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
         const formGroupClass = `form-group me-4 mb-1${loading ? ' loading-filter' : ''}`
 
         return (
-          <div className={formGroupClass} key={`${label}-filtersection-${filterIndex}`}>
+          <div className={formGroupClass} key={`${filter.key}-filtersection-${filterIndex}`}>
             {label && (
               <label className='font-weight-bold mb-2' htmlFor={`filter-${filterIndex}`}>
                 {label}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/DashboardFiltersEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/DashboardFiltersEditor.tsx
@@ -60,11 +60,11 @@ const DashboardFiltersEditor: React.FC<DashboardFitlersEditorProps> = ({ vizConf
       subgroupTextSelector: oldSubgroupTextSelector
     } = sharedFilters[index].apiFilter || {}
     const apiFilterChanged =
-      value.apiEndpoint !== oldEndpoint ||
-      value.valueSelector !== oldValueSelector ||
-      value.textSelector !== oldTextSelector ||
-      value.subgroupValueSelector !== oldSubgroupValueSelector ||
-      value.subgroupTextSelector !== oldSubgroupTextSelector
+      value?.apiEndpoint !== oldEndpoint ||
+      value?.valueSelector !== oldValueSelector ||
+      value?.textSelector !== oldTextSelector ||
+      value?.subgroupValueSelector !== oldSubgroupValueSelector ||
+      value?.subgroupTextSelector !== oldSubgroupTextSelector
 
     newSharedFilters[index][prop] = value
     if (prop === 'columnName') {
@@ -228,6 +228,7 @@ const DashboardFiltersEditor: React.FC<DashboardFitlersEditorProps> = ({ vizConf
               >
                 <FilterEditor
                   filter={filter}
+                  filterIndex={index}
                   updateFilterProp={(name, value) => {
                     updateFilterProp(name, index, value)
                   }}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/DeleteFilterModal.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/DeleteFilterModal.tsx
@@ -10,12 +10,22 @@ type DeleteFilterProps = {
   filterIndex: number
 }
 
-const DeleteFilterModal: React.FC<DeleteFilterProps> = ({ removeFilterCompletely, removeFilterFromViz, filterIndex }) => {
+const DeleteFilterModal: React.FC<DeleteFilterProps> = ({
+  removeFilterCompletely,
+  removeFilterFromViz,
+  filterIndex
+}) => {
   const { overlay } = useGlobalContext()
   const { config } = useContext(DashboardContext)
-  const filterUsedByMany = Object.values(config.visualizations).filter(viz => (viz as DashboardFilters).sharedFilterIndexes?.map(Number).includes(Number(filterIndex))).length > 1
 
-  const message = filterUsedByMany ? 'This filter is used by multiple visualizations. You can either delete the filter from this visualization only or you can delete the filter completely, which will also remove it from other visualizations.' : 'Are you sure you want to delete this filter?'
+  const filterUsedByMany =
+    Object.values(config.visualizations).filter(viz => {
+      return (viz as DashboardFilters).sharedFilterIndexes?.map(Number).includes(Number(filterIndex))
+    }).length > 1
+
+  const message = filterUsedByMany
+    ? 'This filter is used by multiple visualizations. You can either delete the filter from this visualization only or you can delete the filter completely, which will also remove it from other visualizations.'
+    : 'Are you sure you want to delete this filter?'
   return (
     <Modal showClose={true}>
       <Modal.Content>

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -211,6 +211,7 @@ const reducer = (state: DashboardState, action: DashboardActions): DashboardStat
       const { uid } = action.payload
       const newRows = _.cloneDeep(state.config.rows)
       const newVisualizations = _.cloneDeep(state.config.visualizations)
+      delete newVisualizations[uid]
       const newSharedFilters = _.cloneDeep(state.config.dashboard.sharedFilters)
       if (newSharedFilters && newSharedFilters.length > 0) {
         newSharedFilters.forEach(sharedFilter => {


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: upload [dev-10241.json](https://github.com/user-attachments/files/18662996/dev-10241.json) and navigate to dashboard preview.

1) change the race in the first "First" dropdown.
2) scroll down and change the second "First" dropdown to a different value that the first.

Expected: The charts should be filtered based on their respective filter value.

3) navigate to one of the dashboard filter widgets' editor panel.
4) add a two new filters and give them the same label.

Expected: The second filter you add should have the label you typed plus ' (1)'

5) add another filter with the same label.

Expected: The third filter you add should have the label you typed plus ' (2)'



<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
