### PR TITLE
Fix [DEV-10399] Don't consider dates to be numbers for table alignment

### DIFF
--- a/packages/core/helpers/isRightAlignedTableValue.js
+++ b/packages/core/helpers/isRightAlignedTableValue.js
@@ -8,8 +8,8 @@ export default function isRightAlignedTableValue(value = '') {
     return !Number.isNaN(value)
   }
   if (typeof value === 'string') {
-    // Dates are not considered numbers
-    if (/^\d{4}-\d{2}-\d{2}$/.test(value) || /^\d{1,2}\/\d{1,2}\/\d{2,4}$/.test(value)) {
+    // Dates like 2024-09-12 are not considered numbers
+    if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(value)) {
       return false
     }
     return numericStrings.includes(value) || /^[\$\d\.\%\,\-\s\(\)CI]*$/.test(value)

--- a/packages/core/helpers/isRightAlignedTableValue.js
+++ b/packages/core/helpers/isRightAlignedTableValue.js
@@ -8,6 +8,10 @@ export default function isRightAlignedTableValue(value = '') {
     return !Number.isNaN(value)
   }
   if (typeof value === 'string') {
+    // Dates are not considered numbers
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value) || /^\d{1,2}\/\d{1,2}\/\d{2,4}$/.test(value)) {
+      return false
+    }
     return numericStrings.includes(value) || /^[\$\d\.\%\,\-\s\(\)CI]*$/.test(value)
   }
   return false


### PR DESCRIPTION
## [DEV-10399]

Don't right-align columns formatted like dates, such as 2024-01-12.

## Testing Steps

Create a chart with dates like "2024-01-12", ensure that they are left-aligned in the data table.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
