### PR TITLE
Fix [DEV-9150] Fix double chart request

### DIFF
--- a/packages/chart/src/CdcChart.tsx
+++ b/packages/chart/src/CdcChart.tsx
@@ -69,12 +69,7 @@ const CdcChartWrapper: React.FC<CdcChartProps> = ({ configUrl, isEditor, isDebug
       setIsLoading(true)
       try {
         const loadedConfig = await loadConfig(configUrl)
-        const data = await loadDataFromConfig(loadedConfig)
-
-        setConfig({
-          ...loadedConfig,
-          data
-        })
+        setConfig(loadedConfig)
       } catch (error) {
         console.error('Failed to load configuration or data', error)
       } finally {
@@ -121,22 +116,6 @@ const fetchAndParseData = async (url: string, ext: string) => {
     }
   } catch (error) {
     console.error(`Error parsing URL: ${url}`, error)
-    return []
-  }
-}
-
-const loadDataFromConfig = async (response: any) => {
-  if (!response.dataUrl || _.some(_.get(response, 'filters', []), { type: 'url' })) {
-    return response.data || []
-  }
-
-  const ext = getFileExtension(response.dataUrl)
-  const urlWithCacheBuster = `${response.dataUrl}`
-
-  try {
-    return await fetchAndParseData(urlWithCacheBuster, ext)
-  } catch {
-    console.error(`Cannot parse URL: ${response.dataUrl}`)
     return []
   }
 }


### PR DESCRIPTION
## [DEV-9150]

This removes a double data request for charts that load remote data via a `dataUrl`.

It's not clear to me what situation this `loadDataFromConfig` function is needed. It only loads remote data when 1) there's a `dataUrl` and 2) there are no url filters, but then [this useEffect](https://github.com/CDCgov/cdc-open-viz/blob/dev/packages/chart/src/CdcChartComponent.tsx#L405-L421) in CDCChartComponent also loads the remote data in that situation.

In my testing I didn't find any configurations where it's needed, but it's possible I missed something.

## Testing Steps

[sample config](https://github.com/user-attachments/files/19030623/covid-vaccination-intent-viz.json)

Load a `dataUrl` chart locally. On the `dev` branch, there will be two network requests for the data file in the network tab, on this branch there will be one.

Ensure that the change does not break any other configurations, like dashboards, charts without `dataUrl`, etc.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
