### PR TITLE
Enhancement/fix new 50375 api sourced dashboard filters editor difficult to work with

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { SharedFilter } from '../../../../types/SharedFilter'
+import Tooltip from '@cdc/core/components/ui/Tooltip'
+import Icon from '@cdc/core/components/ui/Icon'
+
+type APIModalProps = {
+  filter: SharedFilter
+  isSubgroup: boolean
+  isNestedDropdown: boolean
+  textSelector: string
+  valueSelector: string
+  updateAPIFilter: Function
+}
+
+const APIModal: React.FC<APIModalProps> = ({
+  filter,
+  isNestedDropdown,
+  updateAPIFilter,
+  valueSelector,
+  textSelector
+}) => {
+  const [APIEndpoint, setAPIEndpoint] = useState(filter.apiFilter?.apiEndpoint || '')
+  const [APIValueSelector, setAPIValueSelector] = useState(filter.apiFilter?.valueSelector || '')
+  const [APITextSelector, setAPITextSelector] = useState(filter.apiFilter?.textSelector || '')
+  const [APISubGroupValueSelector, setAPISubGroupValueSelector] = useState(
+    filter.apiFilter?.subgroupValueSelector || ''
+  )
+  const [APISubGroupTextSelector, setAPISubGroupTextSelector] = useState(filter.apiFilter?.subgroupTextSelector || '')
+  return (
+    <fieldset className='edit-block mb-1 px-3 cdc-open-viz-module'>
+      <label className='d-block'>
+        <span>API Endpoint: </span>
+        <textarea
+          value={APIEndpoint}
+          rows={4}
+          onChange={e => setAPIEndpoint(e.target.value)}
+          className='w-100'
+          style={{ minHeight: '1.5rem', maxWidth: '90%' }}
+        />
+        {isNestedDropdown && (
+          <Tooltip style={{ textTransform: 'none' }}>
+            <Tooltip.Target>
+              <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+            </Tooltip.Target>
+            <Tooltip.Content>
+              <p>Your API Endpoint should return both value selector values.</p>
+            </Tooltip.Content>
+          </Tooltip>
+        )}
+      </label>
+      <div className='d-flex'>
+        <div className={`w-50${isNestedDropdown ? ' border border-dark p-1 m-1' : ''}`}>
+          <label>
+            <span>Value Selector: </span>
+            <input value={APIValueSelector || ''} onChange={e => setAPIValueSelector(e.target.value)} />
+            <Tooltip style={{ textTransform: 'none' }}>
+              <Tooltip.Target>
+                <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+              </Tooltip.Target>
+              <Tooltip.Content>
+                <p>Value to use in the html option element</p>
+              </Tooltip.Content>
+            </Tooltip>
+            <div>{` * Required`}</div>
+          </label>
+          <label>
+            <span>Display Text Selector: </span>
+            <input value={APITextSelector || ''} onChange={e => setAPITextSelector(e.target.value)} />
+            <Tooltip style={{ textTransform: 'none' }}>
+              <Tooltip.Target>
+                <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+              </Tooltip.Target>
+              <Tooltip.Content>
+                <p>Text to use in the html option element. If none is applied value selector will be used.</p>
+              </Tooltip.Content>
+            </Tooltip>
+            <div>{` * Optional`}</div>
+          </label>
+        </div>
+
+        {isNestedDropdown && (
+          <div className={`w-50${isNestedDropdown ? ' border border-dark p-1 m-1' : ''}`}>
+            <label>
+              <span>Subgroup Value Selector: </span>
+              <input
+                value={APISubGroupValueSelector || ''}
+                onChange={e => setAPISubGroupValueSelector(e.target.value)}
+              />
+              <Tooltip style={{ textTransform: 'none' }}>
+                <Tooltip.Target>
+                  <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                </Tooltip.Target>
+                <Tooltip.Content>
+                  <p>Value to use in the html option element</p>
+                </Tooltip.Content>
+              </Tooltip>
+              <div>{` * Required`}</div>
+            </label>
+            <label>
+              <span>Subgroup Display Text Selector: </span>
+              <input value={APISubGroupTextSelector || ''} onChange={e => setAPISubGroupTextSelector(e.target.value)} />
+              <Tooltip style={{ textTransform: 'none' }}>
+                <Tooltip.Target>
+                  <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                </Tooltip.Target>
+                <Tooltip.Content>
+                  <p>Text to use in the html option element. If none is applied value selector will be used.</p>
+                </Tooltip.Content>
+              </Tooltip>
+              <div>{` * Optional`}</div>
+            </label>
+          </div>
+        )}
+      </div>
+      <div className='d-flex justify-content-end mt-2'>
+        <button
+          className='btn mt-2'
+          onClick={() => updateAPIFilter(APIEndpoint, APIValueSelector, APITextSelector, valueSelector, textSelector)}
+        >
+          Save
+        </button>
+      </div>
+    </fieldset>
+  )
+}
+
+export default APIModal

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
@@ -112,7 +112,7 @@ const APIModal: React.FC<APIModalProps> = ({
       </div>
       <div className='d-flex justify-content-end mt-2'>
         <button
-          className='btn mt-2'
+          className='btn btn-primary mt-2'
           onClick={() => updateAPIFilter(APIEndpoint, APIValueSelector, APITextSelector, valueSelector, textSelector)}
         >
           Save

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
@@ -22,12 +22,10 @@ const APIModal: React.FC<APIModalProps> = ({
   const [APIEndpoint, setAPIEndpoint] = useState(filter.apiFilter?.apiEndpoint || '')
   const [APIValueSelector, setAPIValueSelector] = useState(filter.apiFilter?.valueSelector || '')
   const [APITextSelector, setAPITextSelector] = useState(filter.apiFilter?.textSelector || '')
-  const [APISubGroupValueSelector, setAPISubGroupValueSelector] = useState(
-    filter.apiFilter?.subgroupValueSelector || ''
-  )
-  const [APISubGroupTextSelector, setAPISubGroupTextSelector] = useState(filter.apiFilter?.subgroupTextSelector || '')
+  const [APISubGroupValueSelector, setAPISubGroupValueSelector] = useState(filter.apiFilter?.subgroupValueSelector)
+  const [APISubGroupTextSelector, setAPISubGroupTextSelector] = useState(filter.apiFilter?.subgroupTextSelector)
   return (
-    <fieldset className='edit-block mb-1 px-3 cdc-open-viz-module'>
+    <fieldset className='mb-1 px-3 cdc-open-viz-module'>
       <label className='d-block'>
         <span>API Endpoint: </span>
         <textarea
@@ -61,7 +59,7 @@ const APIModal: React.FC<APIModalProps> = ({
                 <p>Value to use in the html option element</p>
               </Tooltip.Content>
             </Tooltip>
-            <div>{` * Required`}</div>
+            <p>{` * Required`}</p>
           </label>
           <label>
             <span>Display Text Selector: </span>
@@ -74,7 +72,7 @@ const APIModal: React.FC<APIModalProps> = ({
                 <p>Text to use in the html option element. If none is applied value selector will be used.</p>
               </Tooltip.Content>
             </Tooltip>
-            <div>{` * Optional`}</div>
+            <p>{` * Optional`}</p>
           </label>
         </div>
 
@@ -94,7 +92,7 @@ const APIModal: React.FC<APIModalProps> = ({
                   <p>Value to use in the html option element</p>
                 </Tooltip.Content>
               </Tooltip>
-              <div>{` * Required`}</div>
+              <p>{` * Required`}</p>
             </label>
             <label>
               <span>Subgroup Display Text Selector: </span>
@@ -107,7 +105,7 @@ const APIModal: React.FC<APIModalProps> = ({
                   <p>Text to use in the html option element. If none is applied value selector will be used.</p>
                 </Tooltip.Content>
               </Tooltip>
-              <div>{` * Optional`}</div>
+              <p>{` * Optional`}</p>
             </label>
           </div>
         )}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -351,54 +351,25 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                   updateField={(_section, _subSection, _key, value) => updateFilterProp('queryParameter', value)}
                 />
               )}
-              <label>
-                <span>API Endpoint: </span>
-                <textarea value={filter?.apiFilter.apiEndpoint || ''} />
-                {isNestedDropdown && (
-                  <Tooltip style={{ textTransform: 'none' }}>
-                    <Tooltip.Target>
-                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                    </Tooltip.Target>
-                    <Tooltip.Content>
-                      <p>Your API Endpoint should return both value selector values.</p>
-                    </Tooltip.Content>
-                  </Tooltip>
-                )}
-              </label>
-              <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
+              <div className='bg-secondary-subtle p-2 my-2'>
                 <label>
-                  <span>Value Selector: </span>
-                  <input value={filter?.apiFilter.valueSelector || ''} />
-                  <Tooltip style={{ textTransform: 'none' }}>
-                    <Tooltip.Target>
-                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                    </Tooltip.Target>
-                    <Tooltip.Content>
-                      <p>Value to use in the html option element</p>
-                    </Tooltip.Content>
-                  </Tooltip>
-                  {` * Required`}
+                  <span>API Endpoint: </span>
+                  <textarea value={filter?.apiFilter?.apiEndpoint || ''} disabled />
+                  {isNestedDropdown && (
+                    <Tooltip style={{ textTransform: 'none' }}>
+                      <Tooltip.Target>
+                        <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                      </Tooltip.Target>
+                      <Tooltip.Content>
+                        <p>Your API Endpoint should return both value selector values.</p>
+                      </Tooltip.Content>
+                    </Tooltip>
+                  )}
                 </label>
-                <label>
-                  <span>Display Text Selector: </span>
-                  <input value={filter?.apiFilter.textSelector || ''} />
-                  <Tooltip style={{ textTransform: 'none' }}>
-                    <Tooltip.Target>
-                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                    </Tooltip.Target>
-                    <Tooltip.Content>
-                      <p>Text to use in the html option element. If none is applied value selector will be used.</p>
-                    </Tooltip.Content>
-                  </Tooltip>
-                  {` * Optional`}
-                </label>
-              </div>
-
-              {isNestedDropdown && (
                 <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
                   <label>
-                    <span>Subgroup Value Selector: </span>
-                    <input value={filter?.apiFilter.subgroupValueSelector || ''} />
+                    <span>Value Selector: </span>
+                    <input value={filter?.apiFilter?.valueSelector || ''} disabled />
                     <Tooltip style={{ textTransform: 'none' }}>
                       <Tooltip.Target>
                         <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -407,11 +378,11 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                         <p>Value to use in the html option element</p>
                       </Tooltip.Content>
                     </Tooltip>
-                    {` * Required`}
+                    <div>{` * Required`}</div>
                   </label>
                   <label>
-                    <span>Subgroup Display Text Selector: </span>
-                    <input value={filter?.apifilter.subgroupTextSelector || ''} />
+                    <span>Display Text Selector: </span>
+                    <input value={filter?.apiFilter?.textSelector || ''} disabled />
                     <Tooltip style={{ textTransform: 'none' }}>
                       <Tooltip.Target>
                         <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -420,14 +391,48 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                         <p>Text to use in the html option element. If none is applied value selector will be used.</p>
                       </Tooltip.Content>
                     </Tooltip>
-                    {` * Optional`}
+                    <div>{` * Optional`}</div>
                   </label>
                 </div>
-              )}
 
-              <button onClick={() => handleEditAPIValues(filter, isNestedDropdown, updateAPIFilter)}>
-                Edit API Values
-              </button>
+                {isNestedDropdown && (
+                  <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
+                    <label>
+                      <span>Subgroup Value Selector: </span>
+                      <input value={filter?.apiFilter?.subgroupValueSelector || ''} disabled />
+                      <Tooltip style={{ textTransform: 'none' }}>
+                        <Tooltip.Target>
+                          <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                        </Tooltip.Target>
+                        <Tooltip.Content>
+                          <p>Value to use in the html option element</p>
+                        </Tooltip.Content>
+                      </Tooltip>
+                      <div>{` * Required`}</div>
+                    </label>
+                    <label>
+                      <span>Subgroup Display Text Selector: </span>
+                      <input value={filter?.apifilter?.subgroupTextSelector || ''} disabled />
+                      <Tooltip style={{ textTransform: 'none' }}>
+                        <Tooltip.Target>
+                          <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                        </Tooltip.Target>
+                        <Tooltip.Content>
+                          <p>Text to use in the html option element. If none is applied value selector will be used.</p>
+                        </Tooltip.Content>
+                      </Tooltip>
+                      <div>{` * Optional`}</div>
+                    </label>
+                  </div>
+                )}
+
+                <button
+                  onClick={() => handleEditAPIValues(filter, isNestedDropdown, updateAPIFilter)}
+                  className='btn mt-2'
+                >
+                  Edit API Values
+                </button>
+              </div>
 
               <label>
                 <input

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -419,7 +419,7 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
 
                 <button
                   onClick={() => handleEditAPIValues(filter, isNestedDropdown, updateAPIFilter)}
-                  className='btn mt-2'
+                  className='btn btn-primary mt-2'
                 >
                   Edit API Values
                 </button>

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -1,5 +1,4 @@
 import _ from 'lodash'
-import { APIFilter } from '../../../../types/APIFilter'
 import { getVizRowColumnLocator } from '../../../../helpers/getVizRowColumnLocator'
 import { Select, TextField } from '@cdc/core/components/EditorPanel/Inputs'
 import DataTransform from '@cdc/core/helpers/DataTransform'
@@ -14,10 +13,13 @@ import Loading from '@cdc/core/components/Loading'
 import { DashboardConfig } from '../../../../types/DashboardConfig'
 import { Visualization } from '@cdc/core/types/Visualization'
 import { hasDashboardApplyBehavior } from '../../../../helpers/hasDashboardApplyBehavior'
+import APIModal from './APIModal'
 import NestedDropDownDashboard from './NestedDropDownDashboard'
 import { FILTER_STYLE } from '../../../../types/FilterStyles'
 import { filterOrderOptions } from '@cdc/core/components/Filters'
 import FilterOrder from '@cdc/core/components/EditorPanel/VizFilterEditor/components/FilterOrder'
+import { useGlobalContext } from '@cdc/core/components/GlobalContext'
+import Modal from '@cdc/core/components/ui/Modal'
 
 type FilterEditorProps = {
   config: DashboardConfig
@@ -36,6 +38,7 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
 }) => {
   const [columns, setColumns] = useState<string[]>([])
   const [dataFiltersLoading, setDataFiltersLoading] = useState(false)
+
   const transform = new DataTransform()
   const filterStyles = Object.values(FILTER_STYLE)
 
@@ -126,11 +129,28 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
     loadColumnData()
   }, [config.datasets, config.dashboard.sharedFilters])
 
-  const updateAPIFilter = (key: keyof APIFilter, value: string | boolean) => {
-    const filterClone = _.cloneDeep(filter)
-    const _filter = filterClone.apiFilter || { apiEndpoint: '', valueSelector: '', textSelector: '' }
-    const newAPIFilter: APIFilter = { ..._filter, [key]: value }
+  const updateAPIFilter = (
+    APIEndpoint,
+    APIValueSelector,
+    APITextSelector,
+    APISubgroupValueSelector,
+    APISubgroupTextSelector
+  ) => {
+    const newAPIFilter = !isNestedDropdown
+      ? {
+          apiEndpoint: APIEndpoint,
+          valueSelector: APIValueSelector,
+          textSelector: APITextSelector
+        }
+      : {
+          apiEndpoint: APIEndpoint,
+          valueSelector: APIValueSelector,
+          textSelector: APITextSelector,
+          subgroupValueSelector: APISubgroupValueSelector,
+          subgroupTextSelector: APISubgroupTextSelector
+        }
     updateFilterProp('apiFilter', newAPIFilter)
+    overlay.actions.toggleOverlay(false)
   }
 
   const updateLabel = (value: string) => {
@@ -141,79 +161,23 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
     updateFilterProp('key', duplicateLabels.length ? value + ` (${duplicateLabels.length})` : value)
   }
 
-  const isNestedDropDown = filter.filterStyle === FILTER_STYLE.nestedDropdown
+  const isNestedDropdown = filter.filterStyle === FILTER_STYLE.nestedDropdown
 
-  type APIInputProps = {
-    isSubgroup?: boolean
-  }
-  const APIInputs: React.FC<APIInputProps> = ({ isSubgroup = false }) => {
-    const textSelector = isSubgroup ? 'subgroupTextSelector' : 'textSelector'
-    const valueSelector = isSubgroup ? 'subgroupValueSelector' : 'valueSelector'
+  const EditAPIValues = (filter, isNestedDropdown, updateAPIFilter) => {
     return (
-      <>
-        {!isSubgroup && (
-          <TextField
-            label='API Endpoint: '
-            value={filter.apiFilter?.apiEndpoint}
-            updateField={(_section, _subSection, _key, value) => updateAPIFilter('apiEndpoint', value)}
-            tooltip={
-              <>
-                {isNestedDropDown && (
-                  <Tooltip style={{ textTransform: 'none' }}>
-                    <Tooltip.Target>
-                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                    </Tooltip.Target>
-                    <Tooltip.Content>
-                      <p>Your API Endpoint should return both value selector values.</p>
-                    </Tooltip.Content>
-                  </Tooltip>
-                )}
-              </>
-            }
-          />
-        )}
-
-        <div className={isNestedDropDown ? 'border border-dark p-1 my-1' : ''}>
-          <TextField
-            label={`${isSubgroup ? 'Subgroup ' : ''}Value Selector:`}
-            value={filter?.apiFilter?.[valueSelector] || ''}
-            updateField={(_section, _subSection, _key, value) => updateAPIFilter(valueSelector, value)}
-            tooltip={
-              <>
-                <Tooltip style={{ textTransform: 'none' }}>
-                  <Tooltip.Target>
-                    <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                  </Tooltip.Target>
-                  <Tooltip.Content>
-                    <p>Value to use in the html option element</p>
-                  </Tooltip.Content>
-                </Tooltip>
-                {` * Required`}
-              </>
-            }
-          />
-
-          <TextField
-            label={`${isSubgroup ? 'Subgroup ' : ''}Display Text Selector:`}
-            value={filter?.apiFilter?.[textSelector] || ''}
-            updateField={(_section, _subSection, _key, value) => updateAPIFilter(textSelector, value)}
-            tooltip={
-              <>
-                <Tooltip style={{ textTransform: 'none' }}>
-                  <Tooltip.Target>
-                    <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                  </Tooltip.Target>
-                  <Tooltip.Content>
-                    <p>Text to use in the html option element. If none is applied value selector will be used.</p>
-                  </Tooltip.Content>
-                </Tooltip>
-                {` * Optional`}
-              </>
-            }
-          />
-        </div>
-      </>
+      <Modal>
+        <Modal.Content>
+          <APIModal filter={filter} isNestedDropdown={isNestedDropdown} updateAPIFilter={updateAPIFilter} />
+        </Modal.Content>
+      </Modal>
     )
+  }
+  const { overlay } = useGlobalContext()
+
+  const handleEditAPIValues = (filter, isNestedDropdown, updateAPIFilter) => {
+    {
+      overlay.actions.openOverlay(EditAPIValues(filter, isNestedDropdown, updateAPIFilter))
+    }
   }
 
   const selectFilterType = (type: string) => {
@@ -387,10 +351,83 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                   updateField={(_section, _subSection, _key, value) => updateFilterProp('queryParameter', value)}
                 />
               )}
+              <label>
+                <span>API Endpoint: </span>
+                <textarea value={filter?.apiFilter.apiEndpoint || ''} />
+                {isNestedDropdown && (
+                  <Tooltip style={{ textTransform: 'none' }}>
+                    <Tooltip.Target>
+                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                    </Tooltip.Target>
+                    <Tooltip.Content>
+                      <p>Your API Endpoint should return both value selector values.</p>
+                    </Tooltip.Content>
+                  </Tooltip>
+                )}
+              </label>
+              <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
+                <label>
+                  <span>Value Selector: </span>
+                  <input value={filter?.apiFilter.valueSelector || ''} />
+                  <Tooltip style={{ textTransform: 'none' }}>
+                    <Tooltip.Target>
+                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                    </Tooltip.Target>
+                    <Tooltip.Content>
+                      <p>Value to use in the html option element</p>
+                    </Tooltip.Content>
+                  </Tooltip>
+                  {` * Required`}
+                </label>
+                <label>
+                  <span>Display Text Selector: </span>
+                  <input value={filter?.apiFilter.textSelector || ''} />
+                  <Tooltip style={{ textTransform: 'none' }}>
+                    <Tooltip.Target>
+                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                    </Tooltip.Target>
+                    <Tooltip.Content>
+                      <p>Text to use in the html option element. If none is applied value selector will be used.</p>
+                    </Tooltip.Content>
+                  </Tooltip>
+                  {` * Optional`}
+                </label>
+              </div>
 
-              <APIInputs />
+              {isNestedDropdown && (
+                <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
+                  <label>
+                    <span>Subgroup Value Selector: </span>
+                    <input value={filter?.apiFilter.subgroupValueSelector || ''} />
+                    <Tooltip style={{ textTransform: 'none' }}>
+                      <Tooltip.Target>
+                        <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                      </Tooltip.Target>
+                      <Tooltip.Content>
+                        <p>Value to use in the html option element</p>
+                      </Tooltip.Content>
+                    </Tooltip>
+                    {` * Required`}
+                  </label>
+                  <label>
+                    <span>Subgroup Display Text Selector: </span>
+                    <input value={filter?.apifilter.subgroupTextSelector || ''} />
+                    <Tooltip style={{ textTransform: 'none' }}>
+                      <Tooltip.Target>
+                        <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                      </Tooltip.Target>
+                      <Tooltip.Content>
+                        <p>Text to use in the html option element. If none is applied value selector will be used.</p>
+                      </Tooltip.Content>
+                    </Tooltip>
+                    {` * Optional`}
+                  </label>
+                </div>
+              )}
 
-              {isNestedDropDown && <APIInputs isSubgroup={true} />}
+              <button onClick={() => handleEditAPIValues(filter, isNestedDropdown, updateAPIFilter)}>
+                Edit API Values
+              </button>
 
               <label>
                 <input
@@ -629,7 +666,7 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                 </select>
               </label>
 
-              {!isNestedDropDown && (
+              {!isNestedDropdown && (
                 <TextField
                   label='Default Value Set By Query String Parameter: '
                   value={filter.setByQueryParameter || ''}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -129,25 +129,19 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
     loadColumnData()
   }, [config.datasets, config.dashboard.sharedFilters])
 
-  const updateAPIFilter = (
-    APIEndpoint,
-    APIValueSelector,
-    APITextSelector,
-    APISubgroupValueSelector,
-    APISubgroupTextSelector
-  ) => {
+  const updateAPIFilter = (apiEndpoint, valueSelector, textSelector, subgroupValueSelector, subgroupTextSelector) => {
     const newAPIFilter = !isNestedDropdown
       ? {
-          apiEndpoint: APIEndpoint,
-          valueSelector: APIValueSelector,
-          textSelector: APITextSelector
+          apiEndpoint,
+          valueSelector,
+          textSelector
         }
       : {
-          apiEndpoint: APIEndpoint,
-          valueSelector: APIValueSelector,
-          textSelector: APITextSelector,
-          subgroupValueSelector: APISubgroupValueSelector,
-          subgroupTextSelector: APISubgroupTextSelector
+          apiEndpoint,
+          valueSelector,
+          textSelector,
+          subgroupValueSelector,
+          subgroupTextSelector
         }
     updateFilterProp('apiFilter', newAPIFilter)
     overlay.actions.toggleOverlay(false)
@@ -163,20 +157,17 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
 
   const isNestedDropdown = filter.filterStyle === FILTER_STYLE.nestedDropdown
 
-  const EditAPIValues = (filter, isNestedDropdown, updateAPIFilter) => {
-    return (
-      <Modal>
-        <Modal.Content>
-          <APIModal filter={filter} isNestedDropdown={isNestedDropdown} updateAPIFilter={updateAPIFilter} />
-        </Modal.Content>
-      </Modal>
-    )
-  }
   const { overlay } = useGlobalContext()
 
   const handleEditAPIValues = (filter, isNestedDropdown, updateAPIFilter) => {
     {
-      overlay.actions.openOverlay(EditAPIValues(filter, isNestedDropdown, updateAPIFilter))
+      overlay.actions.openOverlay(
+        <Modal>
+          <Modal.Content>
+            <APIModal filter={filter} isNestedDropdown={isNestedDropdown} updateAPIFilter={updateAPIFilter} />
+          </Modal.Content>
+        </Modal>
+      )
     }
   }
 


### PR DESCRIPTION
## NEW-50375

Scenario: Upload [NEW-50375-config.json](https://github.com/user-attachments/files/19448884/NEW-50375-config.json), open the Configuration Tab, and click on the tools icon on the top Filter Dropdowns widget.
Expected: Dashboard Filters Editor opens with 2 filters: Location and Time Period

1. Open the Filters Accordion tab and open the Location filter
2. Scroll down to the gray area that has the API Endpoint
3. Click on the Edit API Values button. 
Expected: A module pops up with 3 text inputs: API Endpoint, Value Selector, and Display Text Selector

4. Change the text in the boxes
5. Then click the Save button
Expected: The values in the gray box will reflect the changes made in the module.

6. Scroll up to Filter Style and change it to Nested-Dropdown
7. Scroll back to the gray area and click the Edit API Values button
Expected: The module pops up with 5 inputs, the same as the other one but with subgroup values. 
## Testing Steps

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
