### PR TITLE
FIX:[DEV-10224] Blank Column Name or Series Name Displays Colon in Hover

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
@@ -500,6 +500,8 @@ const SeriesInputName = props => {
 
     updateConfig(newConfig)
   }
+  // if series name is emty show default data value.
+  const value = series.name !== undefined && series.name !== series.dataKey ? series.name : series.dataKey
 
   return (
     <>
@@ -507,7 +509,7 @@ const SeriesInputName = props => {
       <input
         type='text'
         key={`series-name-${i}`}
-        value={series.name ? series.name : ''}
+        value={value}
         onChange={event => {
           changeSeriesName(i, event.target.value)
         }}

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -175,11 +175,16 @@ export const useTooltip = props => {
             ?.flatMap(seriesKey => {
               const value = resolvedScaleValues[0]?.[seriesKey]
               const formattedValue = getFormattedValue(seriesKey, value, config, getAxisPosition)
+              const seriesObjWithName = config.runtime.series.find(
+                series => series.dataKey === seriesKey && series.name !== undefined
+              )
               if (
                 (value === null || value === undefined || value === '' || formattedValue === 'N/A') &&
                 config.general.hideNullValue
               ) {
                 return []
+              } else if (seriesObjWithName && seriesObjWithName.name === '') {
+                return [['', formattedValue, getAxisPosition(seriesKey)]]
               } else {
                 return [[seriesKey, formattedValue, getAxisPosition(seriesKey)]]
               }
@@ -567,8 +572,14 @@ export const useTooltip = props => {
     if (index == 1 && config.dataFormat.onlyShowTopPrefixSuffix) {
       newValue = `${config.dataFormat.prefix}${newValue}${config.dataFormat.suffix}`
     }
+    const activeLabel = getSeriesNameFromLabel(key)
+    const displayText = activeLabel ? `${activeLabel}: ${newValue}` : newValue
 
-    return <li style={style} className='tooltip-body'>{`${getSeriesNameFromLabel(key)}: ${newValue}`}</li>
+    return (
+      <li style={style} className='tooltip-body'>
+        {displayText}
+      </li>
+    )
   }
 
   return {


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Open Charts. Under Data Series Panel now each series has default value on the Title textfield. if you clean it the toltips will be cleaned as well. Legend will remain. This is requirement from ticket. Thet want remove blank fields from tooltip while keeping value.
<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
