### PR TITLE
FIX:[DEV-10304a] Dynamic Series Legends Can't be Isolated

### DIFF
--- a/packages/chart/src/components/LineChart/index.tsx
+++ b/packages/chart/src/components/LineChart/index.tsx
@@ -89,14 +89,14 @@ const LineChart = (props: LineChartProps) => {
               opacity={
                 legend.behavior === 'highlight' &&
                 seriesHighlight.length > 0 &&
-                seriesHighlight.indexOf(_seriesKey) === -1
+                seriesHighlight.indexOf(seriesKey) === -1
                   ? 0.5
                   : 1
               }
               display={
                 legend.behavior === 'highlight' ||
                 (seriesHighlight.length === 0 && !legend.dynamicLegend) ||
-                seriesHighlight.indexOf(_seriesKey) !== -1
+                seriesHighlight.indexOf(seriesKey) !== -1
                   ? 'block'
                   : 'none'
               }


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
When dynamic series was On and Legend behavior was isolate mode the Line chart lines was missing when user clicked Legend items to make visible only specific lines. now they work properly.
<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
