### PR TITLE
FIX: Dev-10303 Filters not applying on Multi-viz Elements

### DIFF
--- a/packages/dashboard/src/helpers/getFilteredData.ts
+++ b/packages/dashboard/src/helpers/getFilteredData.ts
@@ -6,11 +6,18 @@ import { getFormattedData } from './getFormattedData'
 import { getVizKeys } from './getVizKeys'
 
 export const getApplicableFilters = (dashboard: Dashboard, key: string | number): false | SharedFilter[] => {
-  const c = dashboard.sharedFilters?.filter(sharedFilter => sharedFilter.usedBy && sharedFilter.usedBy.indexOf(`${key}`) !== -1)
+  const c = dashboard.sharedFilters?.filter(
+    sharedFilter =>
+      (sharedFilter.usedBy && sharedFilter.usedBy.indexOf(`${key}`) !== -1) || sharedFilter.usedBy.indexOf(key) !== -1
+  )
   return c?.length > 0 ? c : false
 }
 
-export const getFilteredData = (state: DashboardState, initialFilteredData?: Record<string, any>, dataOverride?: Object) => {
+export const getFilteredData = (
+  state: DashboardState,
+  initialFilteredData?: Record<string, any>,
+  dataOverride?: Object
+) => {
   const newFilteredData = initialFilteredData || {}
   const { config } = state
   getVizKeys(config).forEach(key => {
@@ -18,7 +25,8 @@ export const getFilteredData = (state: DashboardState, initialFilteredData?: Rec
     if (applicableFilters) {
       const { dataKey, data, dataDescription } = config.visualizations[key]
       const _data = (dataOverride || state.data)[dataKey] || data
-      const formattedData = dataOverride?.[dataKey] || (dataDescription ? getFormattedData(_data, dataDescription) : _data)
+      const formattedData =
+        dataOverride?.[dataKey] || (dataDescription ? getFormattedData(_data, dataDescription) : _data)
 
       newFilteredData[key] = filterData(applicableFilters, formattedData)
     }
@@ -29,7 +37,8 @@ export const getFilteredData = (state: DashboardState, initialFilteredData?: Rec
       const { dataKey, data, dataDescription } = row
       const _data = (dataOverride || state.data)[dataKey] || data
       if (applicableFilters) {
-        const formattedData = dataOverride?.[dataKey] ?? dataDescription ? getFormattedData(_data, dataDescription) : _data
+        const formattedData =
+          dataOverride?.[dataKey] ?? dataDescription ? getFormattedData(_data, dataDescription) : _data
 
         newFilteredData[index] = filterData(applicableFilters, formattedData)
       } else {


### PR DESCRIPTION
## Dev-10303
https://websupport.cdc.gov/browse/DEV-10303
Multi-viz Rows are able to be filtered by Dashboard Filters

## Testing Steps

Scenario: Upload [multiviz dash.json](https://websupport.cdc.gov/secure/attachment/73225/73225_multiviz+dash.json)and open Dashboard Preview

Expected: There is a filtered text Viz with the word Overall in it and 2 Dashboard Filters for State and Location. There is a Multiviz Table that is show information for Vehicle.

1. Change the State filter to another state
Expectations: The Filtered Text Viz will change and the name of the chosen state will be displayed.
2. Change the Location filter to another Location
Expectations: The Multiviz Table and Footnotes will show information for the Location that was chosen.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
