### PR TITLE
FIX: [DEV-10222] Scatter Plot X Axis Rounding Down

### DIFF
--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -136,6 +136,16 @@ const useScales = (properties: useScaleProps) => {
       })
       xScale.type = scaleTypes.LINEAR
     }
+    if (xAxis.type === 'categorical') {
+      // Map items to rounded numbers if numeric, skip formatting  non-numeric strings.
+      const xAxisDataMappedRoundedItems = xAxisDataMapped.map(item => {
+        const strItem = String(item)
+        const parsed = parseFloat(strItem)
+        return !isNaN(parsed) ? Math.round(parsed).toString() : strItem
+      })
+
+      xScale = composeScaleBand(xAxisDataMappedRoundedItems, [0, xMax], 1 - config.barThickness)
+    }
   }
 
   // handle Box plot


### PR DESCRIPTION
## [[DEV-10222]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Fixed issue with numbers like 99.5  to round for scatter plot if X axis type categorical. for continues axis it is working properly.
<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
