### PR TITLE
Fix/new 50355 bar chart tooltip shows blank when na expected

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -565,6 +565,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
     addColRoundTo,
     { index, length } = { index: null, length: null }
   ) => {
+    if (num === '') return 'N/A'
     // if num is NaN return num
     if (isNaN(num) || !num) return num
     // Check if the input number is negative


### PR DESCRIPTION
## Fix: New-50355
https://devops2.cdc.gov/ado/NCCDPHP_Apps_Dev/OD_COVE/_queries/edit/111717/?triage=true

In tooltip, when the value is blank then the tooltip displays N/A for the value

## Testing Steps

Scenario: Upload [adhap-test-test_1 (21).json](https://github.com/user-attachments/files/19231898/adhap-test-test_1.21.json) and open Dashboard Preview
Expected: There is a Dashboard Filter with 3 dropdowns

1. Select following in the Dropdowns then Click View Results:
Location: Colorado
Category: Smoking and Alcohol Use
Indicator: Current smoking
Expected: The page loads and is displaying the data

2. Scroll down to the "Details for a Specific Year" section
Expected: there are 3 filter fields

3. Select in the Dropdowns
Year: 2022
Age Group: 50-64 years
Demographic: Race/Ethnicity - All Available
Expected: The chart displays data and there are 2 bars that have the N/A label

4. Hover over the first N/A Bar
Expected: The Tooltip displays:
Asian/Pacific Islander: N/A
95%_CI : null 


## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
