### PR TITLE
Fix: Dev-10508 Group By column doesn't allow column order

### DIFF
--- a/packages/core/components/DataTable/helpers/chartCellMatrix.tsx
+++ b/packages/core/components/DataTable/helpers/chartCellMatrix.tsx
@@ -16,7 +16,15 @@ type ChartRowsProps = DataTableProps & {
   hasRowType?: boolean
 }
 
-const chartCellArray = ({ rows, runtimeData, config, isVertical, sortBy, colorScale, hasRowType }: ChartRowsProps): CellMatrix | GroupCellMatrix => {
+const chartCellArray = ({
+  rows,
+  runtimeData,
+  config,
+  isVertical,
+  sortBy,
+  colorScale,
+  hasRowType
+}: ChartRowsProps): CellMatrix | GroupCellMatrix => {
   const groupBy = config.table?.groupBy
   const dataSeriesColumns = getDataSeriesColumns(config, isVertical, runtimeData)
 
@@ -38,7 +46,7 @@ const chartCellArray = ({ rows, runtimeData, config, isVertical, sortBy, colorSc
 
   if (isVertical) {
     if (groupBy) {
-      const cellMatrix: GroupCellMatrix = {}
+      const cellMatrix = new Map()
       rows.forEach(row => {
         let groupKey: string
         let groupValues = []
@@ -49,10 +57,11 @@ const chartCellArray = ({ rows, runtimeData, config, isVertical, sortBy, colorSc
             groupValues.push(getChartCellValue(row, column, config, runtimeData))
           }
         })
-        if (!cellMatrix[groupKey]) {
-          cellMatrix[groupKey] = [groupValues]
+        if (!cellMatrix.has(groupKey)) {
+          cellMatrix.set(groupKey, [groupValues])
         } else {
-          cellMatrix[groupKey].push(groupValues)
+          const currentGroupValues = cellMatrix.get(groupKey)
+          cellMatrix.set(groupKey, [...currentGroupValues, groupValues])
         }
       })
       return cellMatrix

--- a/packages/core/components/Table/Table.tsx
+++ b/packages/core/components/Table/Table.tsx
@@ -1,13 +1,13 @@
 import { ReactNode } from 'react'
 import Row from './components/Row'
 import GroupRow from './components/GroupRow'
-import { CellMatrix, GroupCellMatrix } from './types/CellMatrix'
+import { CellMatrix } from './types/CellMatrix'
 import { RowType } from './types/RowType'
 import { PreliminaryDataItem } from '@cdc/chart/src/types/ChartConfig'
 import _ from 'lodash'
 
 type TableProps = {
-  childrenMatrix: CellMatrix | GroupCellMatrix
+  childrenMatrix: CellMatrix | Map<string, CellMatrix>
   noData?: boolean
   tableName: string
   caption: string
@@ -56,9 +56,9 @@ const Table = ({
           <thead style={headStyle}>{headContent}</thead>
           <tbody>
             {isGroupedMatrix
-              ? Object.keys(childrenMatrix).flatMap(groupName => {
+              ? Array.from(childrenMatrix.keys()).flatMap(groupName => {
                   let colSpan = 0
-                  const rows = childrenMatrix[groupName].map((row, i) => {
+                  const rows = childrenMatrix.get(groupName).map((row, i) => {
                     colSpan = row.length
                     const key = `${tableName}-${groupName}-row-${i}`
                     return (


### PR DESCRIPTION
## DEV-10508

Group by presents the data in the order it is passed through the dataset

## Testing Steps

In the Ticket https://websupport.cdc.gov/browse/DEV-10508

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

Did not test with URL data with the server acting up. But I believe there shouldn't be a difference. 
