### PR TITLE
Fix [DEV-10399] Expand regex for numeric columns to include CIs

### DIFF
--- a/packages/core/helpers/isRightAlignedTableValue.js
+++ b/packages/core/helpers/isRightAlignedTableValue.js
@@ -8,7 +8,7 @@ export default function isRightAlignedTableValue(value = '') {
     return !Number.isNaN(value)
   }
   if (typeof value === 'string') {
-    return numericStrings.includes(value) || /^[\$\d\.\%\,\-]*$/.test(value)
+    return numericStrings.includes(value) || /^[\$\d\.\%\,\-\s\(\)CI]*$/.test(value)
   }
   return false
 }


### PR DESCRIPTION
## [DEV-10399]

Expands regex for numeric columns to include CIs.

## Testing Steps

```
/^[\$\d\.\%\,\-\s\(\)IC]*$/.test("20.7 (CI 18.4 - 23.3)")
```

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
