### PR TITLE
Fix: Dev-10619 Arrow on Nested Dropdown input not clickable

### DIFF
--- a/packages/core/components/NestedDropdown/NestedDropdown.tsx
+++ b/packages/core/components/NestedDropdown/NestedDropdown.tsx
@@ -283,7 +283,11 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
             onFocus={() => setInputHasFocus(true)}
           />
           <span className='list-arrow' aria-hidden={true}>
-            <Icon display='caretDown' />
+            {isListOpened ? (
+              <Icon display='caretUp' alt='arrow pointing up' />
+            ) : (
+              <Icon display='caretDown' alt='arrow pointing down' />
+            )}
           </span>
         </div>
         {loading && <Loader spinnerType={'text-secondary'} />}

--- a/packages/core/components/NestedDropdown/nesteddropdown.styles.css
+++ b/packages/core/components/NestedDropdown/nesteddropdown.styles.css
@@ -29,11 +29,14 @@
     }
   }
 
+  [class^='main-nested-dropdown-container-'] {
+    cursor: pointer;
+  }
+
   [class^='main-nested-dropdown-container-'],
   .nested-dropdown-input-container {
     border: 1px solid var(--cool-gray-10);
     min-width: 200px;
-    cursor: pointer;
     padding: 0.4rem 0.75rem;
     font-size: 1em;
   }
@@ -57,14 +60,15 @@
 
   .nested-dropdown-input-container {
     display: block;
-    width: 100%;
+    width: calc(100% + 7px);
     border-radius: 0.25rem;
     position: relative;
     & > span.list-arrow {
       position: absolute;
       top: 9px;
-      right: 1px;
+      right: 9px;
       float: right;
+      pointer-events: none;
     }
 
     &.disabled {
@@ -77,7 +81,7 @@
 
   & [class^='main-nested-dropdown-container-'] {
     max-height: 375px;
-    overflow-y: scroll;
+    overflow-y: auto;
     position: absolute;
     z-index: 3;
     min-width: 200px;


### PR DESCRIPTION
## Dev-10619

Made the arrow in the Nested Dropdown search box clickable 
Removed the scroll bar from Nested Dropdowns that are short enough to not need it

## Testing Steps

Scenario: Upload [dev-10619-config](https://cdc.sharepoint.com/teams/OADC-DPA-DMB-WCMS-TPVisualizationsProject/_layouts/15/download.aspx?UniqueId=4f46ba8f1d07498ba16fde5964ff6fbf&e=qFdp1m) and open Dashboard Preview
Expected: There are 2 Nested Dropdown filters named "Scroll Bar" and "No Scroll Bar"

1. Click on the arrow in the Scroll Bar dropdown input
Expected: The dropdown opens and there is a functioning scroll bar
2. Click on the arrow in the Scroll Bar dropdown input
Expected: The dropdown closes
3. Click on the arrow in the No Scroll Bar dropdown input
Expected: The dropdown opens and there is a scroll bar because the list fits in the size of the dropdown
4. Click on the arrow in the No Scroll Bar dropdown input
Expected: The dropdown closes

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
