### PR TITLE
Fix [new-50356] data table pivot rounding

### DIFF
--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -88,7 +88,7 @@ const DataTable = (props: DataTableProps) => {
       }
     }
     return data
-  }, [parentRuntimeData, config.table.pivot?.columnName, config.table.pivot?.valueColumn])
+  }, [parentRuntimeData, config.table.pivot?.columnName, config.table.pivot?.valueColumns])
 
   const [expanded, setExpanded] = useState(expandDataTable)
   const [sortBy, setSortBy] = useState<any>({

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -54,7 +54,7 @@ const ChartHeader = ({
   }
 
   const ColumnHeadingText = ({ column, text, config }) => {
-    if (text === 'pivotColumn') return ''
+    if (text === '_pivotedFrom') return ''
     let notApplicableText = 'Not Applicable'
     if (text === '__series__' && config.table.indexLabel) return `${config.table.indexLabel} `
     if (text === '__series__' && !config.table.indexLabel)

--- a/packages/core/components/DataTable/helpers/getDataSeriesColumns.ts
+++ b/packages/core/components/DataTable/helpers/getDataSeriesColumns.ts
@@ -61,5 +61,9 @@ export const getDataSeriesColumns = (config: TableConfig, isVertical: boolean, r
     if (b === 'pivotColumn') return 1
     return columnOrderingHash[a] - columnOrderingHash[b]
   })
-  return tmpSeriesColumns
+
+  return tmpSeriesColumns.filter(colName => {
+    // remove metadata added by pivotData function
+    return colName !== '_pivotedFrom'
+  })
 }

--- a/packages/core/components/DataTable/helpers/getDataSeriesColumns.ts
+++ b/packages/core/components/DataTable/helpers/getDataSeriesColumns.ts
@@ -57,8 +57,8 @@ export const getDataSeriesColumns = (config: TableConfig, isVertical: boolean, r
   })
 
   tmpSeriesColumns.sort((a, b) => {
-    if (a === 'pivotColumn') return -1
-    if (b === 'pivotColumn') return 1
+    if (a === '_pivotedFrom') return -1
+    if (b === '_pivotedFrom') return 1
     return columnOrderingHash[a] - columnOrderingHash[b]
   })
 

--- a/packages/core/helpers/pivotData.ts
+++ b/packages/core/helpers/pivotData.ts
@@ -31,7 +31,8 @@ export const pivotData = (data: Record<string, any>[], columnName: string, pivot
         aggregateRows[key][pivotColumn] = {
           ...aggregateRows[key][pivotColumn],
           ...toAdd,
-          [row[columnName]]: row[pivotColumn]
+          [row[columnName]]: row[pivotColumn],
+          _pivotedFrom: pivotColumn
         }
       })
     } else {
@@ -40,7 +41,8 @@ export const pivotData = (data: Record<string, any>[], columnName: string, pivot
       aggregateRows[key] = {
         ...aggregateRows[key],
         ...toAdd,
-        [row[columnName]]: row[_pivot]
+        [row[columnName]]: row[_pivot],
+        _pivotedFrom: _pivot
       }
     }
 

--- a/packages/core/helpers/pivotData.ts
+++ b/packages/core/helpers/pivotData.ts
@@ -52,7 +52,7 @@ export const pivotData = (data: Record<string, any>[], columnName: string, pivot
   if (pivot.length > 1) {
     return Object.keys(aggregateRows).flatMap(aggregateKey => {
       return Object.keys(aggregateRows[aggregateKey]).map(pivotColumn => ({
-        pivotColumn,
+        _pivotedFrom: pivotColumn,
         ...aggregateRows[aggregateKey][pivotColumn]
       }))
     })

--- a/packages/core/helpers/tests/pivotData.test.ts
+++ b/packages/core/helpers/tests/pivotData.test.ts
@@ -12,8 +12,8 @@ describe('pivotData', () => {
   it('should pivot data correctly', () => {
     const result = pivotData(data, 'name', ['age'])
     expect(result).toEqual([
-      { city: 'New York', John: 25, Jane: 27 },
-      { city: 'San Francisco', Jane: 30, John: 31 }
+      { city: 'New York', John: 25, Jane: 27, _pivotedFrom: 'age' },
+      { city: 'San Francisco', Jane: 30, John: 31, _pivotedFrom: 'age' }
     ])
   })
   it('should fill in columns with no data with empty strings', () => {
@@ -21,15 +21,15 @@ describe('pivotData', () => {
     const result = pivotData(data2, 'name', ['age'])
 
     expect(result).toEqual([
-      { city: 'New York', John: 25, Jane: '' },
-      { city: 'San Francisco', Jane: 30, John: '' }
+      { city: 'New York', John: 25, Jane: '', _pivotedFrom: 'age' },
+      { city: 'San Francisco', Jane: 30, John: '', _pivotedFrom: 'age' }
     ])
 
     const data3 = [data[0], data[1], data[2]]
     const result2 = pivotData(data3, 'name', ['age'])
     expect(result2).toEqual([
-      { city: 'New York', John: 25, Jane: 27 },
-      { city: 'San Francisco', Jane: 30, John: '' }
+      { city: 'New York', John: 25, Jane: 27, _pivotedFrom: 'age' },
+      { city: 'San Francisco', Jane: 30, John: '', _pivotedFrom: 'age' }
     ])
   })
   it('should be able to pivot more than one column', () => {
@@ -41,10 +41,10 @@ describe('pivotData', () => {
     ]
     const result = pivotData(data, 'name', ['age', 'color'])
     expect(result).toEqual([
-      { city: 'New York', John: 25, Jane: 27, pivotColumn: 'age' },
-      { city: 'New York', John: 'blue', Jane: 'red', pivotColumn: 'color' },
-      { city: 'San Francisco', Jane: 30, John: 31, pivotColumn: 'age' },
-      { city: 'San Francisco', Jane: 'yellow', John: 'green', pivotColumn: 'color' }
+      { city: 'New York', John: 25, Jane: 27, _pivotedFrom: 'age' },
+      { city: 'New York', John: 'blue', Jane: 'red', _pivotedFrom: 'color' },
+      { city: 'San Francisco', Jane: 30, John: 31, _pivotedFrom: 'age' },
+      { city: 'San Francisco', Jane: 'yellow', John: 'green', _pivotedFrom: 'color' }
     ])
   })
 })


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: Load storybook and navigate to Pages/Dashboard/Pivot Filter. Toggle the Edit mode.

1) Click the tools icon to edit the data table.
2) Make sure to select some values from the multi select panel.
3) Under columns add a column configuration.
4) Select Age-adjusted Rate.
5) Increase the Round to 1.

Expected: the values in the table should show a decimal place.

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
