### PR TITLE
FIX:[DEV-10302a] Fix Markup-Include title with Filters

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -50,6 +50,14 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
 
   const vizRowColumnLocator = getVizRowColumnLocator(config.rows)
 
+  const getVizTitle = (viz, vizKey) => {
+    let vizName = viz.general?.title || viz.title || vizKey
+    if (viz.visualizationType === 'markup-include') {
+      vizName = viz.contentEditor.title || vizKey
+    }
+    return vizName
+  }
+
   const [usedByNameLookup, usedByOptions] = useMemo(() => {
     const nameLookup = {}
     const vizOptions = Object.keys(config.visualizations).filter(vizKey => {
@@ -57,7 +65,8 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
       if (!vizLookup) return false
       const viz = config.visualizations[vizKey] as Visualization
       if (viz.type === 'dashboardFilters') return false
-      const vizName = viz.general?.title || viz.title || vizKey
+      const vizName = getVizTitle(viz, vizKey)
+
       nameLookup[vizKey] = vizName
       const usesSharedFilter = viz.usesSharedFilter
       const rowIndex = vizLookup.row
@@ -565,11 +574,11 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
               <Select
                 label='Set By:'
                 value={filter.setBy}
-                options={Object.keys(config.visualizations)
-                  .filter(vizKey => config.visualizations[vizKey].type !== 'dashboardFilters')
-                  .map(vizKey => ({
-                    value: vizKey,
-                    label: config.visualizations[vizKey].general?.title || config.visualizations[vizKey].title || vizKey
+                options={Object.values(config.visualizations)
+                  .filter(viz => viz.type !== 'dashboardFilters')
+                  .map(viz => ({
+                    value: viz.uid,
+                    label: getVizTitle(viz, viz.type)
                   }))}
                 updateField={(_section, _subSection, _key, value) => updateFilterProp('setBy', value)}
                 initial='- Select Option -'


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Open Dashboards
Create 2 viz : Markup Include & Filters
On Markup Include update title "Custom title"
on the filters see two dropdowns "setby" "usedBy" these drop downs should show updated title of the component.
Before: it used to show viz key "markup-include9429829024" even after title update.
<img width="1043" alt="Screenshot 2025-03-12 at 10 50 33" src="https://github.com/user-attachments/assets/166c6a82-dccd-4acd-bb69-be4833b0dae8" />

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
