### PR TITLE
FIX[DEV-10222] : Scatter plot plots alighment issue

### DIFF
--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -127,7 +127,16 @@ const useScales = (properties: useScaleProps) => {
 
   // handle Scatter plot
   if (config.visualizationType === 'Scatter Plot') {
-    if (xAxis.type === 'categorical' || xAxis.type === 'continuous') {
+    if (xAxis.type === 'continuous') {
+      let min = xAxis.min ? xAxis.min : Math.min.apply(null, xScale.domain())
+      let max = xAxis.max ? xAxis.max : Math.max.apply(null, xScale.domain())
+      xScale = scaleLinear({
+        domain: [min, max],
+        range: [0, xMax]
+      })
+      xScale.type = scaleTypes.LINEAR
+    }
+    if (xAxis.type === 'categorical') {
       xScale = composeScaleBand(xAxisDataMapped, [0, xMax], 1)
       xScale.type = scaleTypes.BAND
     }

--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -127,24 +127,9 @@ const useScales = (properties: useScaleProps) => {
 
   // handle Scatter plot
   if (config.visualizationType === 'Scatter Plot') {
-    if (xAxis.type === 'continuous') {
-      let min = xAxis.min ? xAxis.min : Math.min.apply(null, xScale.domain())
-      let max = xAxis.max ? xAxis.max : Math.max.apply(null, xScale.domain())
-      xScale = scaleLinear({
-        domain: [min, max],
-        range: [0, xMax]
-      })
-      xScale.type = scaleTypes.LINEAR
-    }
-    if (xAxis.type === 'categorical') {
-      // Map items to rounded numbers if numeric, skip formatting  non-numeric strings.
-      const xAxisDataMappedRoundedItems = xAxisDataMapped.map(item => {
-        const strItem = String(item)
-        const parsed = parseFloat(strItem)
-        return !isNaN(parsed) ? Math.round(parsed).toString() : strItem
-      })
-
-      xScale = composeScaleBand(xAxisDataMappedRoundedItems, [0, xMax], 1 - config.barThickness)
+    if (xAxis.type === 'categorical' || xAxis.type === 'continuous') {
+      xScale = composeScaleBand(xAxisDataMapped, [0, xMax], 1)
+      xScale.type = scaleTypes.BAND
     }
   }
 


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->
Open Scatter Plot
Set axis to Categorical
dots(plots) should be properly aligned with ticks
<img width="1496" alt="Screenshot 2025-03-12 at 11 33 17" src="https://github.com/user-attachments/assets/8ee75b22-dfc2-47b0-94b1-de7abf1d4db3" />

## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
