### PR TITLE
Hot Fix: Run cove_loaded after charts load

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -424,11 +424,11 @@ const CdcChart: React.FC<CdcChartProps> = ({
    * When cove has a config and container ref publish the cove_loaded event.
    */
   useEffect(() => {
-    if (container && !_.isEmpty(config) && !coveLoadedEventRan) {
+    if (container && !isLoading && !_.isEmpty(config) && !coveLoadedEventRan) {
       publish('cove_loaded', { config: config })
       dispatch({ type: 'SET_LOADED_EVENT', payload: true })
     }
-  }, [container, config]) // eslint-disable-line
+  }, [container, config, isLoading]) // eslint-disable-line
 
   /**
    * Handles filter change events outside of COVE

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -1282,11 +1282,11 @@ const CdcMap = ({
   }, []) // eslint-disable-line
 
   useEffect(() => {
-    if (state && !coveLoadedHasRan && container) {
+    if (state && !runtimeData.init && !coveLoadedHasRan && container) {
       publish('cove_loaded', { config: state })
       setCoveLoadedHasRan(true)
     }
-  }, [state, container]) // eslint-disable-line
+  }, [state, container, runtimeData.init]) // eslint-disable-line
 
   useEffect(() => {
     // When geotype changes - add UID


### PR DESCRIPTION
## [no ticket]

This fixes the `cove_loaded` event so it runs after charts finish loading. I'm pretty sure it used to work that way, but was changed during one of the refactors.

## Testing Steps

Load a chart/map with subtext. Right after the `publish('cove_loaded'` lines touched in this PR, add:

```
console.log(['COVE LOADED', container.querySelector('.subtext')])
```

On the `test` branch, the `querySelector` will not find anything, on this branch it will. Also test various chart configs to ensure it doesn't break.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
