### PR TITLE
Fix/ [new-50345] unused dashboard filters

### DIFF
--- a/packages/core/helpers/tests/formatConfigBeforeSave.test.ts
+++ b/packages/core/helpers/tests/formatConfigBeforeSave.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { cleanSharedFilters } from '../formatConfigBeforeSave'
+import { DashboardConfig } from '@cdc/dashboard/src/types/DashboardConfig'
+
+describe('cleanSharedFilters', () => {
+  it('should remove unused shared filters', () => {
+    const config: DashboardConfig = {
+      dashboard: {
+        sharedFilters: [
+          { id: 1, type: 'filter1' },
+          { id: 2, type: 'filter2' },
+          { id: 3, type: 'filter3' },
+          { id: 4, type: 'filter4' }
+        ]
+      },
+      visualizations: {
+        viz1: { type: 'dashboardFilters', sharedFilterIndexes: [0, 3] },
+        viz2: { type: 'chart'}
+      }
+    }
+
+    cleanSharedFilters(config)
+
+    expect(config.dashboard.sharedFilters).toEqual([{ id: 1, type: 'filter1' }, { id: 4, type: 'filter4' }])
+  })
+
+  it('should retain used shared filters and remove their active state', () => {
+    const config: DashboardConfig = {
+      dashboard: {
+        sharedFilters: [
+          { id: 1, type: 'filter1', active: true },
+          { id: 2, type: 'filter2', active: true }
+        ]
+      },
+      visualizations: {
+        viz1: { type: 'dashboardFilters', sharedFilterIndexes: [0] },
+        viz2: { type: 'dashboardFilters', sharedFilterIndexes: [1] }
+      }
+    }
+
+    cleanSharedFilters(config)
+
+    expect(config.dashboard.sharedFilters).toEqual([
+      { id: 1, type: 'filter1' },
+      { id: 2, type: 'filter2' }
+    ])
+  })
+
+  it('should remove values from urlfilter type shared filters', () => {
+    const config: DashboardConfig = {
+      dashboard: {
+        sharedFilters: [
+          { id: 1, type: 'urlfilter', values: [1, 2, 3] },
+          { id: 2, type: 'filter2' }
+        ]
+      },
+      visualizations: {
+        viz1: { type: 'dashboardFilters', sharedFilterIndexes: [0] }
+      }
+    }
+
+    cleanSharedFilters(config)
+
+    expect(config.dashboard.sharedFilters).toEqual([
+      { id: 1, type: 'urlfilter' }
+    ])
+  })
+})

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/DashboardFiltersEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/DashboardFiltersEditor.tsx
@@ -21,6 +21,7 @@ import DeleteFilterModal from './components/DeleteFilterModal'
 import { addValuesToDashboardFilters } from '../../../helpers/addValuesToDashboardFilters'
 import { FILTER_STYLE } from '../../../types/FilterStyles'
 import { handleSorting } from '@cdc/core/components/Filters'
+import { removeDashboardFilter } from '../../../helpers/removeDashboardFilter'
 
 type DashboardFitlersEditorProps = {
   vizConfig: DashboardFilters
@@ -116,27 +117,9 @@ const DashboardFiltersEditor: React.FC<DashboardFitlersEditorProps> = ({ vizConf
   }
 
   const removeFilter = index => {
-    const newSharedFilters = _.cloneDeep(sharedFilters)
-
-    newSharedFilters.splice(index, 1)
-    const shiftDownIndexes = Object.keys(sharedFilters).slice(index + 1)
-    const anyViz: Record<string, AnyVisualization> = visualizations
-    Object.keys(anyViz).forEach(vizKey => {
-      const viz = anyViz[vizKey]
-      if (viz.type === 'dashboardFilters') {
-        // shift the indexes down
-        const sharedFilterIndexes = viz.sharedFilterIndexes
-          .filter(filterIndex => filterIndex != index)
-          .map(filterIndex => {
-            if (shiftDownIndexes.includes(filterIndex.toString())) {
-              return filterIndex - 1
-            }
-            return filterIndex
-          })
-        dispatch({ type: 'UPDATE_VISUALIZATION', payload: { vizKey, configureData: { sharedFilterIndexes } } })
-      }
-    })
-    dispatch({ type: 'SET_SHARED_FILTERS', payload: newSharedFilters })
+    const [newSharedFilters, newVisualizations] = removeDashboardFilter(index, sharedFilters, visualizations)
+    const dashboard = {...config.dashboard, sharedFilters: newSharedFilters}
+    dispatch({ type: 'SET_CONFIG', payload: { dashboard, visualizations: newVisualizations } })
   }
 
   const addNewFilter = () => {

--- a/packages/dashboard/src/helpers/removeDashboardFilter.ts
+++ b/packages/dashboard/src/helpers/removeDashboardFilter.ts
@@ -1,0 +1,33 @@
+import { AnyVisualization } from '@cdc/core/types/Visualization'
+import _ from 'lodash'
+import { SharedFilter } from '../types/SharedFilter'
+
+type Viz = Record<string, AnyVisualization>
+
+export const removeDashboardFilter = (
+  index,
+  sharedFilters: SharedFilter[],
+  visualizations: Viz
+): [SharedFilter[], Viz] => {
+  const newSharedFilters = _.cloneDeep(sharedFilters)
+
+  newSharedFilters.splice(index, 1)
+  const shiftDownIndexes = Object.keys(sharedFilters).slice(index + 1)
+  const newVisualizations: Viz = _.cloneDeep(visualizations)
+  Object.keys(newVisualizations).forEach(vizKey => {
+    const viz = newVisualizations[vizKey]
+    if (viz.type === 'dashboardFilters') {
+      // shift the indexes down
+      const sharedFilterIndexes = viz.sharedFilterIndexes
+        .filter(filterIndex => filterIndex != index)
+        .map(filterIndex => {
+          if (shiftDownIndexes.includes(filterIndex.toString())) {
+            return filterIndex - 1
+          }
+          return filterIndex
+        })
+      newVisualizations[vizKey].sharedFilterIndexes = sharedFilterIndexes
+    }
+  })
+  return [newSharedFilters, newVisualizations]
+}

--- a/packages/dashboard/src/helpers/tests/removeDashboardFilter.test.ts
+++ b/packages/dashboard/src/helpers/tests/removeDashboardFilter.test.ts
@@ -1,0 +1,147 @@
+import { removeDashboardFilter } from '../removeDashboardFilter'
+import { AnyVisualization } from '@cdc/core/types/Visualization'
+import _ from 'lodash'
+
+describe('removeDashboardFilter', () => {
+  it('should remove the filter and update shared filters and visualizations', () => {
+    const index = 1
+    const sharedFilters = [
+      { id: 1, name: 'Filter 1' },
+      { id: 2, name: 'Filter 2' },
+      { id: 3, name: 'Filter 3' }
+    ]
+    const visualizations: Record<string, AnyVisualization> = {
+      viz1: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [0, 1, 2]
+      },
+      viz2: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [1]
+      }
+    }
+
+    const [newSharedFilters, newVisualizations] = removeDashboardFilter(index, sharedFilters, visualizations)
+
+    expect(newSharedFilters).toEqual([
+      { id: 1, name: 'Filter 1' },
+      { id: 3, name: 'Filter 3' }
+    ])
+
+    expect(newVisualizations).toEqual({
+      viz1: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [0, 1]
+      },
+      viz2: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: []
+      }
+    })
+  })
+
+  it('should handle removing the first filter', () => {
+    const index = 0
+    const sharedFilters = [
+      { id: 1, name: 'Filter 1' },
+      { id: 2, name: 'Filter 2' },
+      { id: 3, name: 'Filter 3' }
+    ]
+    const visualizations: Record<string, AnyVisualization> = {
+      viz1: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [0, 1, 2]
+      },
+      viz2: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [0]
+      }
+    }
+
+    const [newSharedFilters, newVisualizations] = removeDashboardFilter(index, sharedFilters, visualizations)
+
+    expect(newSharedFilters).toEqual([
+      { id: 2, name: 'Filter 2' },
+      { id: 3, name: 'Filter 3' }
+    ])
+
+    expect(newVisualizations).toEqual({
+      viz1: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [0, 1]
+      },
+      viz2: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: []
+      }
+    })
+  })
+
+  it('should handle removing the last filter', () => {
+    const index = 2
+    const sharedFilters = [
+      { id: 1, name: 'Filter 1' },
+      { id: 2, name: 'Filter 2' },
+      { id: 3, name: 'Filter 3' }
+    ]
+    const visualizations: Record<string, AnyVisualization> = {
+      viz1: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [0, 1, 2]
+      },
+      viz2: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [2]
+      }
+    }
+
+    const [newSharedFilters, newVisualizations] = removeDashboardFilter(index, sharedFilters, visualizations)
+
+    expect(newSharedFilters).toEqual([
+      { id: 1, name: 'Filter 1' },
+      { id: 2, name: 'Filter 2' }
+    ])
+
+    expect(newVisualizations).toEqual({
+      viz1: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [0, 1]
+      },
+      viz2: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: []
+      }
+    })
+  })
+
+
+  it('should handle removing the last filter', () => {
+    const sharedFilters = [
+      { id: 1, name: 'Filter 1' },
+      { id: 2, name: 'Filter 2' },
+      { id: 3, name: 'Filter 3' },
+      { id: 4, name: 'Filter 4' }
+    ]
+    const visualizations: Record<string, AnyVisualization> = {
+      viz1: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [0, 2, 3]
+      }
+    }
+
+    const [newSharedFilters, newVisualizations] = removeDashboardFilter(0, sharedFilters, visualizations)
+
+    expect(newSharedFilters).toEqual([
+      { id: 2, name: 'Filter 2' },
+      { id: 3, name: 'Filter 3' },
+      { id: 4, name: 'Filter 4' }
+    ])
+
+    expect(newVisualizations).toEqual({
+      viz1: {
+        type: 'dashboardFilters',
+        sharedFilterIndexes: [1, 2]
+      }
+    })
+  })
+})


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: In cove editor. select dashboard visualization. Select a data set and navigate to the configure tab.

1) drag and drop a "dashboard filters" widget onto the visualization panel.
2) navigate to the editor panel for the dashboard filters widget.
3) add some dashboard filters.
4) navigate back to the dashboard panel.
5) delete the dashboard filters widget.
6) click to toggle the advanced editor

Expected: the sharedFilters under dashboard should be empty. The visualizations should be empty.

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
