### PR TITLE
Fix [DEV-10399] Right align suppressed data

### DIFF
--- a/packages/core/helpers/isRightAlignedTableValue.js
+++ b/packages/core/helpers/isRightAlignedTableValue.js
@@ -1,6 +1,6 @@
 import { footnotesSymbols } from '@cdc/core/helpers/footnoteSymbols'
 
-const numericStrings = ['N/A', 'NA', ''].concat(footnotesSymbols.map(s => s[0]))
+const numericStrings = ['N/A', 'NA', '', 'Suppressed'].concat(footnotesSymbols.map(s => s[0]))
 
 export default function isRightAlignedTableValue(value = '') {
   if (!value) return false


### PR DESCRIPTION
## [DEV-10399]

Considers the text "Suppressed" to be a number for table alignment purposes.

## Testing Steps

Create a chart with data that includes "Suppressed", check that the column in the data table is right aligned.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
