### PR TITLE
Fix [NEW-50348] Don't calculate auto padding if yaxis max is set

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -440,8 +440,10 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   }, [maxValue])
 
   useEffect(() => {
-    if (orientation === 'horizontal') return
-    if (!labelsOverflow) return
+    if (orientation === 'horizontal' || !labelsOverflow || config.yAxis?.max) {
+      setYAxisAutoPadding(0)
+      return
+    }
 
     // minimum percentage of the max value that the distance should be from the top grid line
     const MINIMUM_DISTANCE_PERCENTAGE = 0.025


### PR DESCRIPTION
## [NEW-50348]

Don't override yaxis max with auto padding if max is set.

## Testing Steps

Create a chart using "only show top suffix/prefix", set a max for the y-axis, ensure that it's not overridden by automatic padding.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
