### PR TITLE
FIX:[DEV-9662] Handle Line chart append text

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -913,11 +913,23 @@ const CdcChart: React.FC<CdcChartProps> = ({
                           </ParentSize>
                         </div>
                       ) : (
-                        <div ref={parentRef} style={{ width: `100%` }}>
+                        <div ref={parentRef} style={{ width: '100%' }}>
                           <ParentSize>
-                            {parent => (
-                              <LinearChart ref={svgRef} parentWidth={parent.width} parentHeight={parent.height} />
-                            )}
+                            {parent => {
+                              const labelMargin = 120
+                              const widthReduction =
+                                config.showLineSeriesLabels &&
+                                (config.legend.position !== 'right' || config.legend.hide)
+                                  ? labelMargin
+                                  : 0
+                              return (
+                                <LinearChart
+                                  ref={svgRef}
+                                  parentWidth={parent.width - widthReduction}
+                                  parentHeight={parent.height}
+                                />
+                              )
+                            }}
                           </ParentSize>
                         </div>
                       ))}

--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -749,7 +749,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
     if (!Array.isArray(data)) return []
     if (config.visualizationType === 'Forecasting') return data
     //  specify keys that needs  to be cleaned to render chart and skip rest
-    const CIkeys: string[] = Object.values(config.confidenceKeys) as string[]
+    const CIkeys: string[] = Object.values(config?.confidenceKeys ?? {}) as string[]
     const seriesKeys: string[] = config.series.map(s => s.dataKey)
     const keysToClean: string[] = seriesKeys.concat(CIkeys)
     // key that does not need to be cleaned

--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -750,7 +750,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
     if (config.visualizationType === 'Forecasting') return data
     //  specify keys that needs  to be cleaned to render chart and skip rest
     const CIkeys: string[] = Object.values(config?.confidenceKeys ?? {}) as string[]
-    const seriesKeys: string[] = config.series.map(s => s.dataKey)
+    const seriesKeys: string[] = config?.series?.map(s => s.dataKey)
     const keysToClean: string[] = seriesKeys.concat(CIkeys)
     // key that does not need to be cleaned
     const excludedKey = config.xAxis.dataKey

--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -749,9 +749,10 @@ const CdcChart: React.FC<CdcChartProps> = ({
     if (!Array.isArray(data)) return []
     if (config.visualizationType === 'Forecasting') return data
     //  specify keys that needs  to be cleaned to render chart and skip rest
-    const CIkeys: string[] = Object.values(config?.confidenceKeys ?? {}) as string[]
-    const seriesKeys: string[] = config?.series?.map(s => s.dataKey)
-    const keysToClean: string[] = seriesKeys.concat(CIkeys)
+    const CIkeys: string[] = Object.values(_.get(config, 'confidenceKeys', {})) as string[]
+    const seriesKeys: string[] = _.get(config, 'series', []).map((s: any) => s.dataKey)
+    const keysToClean: string[] = [...(seriesKeys ?? []), ...(CIkeys ?? [])]
+
     // key that does not need to be cleaned
     const excludedKey = config.xAxis.dataKey
     return config?.xAxis?.dataKey ? transform.cleanData(data, excludedKey, keysToClean) : data

--- a/packages/chart/src/components/EditorPanel/helpers/updateFieldRankByValue.ts
+++ b/packages/chart/src/components/EditorPanel/helpers/updateFieldRankByValue.ts
@@ -31,7 +31,7 @@ export const updateFieldRankByValue = (
 
   if (config.rankByValue && !newValue) {
     const CIkeys: string[] = Object.values(config?.confidenceKeys ?? {}) as string[]
-    const seriesKeys: string[] = config.series.map(s => s.dataKey)
+    const seriesKeys: string[] = config?.series?.map(s => s.dataKey)
     const keysToClean: string[] = seriesKeys.concat(CIkeys)
     const cleanData = config?.xAxis?.dataKey
       ? transform.cleanData(config.data, config.xAxis.dataKey, keysToClean)

--- a/packages/chart/src/components/EditorPanel/helpers/updateFieldRankByValue.ts
+++ b/packages/chart/src/components/EditorPanel/helpers/updateFieldRankByValue.ts
@@ -30,9 +30,10 @@ export const updateFieldRankByValue = (
   newConfig.rankByValue = newValue
 
   if (config.rankByValue && !newValue) {
-    const CIkeys: string[] = Object.values(config?.confidenceKeys ?? {}) as string[]
-    const seriesKeys: string[] = config?.series?.map(s => s.dataKey)
-    const keysToClean: string[] = seriesKeys.concat(CIkeys)
+    const CIkeys: string[] = Object.values(_.get(config, 'confidenceKeys', {})) as string[]
+    const seriesKeys: string[] = _.get(config, 'series', []).map((s: any) => s.dataKey)
+    const keysToClean: string[] = [...(seriesKeys ?? []), ...(CIkeys ?? [])]
+
     const cleanData = config?.xAxis?.dataKey
       ? transform.cleanData(config.data, config.xAxis.dataKey, keysToClean)
       : config.data

--- a/packages/chart/src/components/EditorPanel/helpers/updateFieldRankByValue.ts
+++ b/packages/chart/src/components/EditorPanel/helpers/updateFieldRankByValue.ts
@@ -30,7 +30,7 @@ export const updateFieldRankByValue = (
   newConfig.rankByValue = newValue
 
   if (config.rankByValue && !newValue) {
-    const CIkeys: string[] = Object.values(config.confidenceKeys) as string[]
+    const CIkeys: string[] = Object.values(config?.confidenceKeys ?? {}) as string[]
     const seriesKeys: string[] = config.series.map(s => s.dataKey)
     const keysToClean: string[] = seriesKeys.concat(CIkeys)
     const cleanData = config?.xAxis?.dataKey

--- a/packages/chart/src/components/LineChart/index.tsx
+++ b/packages/chart/src/components/LineChart/index.tsx
@@ -416,11 +416,7 @@ const LineChart = (props: LineChartProps) => {
                       x={xPos(lastDatum) + 5}
                       y={yScale(getYAxisData(lastDatum, seriesKey))}
                       alignmentBaseline='middle'
-                      fill={
-                        config.colorMatchLineSeriesLabels && colorScale
-                          ? colorScale(config.runtime.seriesLabels[seriesKey] || seriesKey)
-                          : 'black'
-                      }
+                      fill={colorScale(config.runtime.seriesLabels[seriesKey] || seriesKey)}
                     >
                       {labelText}
                     </Text>

--- a/packages/chart/src/components/LineChart/index.tsx
+++ b/packages/chart/src/components/LineChart/index.tsx
@@ -393,11 +393,26 @@ const LineChart = (props: LineChartProps) => {
                       break
                     }
                   }
-                  if (!lastDatum) {
+                  if (!lastDatum || legend.position === 'right') {
                     return <></>
                   }
+
+                  let labelText = config.runtime.seriesLabels[seriesKey] || seriesKey
+                  // truncate labels longer that 10 chars
+                  const ellipsis = '...'
+                  if (labelText.length > 10) {
+                    labelText = labelText.substring(0, 10) + ellipsis
+                  }
+
                   return (
                     <Text
+                      display={
+                        legend.behavior === 'highlight' ||
+                        (seriesHighlight.length === 0 && !legend.dynamicLegend) ||
+                        seriesHighlight.indexOf(seriesKey) !== -1
+                          ? 'block'
+                          : 'none'
+                      }
                       x={xPos(lastDatum) + 5}
                       y={yScale(getYAxisData(lastDatum, seriesKey))}
                       alignmentBaseline='middle'
@@ -407,7 +422,7 @@ const LineChart = (props: LineChartProps) => {
                           : 'black'
                       }
                     >
-                      {config.runtime.seriesLabels[seriesKey] || seriesKey}
+                      {labelText}
                     </Text>
                   )
                 })}


### PR DESCRIPTION
## [DEV-9662]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Open Line chart
On visual panel check "Append Series Name to End of Line Charts" 
It should show text to the end of line chart.
if text is more than 10 letters it will start truncating it.
if legend on the right the text will be hidden.
Line text colors follows the line colors
update series names manually to see different text results.
<img width="1494" alt="Screenshot 2025-02-27 at 13 12 30" src="https://github.com/user-attachments/assets/1e659578-9271-4dfa-b6c1-d042149c5ec1" />

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
