### PR TITLE
FIX: [DEV-10302] Fix markup-include title on filters

### DIFF
--- a/packages/core/types/Visualization.ts
+++ b/packages/core/types/Visualization.ts
@@ -49,6 +49,9 @@ type DeprecatedVisualizationType = {
     | 'table'
     | 'navigation'
   usesSharedFilter?: any
+  contentEditor: {
+    title: string
+  }
   visualizationSubType: string
   visualizationType: string
   xAxis: Axis

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -55,7 +55,11 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
       if (!vizLookup) return false
       const viz = config.visualizations[vizKey] as Visualization
       if (viz.type === 'dashboardFilters') return false
-      const vizName = viz.general?.title || viz.title || vizKey
+      let vizName = viz.general?.title || viz.title || vizKey
+      if (viz.visualizationType === 'markup-include') {
+        vizName = viz.contentEditor.title || vizKey
+      }
+
       nameLookup[vizKey] = vizName
       const usesSharedFilter = viz.usesSharedFilter
       const rowIndex = vizLookup.row
@@ -74,6 +78,14 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
     const rowsNotSelected = rowOptions.filter(row => !filter.usedBy || filter.usedBy.indexOf(row.toString()) === -1)
     return [nameLookup, [...vizOptions, ...rowsNotSelected]]
   }, [config.visualizations, filter.usedBy, filter.setBy, vizRowColumnLocator])
+
+  const getUsedByOptions = (viz, vizKey) => {
+    let vizName = viz.general?.title || viz.title || vizKey
+    if (viz.visualizationType === 'markup-include') {
+      vizName = viz.contentEditor.title || vizKey
+    }
+    return vizName
+  }
 
   const useParameters = useMemo(() => {
     if (filter.subGrouping) return !!(filter.setByQueryParameter && filter.subGrouping?.setByQueryParameter)
@@ -204,7 +216,6 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
       </>
     )
   }
-
   return (
     <>
       <label>
@@ -557,7 +568,7 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                       const viz = config.visualizations[vizKey] as Visualization
                       return (
                         <option value={vizKey} key={`set-by-select-item-${vizKey}`}>
-                          {viz.general?.title || viz.title || vizKey}
+                          {getUsedByOptions(viz, vizKey)}
                         </option>
                       )
                     })}


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Open Dashboards
Create 2 viz : Markup Include & Filters
On Markup Include update title "Custom title"
on the filters see two dropdowns "setby" "usedBy" these drop downs should show updated title of the component.
Before: it used to show viz key "markup-include9429829024" even after title update.
<img width="1152" alt="Screenshot 2025-03-07 at 12 25 33" src="https://github.com/user-attachments/assets/0453854f-139a-406b-a515-21b2eef5fc27" />

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
