### PR TITLE
Fix: NEW-50362 Data value dots vary in size on dynamic series line charts

### DIFF
--- a/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
+++ b/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
@@ -46,7 +46,7 @@ const Glyphs = [
 const LineChartCircle = (props: LineChartCircleProps) => {
   const {
     config,
-    d,
+    d: pointData,
     tableData,
     displayArea,
     seriesKey,
@@ -96,7 +96,7 @@ const LineChartCircle = (props: LineChartCircleProps) => {
   if (mode === 'ALWAYS_SHOW_POINTS' && lineDatapointStyle !== 'hidden') {
     if (lineDatapointStyle === 'always show') {
       const isMatch = circleData?.some(
-        cd => cd[config.xAxis.dataKey] === d[config.xAxis.dataKey] && cd[seriesKey] === d[seriesKey]
+        cd => cd[config.xAxis.dataKey] === pointData[config.xAxis.dataKey] && cd[seriesKey] === pointData[seriesKey]
       )
 
       if (
@@ -105,13 +105,14 @@ const LineChartCircle = (props: LineChartCircleProps) => {
         (visual.maximumShapeAmount === seriesIndex && visual.lineDatapointSymbol === 'standard')
       )
         return <></>
-      const positionLeft = getXPos(d[config.xAxis.dataKey])
-      const positionTop = filtered.axis === 'Right' ? yScaleRight(d[filtered.dataKey]) : yScale(d[filtered.dataKey])
+      const positionLeft = getXPos(pointData[config.xAxis.dataKey])
+      const positionTop =
+        filtered.axis === 'Right' ? yScaleRight(pointData[filtered.dataKey]) : yScale(pointData[filtered.dataKey])
 
       return (
         <g transform={transformShape(positionTop, positionLeft)}>
           <Shape
-            opacity={d[seriesKey] ? 1 : 0}
+            opacity={pointData[seriesKey] ? 1 : 0}
             fillOpacity={1}
             fill={getColor(displayArea, colorScale, config, seriesKey, seriesKey)}
             style={{ filter: 'unset', opacity: 1 }}
@@ -178,19 +179,24 @@ const LineChartCircle = (props: LineChartCircleProps) => {
     }
   }
   if (mode === 'ISOLATED_POINTS') {
+    const findDataIndex = () => {
+      const indexNumber = data.findIndex(item => item[config.xAxis.dataKey] === pointData[config.xAxis.dataKey])
+      return indexNumber
+    }
     const drawIsolatedPoints = (currentIndex, seriesKey) => {
-      const currentPoint = data[currentIndex]
-      const previousPoint = data[currentIndex - 1] || {}
-      const nextPoint = data[currentIndex + 1] || {}
+      const workingIndex = pointData ? findDataIndex() : currentIndex
+      const currentPoint = data[workingIndex]
+      const previousPoint = data[workingIndex - 1] || {}
+      const nextPoint = data[workingIndex + 1] || {}
 
       const isMatch = circleData.some(item => item?.data[seriesKey] === currentPoint[seriesKey])
       if (isMatch) return false
 
-      const isFirstPoint = currentIndex === 0 && !nextPoint[seriesKey]
-      const isLastPoint = currentIndex === data.length - 1 && !previousPoint[seriesKey]
+      const isFirstPoint = workingIndex === 0 && !nextPoint[seriesKey]
+      const isLastPoint = workingIndex === data.length - 1 && !previousPoint[seriesKey]
       const isMiddlePoint =
-        currentIndex > 0 &&
-        currentIndex < data.length - 1 &&
+        workingIndex > 0 &&
+        workingIndex < data.length - 1 &&
         currentPoint[seriesKey] &&
         !previousPoint[seriesKey] &&
         !nextPoint[seriesKey]
@@ -199,8 +205,9 @@ const LineChartCircle = (props: LineChartCircleProps) => {
     }
 
     if (drawIsolatedPoints(dataIndex, seriesKey)) {
-      const positionTop = filtered?.axis === 'Right' ? yScaleRight(d[filtered?.dataKey]) : yScale(d[filtered?.dataKey])
-      const positionLeft = getXPos(d[config.xAxis?.dataKey])
+      const positionTop =
+        filtered?.axis === 'Right' ? yScaleRight(pointData[filtered?.dataKey]) : yScale(pointData[filtered?.dataKey])
+      const positionLeft = getXPos(pointData[config.xAxis?.dataKey])
       const color = colorScale(config.runtime.seriesLabelsAll[seriesIndex])
 
       return (

--- a/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
+++ b/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
@@ -179,32 +179,30 @@ const LineChartCircle = (props: LineChartCircleProps) => {
     }
   }
   if (mode === 'ISOLATED_POINTS') {
-    const findDataIndex = () => {
-      const indexNumber = data.findIndex(item => item[config.xAxis.dataKey] === pointData[config.xAxis.dataKey])
-      return indexNumber
-    }
     const drawIsolatedPoints = (currentIndex, seriesKey) => {
-      const workingIndex = pointData ? findDataIndex() : currentIndex
-      const currentPoint = data[workingIndex]
-      const previousPoint = data[workingIndex - 1] || {}
-      const nextPoint = data[workingIndex + 1] || {}
+      const currentPoint = data[currentIndex]
+      const previousPoint = data[currentIndex - 1] || {}
+      const nextPoint = data[currentIndex + 1] || {}
 
       const isMatch = circleData.some(item => item?.data[seriesKey] === currentPoint[seriesKey])
       if (isMatch) return false
 
-      const isFirstPoint = workingIndex === 0 && !nextPoint[seriesKey]
-      const isLastPoint = workingIndex === data.length - 1 && !previousPoint[seriesKey]
+      const isFirstPoint = currentIndex === 0 && !nextPoint[seriesKey]
+      const isLastPoint = currentIndex === data.length - 1 && !previousPoint[seriesKey]
       const isMiddlePoint =
-        workingIndex > 0 &&
-        workingIndex < data.length - 1 &&
+        currentIndex > 0 &&
+        currentIndex < data.length - 1 &&
         currentPoint[seriesKey] &&
         !previousPoint[seriesKey] &&
         !nextPoint[seriesKey]
 
       return isFirstPoint || isLastPoint || isMiddlePoint
     }
+    const _dataIndex = pointData
+      ? data.findIndex(item => item[config.xAxis.dataKey] === pointData[config.xAxis.dataKey])
+      : dataIndex
 
-    if (drawIsolatedPoints(dataIndex, seriesKey)) {
+    if (drawIsolatedPoints(_dataIndex, seriesKey)) {
       const positionTop =
         filtered?.axis === 'Right' ? yScaleRight(pointData[filtered?.dataKey]) : yScale(pointData[filtered?.dataKey])
       const positionLeft = getXPos(pointData[config.xAxis?.dataKey])


### PR DESCRIPTION
## NEW-50362

## Testing Steps

Scenario: upload https://cdc.sharepoint.com/teams/OADC-DPA-DMB-WCMS-TPVisualizationsProject/_layouts/15/download.aspx?UniqueId=8235bee51f5f4d36ba6feb00fa34369c&e=vle37l and open the Dashboard Preview

Expected: There is a Line Chart with multiple lines. There is also individual points for both Am/Alaskan Native and Black, non-Hispanic data. These points are the same sizes of each other but, are bigger than the points on the lines of the chart.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
