### PR TITLE
Hot Fix: Dev-9932 Multiviz h4 adding white space

### DIFF
--- a/packages/dashboard/src/components/CollapsibleVisualizationRow.tsx
+++ b/packages/dashboard/src/components/CollapsibleVisualizationRow.tsx
@@ -28,7 +28,7 @@ const CollapsibleVisualizationRow: React.FC<CollapsableVizRow> = ({
       <div
         style={{ fontSize: titleFontSize }}
         role='button'
-        className={`multi-visualiation-heading${isExpanded ? '' : ' collapsed'} h4 py-0`}
+        className={`multi-visualiation-heading${isExpanded ? '' : ' collapsed'} h4 my-0`}
         onClick={() => {
           setIsExpanded(!isExpanded)
         }}


### PR DESCRIPTION
## DEV-9932

Needed to remove more space around the Heading title

## Testing Steps

Scenario: Upload [dev-9932-config.json](https://github.com/user-attachments/files/18945335/dev-9932-config.json) and open Dashboard Preview.
Expected: There is a multi-viz table row that is separated by Race with Expand All/Collapse All buttons.

Expected change: There are no white spaces around the table headers

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->