### PR TITLE
Enhancement: New 50360 Widgets having datasets when in a Row with a dataset causing config issues

### DIFF
--- a/packages/dashboard/src/components/DataDesignerModal.tsx
+++ b/packages/dashboard/src/components/DataDesignerModal.tsx
@@ -29,20 +29,16 @@ export const DataDesignerModal: React.FC<DataDesignerModalProps> = ({ vizKey, ro
   const [errorMessage, setErrorMessage] = useState('')
   const [loadingAPIData, setLoadingAPIData] = useState(false)
 
+  const isUpdatingVisualization = useMemo(() => {
+    return !!vizKey && !useRow
+  }, [vizKey, useRow])
+
   const configureData = useMemo(() => {
-    if (vizKey && !useRow) {
+    if (isUpdatingVisualization) {
       return config.visualizations[vizKey]
     }
     return config.rows[rowIndex]
-  }, [config.visualizations, config.rows, vizKey, rowIndex, useRow])
-
-  const updateConfigureData = (newConfigureData: Partial<ConfigureData>) => {
-    if (vizKey && !useRow) {
-      dispatch({ type: 'UPDATE_VISUALIZATION', payload: { vizKey, configureData: newConfigureData } })
-    } else {
-      dispatch({ type: 'UPDATE_ROW', payload: { rowIndex, rowData: newConfigureData } })
-    }
-  }
+  }, [config.visualizations, config.rows, rowIndex, isUpdatingVisualization])
 
   const fetchData = async datasetKey => {
     const { data, dataUrl } = config.datasets[datasetKey]
@@ -65,26 +61,32 @@ export const DataDesignerModal: React.FC<DataDesignerModalProps> = ({ vizKey, ro
     return newData
   }
 
-  const removeDataset = (widgetKey = vizKey) => {
-    const newConfigureData = widgetKey ? config.visualizations[widgetKey] : config.rows[rowIndex]
-    delete newConfigureData.data
-    delete newConfigureData.dataKey
-    delete newConfigureData.dataDescription
-    delete newConfigureData.formattedData
+  const updateConfigureData = (newConfigureData: Partial<ConfigureData>) => {
+    if (isUpdatingVisualization) {
+      dispatch({ type: 'UPDATE_VISUALIZATION', payload: { vizKey, configureData: newConfigureData } })
+    } else {
+      dispatch({ type: 'UPDATE_ROW', payload: { rowIndex, rowData: newConfigureData } })
+    }
+  }
 
-    return (newConfigureData as ConfigureData) || {}
+  const removeDatasetsFromVisualizations = () => {
+    const columnVisualizations = config.rows[rowIndex].columns.map(column => column.widget).filter(Boolean)
+    columnVisualizations.forEach(currentVisualizationKey => {
+      dispatch({ type: 'RESET_VISUALIZATION', payload: { vizKey: currentVisualizationKey } })
+    })
   }
 
   const changeDataset = async ({ target: { value } }) => {
+    if (!isUpdatingVisualization) removeDatasetsFromVisualizations()
     const newData = value === '' ? {} : await fetchData(value)
-    const newConfigureData =
-      value === '' ? removeDataset() : { dataDescription: {}, formattedData: undefined, dataKey: value, data: newData }
-
-    const columnWidgets = config.rows[rowIndex].columns.filter(column => column.widget).map(column => column.widget)
-    if (!vizKey) {
-      columnWidgets.forEach(currentWidgetKey => removeDataset(currentWidgetKey))
-    }
-
+    const newConfigureData = {
+      dataDescription: {
+        horizontal: false
+      },
+      formattedData: undefined,
+      dataKey: value,
+      data: newData
+    } as ConfigureData
     updateConfigureData(newConfigureData)
   }
 
@@ -128,12 +130,13 @@ export const DataDesignerModal: React.FC<DataDesignerModalProps> = ({ vizKey, ro
               Object.keys(config.datasets).map(datasetKey => <option key={datasetKey}>{datasetKey}</option>)}
           </select>
           {vizKey && (
+            // only shows for visualizations
             <CheckBox
               label='Apply To Row'
               value={useRow}
               updateField={(section, subsection, fieldName, value) => {
                 setUseRow(value)
-                changeDataset({ target: { value: '' } })
+                changeDataset({ target: { value: configureData.dataKey } })
               }}
             />
           )}

--- a/packages/dashboard/src/components/DataDesignerModal.tsx
+++ b/packages/dashboard/src/components/DataDesignerModal.tsx
@@ -65,9 +65,25 @@ export const DataDesignerModal: React.FC<DataDesignerModalProps> = ({ vizKey, ro
     return newData
   }
 
+  const removeDataset = (widgetKey = vizKey) => {
+    const newConfigureData = widgetKey ? config.visualizations[widgetKey] : config.rows[rowIndex]
+    delete newConfigureData.data
+    delete newConfigureData.dataKey
+    delete newConfigureData.dataDescription
+    delete newConfigureData.formattedData
+
+    return (newConfigureData as ConfigureData) || {}
+  }
+
   const changeDataset = async ({ target: { value } }) => {
-    const newData = await fetchData(value)
-    const newConfigureData = { dataDescription: {}, formattedData: undefined, dataKey: value, data: newData }
+    const newData = value === '' ? {} : await fetchData(value)
+    const newConfigureData =
+      value === '' ? removeDataset() : { dataDescription: {}, formattedData: undefined, dataKey: value, data: newData }
+
+    const columnWidgets = config.rows[rowIndex].columns.filter(column => column.widget).map(column => column.widget)
+    if (!vizKey) {
+      columnWidgets.forEach(currentWidgetKey => removeDataset(currentWidgetKey))
+    }
 
     updateConfigureData(newConfigureData)
   }

--- a/packages/dashboard/src/store/dashboard.actions.ts
+++ b/packages/dashboard/src/store/dashboard.actions.ts
@@ -30,6 +30,7 @@ type ADD_NEW_DASHBOARD = Action<'ADD_NEW_DASHBOARD', undefined>
 type SAVE_CURRENT_CHANGES = Action<'SAVE_CURRENT_CHANGES', undefined>
 type SWITCH_CONFIG = Action<'SWITCH_CONFIG', number>
 type TOGGLE_ROW = Action<'TOGGLE_ROW', { rowIndex: number; colIndex: number }>
+type RESET_VISUALIZATION = Action<'RESET_VISUALIZATION', { vizKey: string }>
 type UPDATE_VISUALIZATION = Action<'UPDATE_VISUALIZATION', { vizKey: string; configureData: Partial<AnyVisualization> }>
 type UPDATE_ROW = Action<'UPDATE_ROW', { rowIndex: number; rowData: Partial<ConfigRow> }>
 type UPDATE_TOGGLE_NAME = Action<'UPDATE_TOGGLE_NAME', { rowIndex: number; columnIndex: number; toggleName: string }>
@@ -56,6 +57,7 @@ type DashboardActions =
   | SWITCH_CONFIG
   | INITIALIZE_MULTIDASHBOARDS
   | TOGGLE_ROW
+  | RESET_VISUALIZATION
   | UPDATE_VISUALIZATION
   | UPDATE_ROW
   | UPDATE_TOGGLE_NAME

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -195,6 +195,21 @@ const reducer = (state: DashboardState, action: DashboardActions): DashboardStat
         config: saveMultiChanges({ ...state.config, rows: newRows }, state.config.activeDashboard)
       }
     }
+    case 'RESET_VISUALIZATION': {
+      const { vizKey } = action.payload
+      const updatedViz = { ...state.config.visualizations[vizKey] } as AnyVisualization
+      delete updatedViz.data
+      delete updatedViz.dataKey
+      delete updatedViz.dataDescription
+      delete updatedViz.formattedData
+      return {
+        ...state,
+        config: saveMultiChanges(
+          { ...state.config, visualizations: { ...state.config.visualizations, [vizKey]: updatedViz } },
+          state.config.activeDashboard
+        )
+      }
+    }
     case 'UPDATE_VISUALIZATION': {
       const { vizKey, configureData } = action.payload
       const updatedViz = { ...state.config.visualizations[vizKey], ...configureData } as AnyVisualization


### PR DESCRIPTION
## NEW-50360

Delete the dataKey from the Vizualizations in a row if the Row is given a dataKey

## Testing Steps

Scenario: upload [dev-50360-config.json](https://github.com/user-attachments/files/19291987/dev-50360-config.json) and open the Configuration tab
Expected: There is a Row with a table widget in it.

1. Click on the Widgets gear icon and choose a dataset
2. Click Vertical, No, and then Continue
3. In the Editor panel on the left, scroll all of the way down click Advanced Options

Expected: The Advanced Options menu will open and there will be a list of properties with arrows next to them. The two main properties to look at are rows and visualizations. In visualizations under table1741961876645, there will be dataKey: "valid-data-chart.csv"

4. Leave the Advanced Options open
5. Click on the 3 gears icon on the Row that has the table widget
6. Select a dataset for the Row, click Vertical, No, and continue

Expected: In Advanced Options, the dataKey: "valid-data-chart.csv" has been removed from table1741961876645. Scroll up in the Advanced Options to rows and there will be dataKey: "valid-data-chart.csv" under the 0 row in the rows property

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
