### PR TITLE
Fix: Dev-10558 Toggle Data Viz disappears when toggle changes

### DIFF
--- a/packages/dashboard/src/components/VisualizationRow.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.tsx
@@ -1,5 +1,5 @@
 import DataTableStandAlone from '@cdc/core/components/DataTable/DataTableStandAlone'
-import React, { useContext, useMemo } from 'react'
+import React, { useContext, useEffect, useMemo, useState } from 'react'
 import Toggle from './Toggle'
 import _ from 'lodash'
 import { ConfigRow } from '../types/ConfigRow'
@@ -85,10 +85,19 @@ const VisualizationRow: React.FC<VizRowProps> = ({
   isLastRow
 }) => {
   const { config, filteredData: dashboardFilteredData, data: rawData } = useContext(DashboardContext)
-  const [show, setShow] = React.useState(row.columns.map((col, i) => i === 0))
-  const setToggled = (colIndex: number) => {
-    setShow(show.map((_, i) => i === colIndex))
-  }
+  const [toggledRow, setToggled] = React.useState<number>(0)
+
+  useEffect(() => {
+    if (row.toggle) setToggled(0)
+  }, [config.activeDashboard, index])
+
+  const show = useMemo(() => {
+    if (row.toggle) {
+      return row.columns.map((col, i) => i === toggledRow)
+    } else {
+      return row.columns.map((col, i) => true)
+    }
+  }, [config.activeDashboard, toggledRow])
 
   const footnotesConfig = useMemo(() => {
     if (row.footnotesId) {
@@ -127,6 +136,9 @@ const VisualizationRow: React.FC<VizRowProps> = ({
   }
   return (
     <div className={`row${row.equalHeight ? ' equal-height' : ''}${row.toggle ? ' toggle' : ''}`} key={`row__${index}`}>
+      {row.toggle && !inNoDataState && (
+        <Toggle row={row} visualizations={config.visualizations} active={show.indexOf(true)} setToggled={setToggled} />
+      )}
       {row.columns.map((col, colIndex) => {
         if (col.width) {
           if (!col.widget) return <div key={`row__${index}__col__${colIndex}`} className={`col col-${col.width}`}></div>
@@ -173,14 +185,6 @@ const VisualizationRow: React.FC<VizRowProps> = ({
                 hideVisualization ? ' hide-parent-visualization' : hasMarginBottom ? ' mb-4' : ''
               }`}
             >
-              {row.toggle && !hideVisualization && (
-                <Toggle
-                  row={row}
-                  visualizations={config.visualizations}
-                  active={show.indexOf(true)}
-                  setToggled={setToggled}
-                />
-              )}
               <VisualizationWrapper
                 allExpanded={allExpanded}
                 currentViewport={currentViewport}

--- a/packages/dashboard/src/components/VisualizationRow.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.tsx
@@ -137,7 +137,7 @@ const VisualizationRow: React.FC<VizRowProps> = ({
   return (
     <div className={`row${row.equalHeight ? ' equal-height' : ''}${row.toggle ? ' toggle' : ''}`} key={`row__${index}`}>
       {row.toggle && !inNoDataState && (
-        <Toggle row={row} visualizations={config.visualizations} active={show.indexOf(true)} setToggled={setToggled} />
+        <Toggle row={row} visualizations={config.visualizations} active={toggledRow} setToggled={setToggled} />
       )}
       {row.columns.map((col, colIndex) => {
         if (col.width) {


### PR DESCRIPTION
## Dev-10558

The toggle rows do not disappear after switching between toggles

## Testing Steps

Scenario: Upload [oral-health-update.json](https://github.com/user-attachments/files/19012087/oral-health-update.json) and open Dashboard Preview
Expected: There are 4 dashboards and the current dashboard, All States, has 2 filters. 

1. Make a selection for both filters and Click Run Report 
Expected: The dashboard loads with a map in a toggle row. There are 3 buttons: Map, Chart, and Table 

2. Click the Table button
Expected: The Map will be replaced with a Table.

3. Click on the Dashboard tab Single County
Expected: The Single County Dashboard opens up and there are 5 filters

4. Make a selection for all 5 filters and click Run Report
Expected: The dashboard loads with a chart in a toggle row. There are 2 buttons: Table and Chart

5. Click the Table button
Expected: The Chart will be replaced with a Table.


## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

When there were multiple dashboards and there was Toggles in each of them, the state from one was passed to the other causing toggles to break. Example: If you choose the 3rd option in a toggle row and then switched dashboards that has a toggle row with only 2 options, the toggle will still try to open the 3rd option even if there isn't a 3rd option. This caused the visualization to show a blank row.