### PR TITLE
Fix [dev-10534] download image cutting

### DIFF
--- a/packages/chart/src/components/AreaChart/components/AreaChart.jsx
+++ b/packages/chart/src/components/AreaChart/components/AreaChart.jsx
@@ -14,13 +14,28 @@ import { bisector } from 'd3-array'
 const AreaChart = props => {
   const { xScale, yScale, yMax, xMax, handleTooltipMouseOver, handleTooltipMouseOff, isDebug, children } = props
   // import data from context
-  let { transformedData, config, handleLineType, parseDate, formatDate, formatNumber, seriesHighlight, colorScale, rawData, brushConfig } = useContext(ConfigContext)
+  let {
+    transformedData,
+    config,
+    handleLineType,
+    parseDate,
+    formatDate,
+    formatNumber,
+    seriesHighlight,
+    colorScale,
+    rawData,
+    brushConfig
+  } = useContext(ConfigContext)
   const data = config.brush?.active && brushConfig.data?.length ? brushConfig.data : transformedData
 
   if (!data) return
 
   const handleX = d => {
-    return (isDateScale(config.xAxis) ? xScale(parseDate(d[config.xAxis.dataKey], false)) : xScale(d[config.xAxis.dataKey])) + (xScale.bandwidth ? xScale.bandwidth() / 2 : 0)
+    return (
+      (isDateScale(config.xAxis)
+        ? xScale(parseDate(d[config.xAxis.dataKey], false))
+        : xScale(d[config.xAxis.dataKey])) + (xScale.bandwidth ? xScale.bandwidth() / 2 : 0)
+    )
   }
 
   const handleY = (d, index, s = undefined) => {
@@ -41,8 +56,14 @@ const AreaChart = props => {
               })
 
               let curveType = allCurves[s.lineType]
-              let transparentArea = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(s.dataKey) === -1
-              let displayArea = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(s.dataKey) !== -1
+              let transparentArea =
+                config.legend.behavior === 'highlight' &&
+                seriesHighlight.length > 0 &&
+                seriesHighlight.indexOf(s.dataKey) === -1
+              let displayArea =
+                config.legend.behavior === 'highlight' ||
+                seriesHighlight.length === 0 ||
+                seriesHighlight.indexOf(s.dataKey) !== -1
 
               return (
                 <React.Fragment key={index}>
@@ -74,7 +95,14 @@ const AreaChart = props => {
                 </React.Fragment>
               )
             })}
-            <Bar width={Number(xMax)} height={Number(yMax)} fill={'transparent'} fillOpacity={0.05} onMouseMove={e => handleTooltipMouseOver(e, rawData)} onMouseLeave={handleTooltipMouseOff} />
+            <Bar
+              width={Number(xMax)}
+              height={Number(yMax)}
+              fill={'transparent'}
+              fillOpacity={0.05}
+              onMouseMove={e => handleTooltipMouseOver(e, rawData)}
+              onMouseLeave={handleTooltipMouseOff}
+            />
           </Group>
         </ErrorBoundary>
       </svg>

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -226,7 +226,10 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     leftMax,
     rightMax,
     dimensions,
-    xMax: parentWidth - Number(config.orientation === 'horizontal' ? config.xAxis.size : config.yAxis.size)
+    xMax:
+      parentWidth -
+      Number(config.orientation === 'horizontal' ? config.xAxis.size : config.yAxis.size) -
+      (hasRightAxis ? config.yAxis.rightAxisSize : 0)
   })
 
   const [yTickCount, xTickCount] = ['yAxis', 'xAxis'].map(axis =>
@@ -613,7 +616,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
       </>
     )
   }
-
   return isNaN(width) ? (
     <React.Fragment></React.Fragment>
   ) : (
@@ -626,7 +628,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
         <svg
           ref={svgRef}
           onMouseMove={onMouseMove}
-          width={parentWidth}
+          width={parentWidth + config.yAxis.rightAxisSize}
           height={isNoDataAvailable ? 1 : parentHeight}
           className={`linear ${config.animate ? 'animated' : ''} ${animatedChart && config.animate ? 'animate' : ''} ${
             debugSvg && 'debug'
@@ -786,7 +788,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               handleTooltipClick={handleTooltipClick}
               tooltipData={tooltipData}
               showTooltip={showTooltip}
-              chartRef={svgRef}
+              //chartRef={svgRef}
             />
           )}
           {(visualizationType === 'Forecasting' || visualizationType === 'Combo') && (
@@ -1566,7 +1568,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               </TooltipWithBounds>
             </>
           )}
-
         {config.visualizationType === 'Bump Chart' && (
           <ReactTooltip
             id={`bump-chart`}

--- a/packages/chart/src/hooks/useRightAxis.ts
+++ b/packages/chart/src/hooks/useRightAxis.ts
@@ -1,9 +1,11 @@
 import { scaleLinear } from '@visx/scale'
 import useReduceData from './useReduceData'
+import { TOP_PADDING } from './useScales'
 
 export default function useRightAxis({ config, yMax = 0, data = [], updateConfig }) {
   const hasRightAxis = config.visualizationType === 'Combo' && config.orientation === 'vertical'
-  const rightSeriesKeys = config.series && config.series.filter(series => series.axis === 'Right').map(key => key.dataKey)
+  const rightSeriesKeys =
+    config.series && config.series.filter(series => series.axis === 'Right').map(key => key.dataKey)
   let { minValue } = useReduceData(config, data)
 
   const allRightAxisData = rightSeriesKeys => {
@@ -35,7 +37,7 @@ export default function useRightAxis({ config, yMax = 0, data = [], updateConfig
 
   const yScaleRight = scaleLinear({
     domain: [minValue, max],
-    range: [yMax, 0]
+    range: [yMax, TOP_PADDING]
   })
 
   return { yScaleRight, hasRightAxis }

--- a/packages/chart/src/hooks/useScales.ts
+++ b/packages/chart/src/hooks/useScales.ts
@@ -22,6 +22,8 @@ const scaleTypes = {
   BAND: 'band'
 }
 
+export const TOP_PADDING = 10
+
 type useScaleProps = {
   config: ChartConfig // standard chart config
   data: Object[] // standard data array
@@ -392,7 +394,7 @@ const composeYScale = ({ min, max, yMax, config, leftMax }) => {
 
   // If the visualization type is a bump chart then the domain and range need different values
   const domainSet = config.visualizationType === 'Bump Chart' ? [1, max] : [min, max]
-  const yRange = config.visualizationType === 'Bump Chart' ? [30, yMax] : [yMax, 0]
+  const yRange = config.visualizationType === 'Bump Chart' ? [30, yMax] : [yMax, TOP_PADDING]
   // Return the configured scale function
   return scaleFunc({
     domain: domainSet,


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

upload:
[dev-10534-download-image.json](https://github.com/user-attachments/files/19391282/dev-10534-download-image.json) and navigate to dashboard preview.

1) click download image:

Expected: you should get an image download with none of the visualization cut off.

2) navigate to the chart editor and switch the legend from bottom to right.

3) click download image.

Expected: visualization shouldn't be cut off


<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
