### PR TITLE
enhancement [tab-simple]: tab-simple feedback

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -344,7 +344,6 @@ const CdcChart: React.FC<CdcChartProps> = ({
   const resizeObserver = new ResizeObserver(entries => {
     for (let entry of entries) {
       let { width, height } = entry.contentRect
-      const svgMarginWidth = 15
       const editorWidth = 350
 
       width = isEditor ? width - editorWidth : width
@@ -357,7 +356,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
         width = width - 2.5
       }
 
-      width = width - svgMarginWidth
+      width = width
       dispatch({ type: 'SET_DIMENSIONS', payload: [width, height] })
     }
   })

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -329,6 +329,15 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   }
 
   // EFFECTS
+  // Adjust padding on the right side of the chart to accommodate for overflow
+  useEffect(() => {
+    if (!parentRef.current) return
+    const lastTickRect = xAxisLabelRefs.current?.[xAxisLabelRefs.current.length - 1]?.getBoundingClientRect()
+    const lastBottomTickEnd = lastTickRect ? lastTickRect.x + lastTickRect.width : 0
+    const paddingToAdd = lastBottomTickEnd > parentWidth ? lastBottomTickEnd - parentWidth : 0
+    const BUFFER = 5
+    parentRef.current.style.paddingRight = `${paddingToAdd + BUFFER}px`
+  }, [parentWidth, parentHeight])
 
   // Make sure the chart is visible if in the editor
   /* eslint-disable react-hooks/exhaustive-deps */
@@ -1399,14 +1408,14 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                 const axisMaxHeight = bottomLabelStart + BOTTOM_LABEL_PADDING
 
                 const containsMultipleWords = inputString => /\s/.test(inputString)
-                const ismultiLabel = filteredTicks.some(tick => containsMultipleWords(tick.value))
+                const isMultiLabel = filteredTicks.some(tick => containsMultipleWords(tick.value))
 
                 // Calculate sumOfTickWidth here, before map function
                 const tickWidthMax = Math.max(
                   ...filteredTicks.map(tick => getTextWidth(tick.formattedValue, GET_TEXT_WIDTH_FONT))
                 )
                 // const marginTop = 20 // moved to top bc need for yMax calcs
-                const accumulator = ismultiLabel ? 180 : 100
+                const accumulator = isMultiLabel ? 180 : 100
 
                 const textWidths = filteredTicks.map(tick => getTextWidth(tick.formattedValue, GET_TEXT_WIDTH_FONT))
                 const sumOfTickWidth = textWidths.reduce((a, b) => a + b, accumulator)

--- a/packages/core/components/Layout/components/Visualization/visualizations.scss
+++ b/packages/core/components/Layout/components/Visualization/visualizations.scss
@@ -1,6 +1,6 @@
 .cdc-open-viz-module {
   .cdc-chart-inner-container .cove-component__content {
-    padding: 0 15px 27px 0 !important;
+    padding: 0 0 27px 0 !important;
   }
   &.isEditor {
     overflow: auto;

--- a/packages/core/styles/filters.scss
+++ b/packages/core/styles/filters.scss
@@ -76,6 +76,7 @@ div.single-filters {
   .tab.tab--simple {
     background: none;
     border: none;
+    border-bottom: 0.3rem solid var(--colors-blue-vivid-60, transparent);
     font-family: var(--app-font-secondary);
     font-size: 1rem;
     font-weight: 300;
@@ -83,11 +84,6 @@ div.single-filters {
     width: auto;
     cursor: pointer;
     border-radius: 6px 6px 0 0;
-
-    @include breakpointClass(xs) {
-      font-size: 0.778em;
-      padding: 0.5rem 0.778em;
-    }
 
     &:hover {
       color: var(--colors-blue-vivid-60, #005ea2);
@@ -104,7 +100,7 @@ div.single-filters {
 
     &.tab--active {
       font-weight: 500;
-      border-bottom: 0.3rem solid var(--colors-blue-vivid-60, #005ea2);
+      border-bottom-color: var(--colors-blue-vivid-60, #005ea2);
       z-index: 1;
     }
   }
@@ -112,8 +108,8 @@ div.single-filters {
 .cdc-open-viz-module {
   @include breakpointClass(xs) {
     .single-filters--tab-simple .tab-simple-container .tab.tab--simple {
-      font-size: 0.778em;
-      padding: 0.5rem 0.778em;
+      font-size: 0.73em;
+      padding: 0.5rem 0.73em;
     }
   }
 }

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -1511,6 +1511,7 @@ const CdcMap = ({
         config={state}
         isEditor={isEditor}
         ref={outerContainerRef}
+        currentViewport={currentViewport}
         imageId={imageId}
         showEditorPanel={state.showEditorPanel}
       >


### PR DESCRIPTION
## No Ticket
A couple things going on here:
enhancement: slightly reduced tab padding and font size reduction on mobile
enhancement: _**Dynamic Padding Right**_ instead of the one size fits all
fix: reduce tab-simple from shifting on selection
fix: currentViewport not being added to container for CdcMaps

## Testing Steps
1. Open chart `Respiratory-Virus-Activity-Age_relative.json` and map `wastewatermap.json`
2. reduce screen-width to mobile
3. test breakpoints with list changes in mind

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing