### PR TITLE
fix: filters should be in a row when possible

### DIFF
--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -546,7 +546,7 @@ const Filters = (props: FilterProps) => {
       {visualizationConfig.filterIntro && (
         <p className='filters-section__intro-text mb-3'>{visualizationConfig.filterIntro}</p>
       )}
-      <div className='d-flex flex-wrap w-100 mb-4 pb-2 filters-section__wrapper'>
+      <div className='d-flex flex-wrap w-100 mb-4 pb-2 filters-section__wrapper align-items-end'>
         {' '}
         <>
           <Style />

--- a/packages/core/styles/filters.scss
+++ b/packages/core/styles/filters.scss
@@ -26,7 +26,6 @@
 }
 
 div.single-filters {
-  width: 100%;
   label {
     width: 100%;
     font-weight: 700;
@@ -66,6 +65,10 @@ div.single-filters {
   .tab--active {
     border-bottom: none;
   }
+}
+
+.single-filters--tab-simple {
+  flex-basis: 100%;
 }
 
 .tab-simple-container {


### PR DESCRIPTION
## No Ticket

Filters should be in a row

## Testing Steps
1. Open Viz with multiple filters
2. Filters should be in a row until they wrap for screensize
3. "Tab-Simple" should still take up a whole row

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)
<img width="1114" alt="Screenshot 2025-02-19 at 5 55 55 PM" src="https://github.com/user-attachments/assets/b4cb321a-e9e8-499a-a7b0-e5b777d706a2" />

