### PR TITLE
Fix/NEW-50376 Data value dots vary in size on dynamic series line charts

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
@@ -222,9 +222,9 @@ const PanelVisual: FC<PanelProps> = props => {
               options={['Same as Line', 'Lighter than Line']}
             />
             <CheckBox
-              value={(config as LineChartConfig).enlargeIsolatedDots}
-              fieldName='enlargeIsolatedDots'
-              label='Enlarge Isolated Dots'
+              value={(config as LineChartConfig).isolatedDotsSameSize}
+              fieldName='isolatedDotsSameSize'
+              label='Isolated Dots Same Size'
               updateField={updateField}
             />
           </>

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
@@ -22,6 +22,7 @@ import { useEditorPermissions } from '../../useEditorPermissions.js'
 import { useEditorPanelContext } from '../../EditorPanelContext.js'
 import ConfigContext from '../../../../ConfigContext.js'
 import { PanelProps } from '../PanelProps'
+import { LineChartConfig } from '../../../../types/ChartConfig'
 
 const PanelVisual: FC<PanelProps> = props => {
   const { config, updateConfig, colorPalettes, twoColorPalette } = useContext<ChartContext>(ConfigContext)
@@ -147,9 +148,7 @@ const PanelVisual: FC<PanelProps> = props => {
                   />
                 </Tooltip.Target>
                 <Tooltip.Content>
-                  <p>
-                  Recommended set to display for Section 508 compliance.
-                  </p>
+                  <p>Recommended set to display for Section 508 compliance.</p>
                 </Tooltip.Content>
               </Tooltip>
             }
@@ -221,6 +220,12 @@ const PanelVisual: FC<PanelProps> = props => {
               label='Line Datapoint Color'
               updateField={updateField}
               options={['Same as Line', 'Lighter than Line']}
+            />
+            <CheckBox
+              value={(config as LineChartConfig).enlargeIsolatedDots}
+              fieldName='enlargeIsolatedDots'
+              label='Enlarge Isolated Dots'
+              updateField={updateField}
             />
           </>
         )}

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
@@ -222,10 +222,12 @@ const PanelVisual: FC<PanelProps> = props => {
               options={['Same as Line', 'Lighter than Line']}
             />
             <CheckBox
-              value={(config as LineChartConfig).isolatedDotsSameSize}
+              value={!(config as LineChartConfig).isolatedDotsSameSize}
               fieldName='isolatedDotsSameSize'
-              label='Isolated Dots Same Size'
-              updateField={updateField}
+              label='Accentuate isolated data points'
+              updateField={(section, subsection, fieldname, value) =>
+                updateField(section, subsection, fieldname, !value)
+              }
             />
           </>
         )}

--- a/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
+++ b/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import chroma from 'chroma-js'
-import { type ChartConfig } from '../../../types/ChartConfig'
+import { LineChartConfig, type ChartConfig } from '../../../types/ChartConfig'
 import { GlyphDiamond, GlyphCircle, GlyphSquare, GlyphTriangle, GlyphCross, Glyph as CustomGlyph } from '@visx/glyph'
 import { Text } from '@visx/text'
 
@@ -62,7 +62,7 @@ const LineChartCircle = (props: LineChartCircleProps) => {
     mode,
     seriesIndex
   } = props
-  const { lineDatapointStyle, visual } = config
+  const { enlargeIsolatedDots, lineDatapointStyle, visual } = config as LineChartConfig
   const filtered = config?.series.filter(s => s.dataKey === seriesKey)?.[0]
   const Shape =
     Glyphs[
@@ -70,6 +70,9 @@ const LineChartCircle = (props: LineChartCircleProps) => {
     ]
   const isReversedTriangle = seriesIndex === 4
   const transformShape = (top, left) => `translate(${left}, ${top})${isReversedTriangle ? ' rotate(180)' : ''}`
+  const LARGE_DOT_SIZE = 124
+  const REGULAR_DOT_SIZE = 55
+  const dotSize = enlargeIsolatedDots ? LARGE_DOT_SIZE : REGULAR_DOT_SIZE
 
   // If we're not showing the circle, simply return
   const getColor = (
@@ -210,7 +213,7 @@ const LineChartCircle = (props: LineChartCircleProps) => {
 
       return (
         <g transform={transformShape(positionTop, positionLeft)}>
-          <Shape size={55} stroke={color} fill={color} />
+          <Shape size={dotSize} stroke={color} fill={color} />
         </g>
       )
     }

--- a/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
+++ b/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
@@ -210,7 +210,7 @@ const LineChartCircle = (props: LineChartCircleProps) => {
 
       return (
         <g transform={transformShape(positionTop, positionLeft)}>
-          <Shape size={124} stroke={color} fill={color} />
+          <Shape size={55} stroke={color} fill={color} />
         </g>
       )
     }

--- a/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
+++ b/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
@@ -62,7 +62,7 @@ const LineChartCircle = (props: LineChartCircleProps) => {
     mode,
     seriesIndex
   } = props
-  const { enlargeIsolatedDots, lineDatapointStyle, visual } = config as LineChartConfig
+  const { isolatedDotsSameSize, lineDatapointStyle, visual } = config as LineChartConfig
   const filtered = config?.series.filter(s => s.dataKey === seriesKey)?.[0]
   const Shape =
     Glyphs[
@@ -72,7 +72,7 @@ const LineChartCircle = (props: LineChartCircleProps) => {
   const transformShape = (top, left) => `translate(${left}, ${top})${isReversedTriangle ? ' rotate(180)' : ''}`
   const LARGE_DOT_SIZE = 124
   const REGULAR_DOT_SIZE = 55
-  const dotSize = enlargeIsolatedDots ? LARGE_DOT_SIZE : REGULAR_DOT_SIZE
+  const dotSize = isolatedDotsSameSize ? REGULAR_DOT_SIZE : LARGE_DOT_SIZE
 
   // If we're not showing the circle, simply return
   const getColor = (

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -13,7 +13,6 @@ export default {
   animate: false,
   lineDatapointStyle: 'hover',
   lineDatapointColor: 'Same as Line',
-  enlargeIsolatedDots: true,
   barHasBorder: 'true',
   isLollipopChart: false,
   lollipopShape: 'circle',

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -13,6 +13,7 @@ export default {
   animate: false,
   lineDatapointStyle: 'hover',
   lineDatapointColor: 'Same as Line',
+  enlargeIsolatedDots: true,
   barHasBorder: 'true',
   isLollipopChart: false,
   lollipopShape: 'circle',

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -233,7 +233,7 @@ export type ForestPlotConfig = {
 export type LineChartConfig = {
   allowLineToBarGraph: boolean
   convertLineToBarGraph: boolean
-  enlargeIsolatedDots: boolean
+  isolatedDotsSameSize: boolean
   lineDatapointStyle: 'hidden' | 'always show' | 'hover'
   visualizationType: 'Line'
 } & AllChartsConfig

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -233,6 +233,7 @@ export type ForestPlotConfig = {
 export type LineChartConfig = {
   allowLineToBarGraph: boolean
   convertLineToBarGraph: boolean
+  enlargeIsolatedDots: boolean
   lineDatapointStyle: 'hidden' | 'always show' | 'hover'
   visualizationType: 'Line'
 } & AllChartsConfig


### PR DESCRIPTION
## NEW-50376

## Testing Steps

Scenario: Upload [NEW-50376-config.json](https://github.com/user-attachments/files/19450425/NEW-50376-config.json), open the Configuration tab, and click on the tools icon on the Line Chart Visualization
Expected: The line chart Editor opens with a line chart with Isolated Dots off of the lines. These Isolated Dots are larger then the dots on the lines.

1. Open the Visual accordion 
2. Uncheck the Enlarge Isolated Dots toggle
Expected: The Isolated Dots are now the same size as the Dots on the lines.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
