### PR TITLE
Fix [DEV 10067] Polyfill BS5 padding

### DIFF
--- a/packages/core/styles/base.scss
+++ b/packages/core/styles/base.scss
@@ -192,4 +192,46 @@ body.post-type-cdc_visualization .cdc-editor .configure .editor-panel {
   .ms-auto {
     margin-left: auto !important;
   }
+  .pe-0 {
+    padding-right: 0 !important;
+  }
+  .pe-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pe-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pe-3 {
+    padding-right: 1rem !important;
+  }
+  .pe-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pe-5 {
+    padding-right: 3rem !important;
+  }
+  .pe-auto {
+    padding-right: auto !important;
+  }
+  .ps-0 {
+    padding-left: 0 !important;
+  }
+  .ps-1 {
+    padding-left: 0.25rem !important;
+  }
+  .ps-2 {
+    padding-left: 0.5rem !important;
+  }
+  .ps-3 {
+    padding-left: 1rem !important;
+  }
+  .ps-4 {
+    padding-left: 1.5rem !important;
+  }
+  .ps-5 {
+    padding-left: 3rem !important;
+  }
+  .ps-auto {
+    padding-left: auto !important;
+  }
 }


### PR DESCRIPTION
## DEV 10067

Polyfill BS5 classes to account for pages still using TP4

## Testing Steps

1. load preview page with TP4
2. confirm 'pe' & 'ps' classes work

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Additional Notes

*An update has been added to TP4 to include the polyfills in TP4. After this release the COVE polyfill should be removed
