### PR TITLE
Hot Fix/Dev-10566 Parent Filters are not saving Sorting issue

### DIFF
--- a/packages/core/components/Filters/helpers/handleSorting.ts
+++ b/packages/core/components/Filters/helpers/handleSorting.ts
@@ -17,8 +17,8 @@ export const handleSorting = singleFilter => {
     return String(asc ? a : b).localeCompare(String(asc ? b : a), 'en', { numeric: true })
   }
 
-  singleFilter.values = singleFilterValues.sort(sort)
-  singleFilter.orderedValues = singleFilterValues.sort(sort)
+  singleFilter.values = singleFilterValues?.sort(sort)
+  singleFilter.orderedValues = singleFilterValues?.sort(sort)
 
   return singleFilter
 }


### PR DESCRIPTION
## DEV-10566

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: Upload [dev-10566.config.json](https://github.com/user-attachments/files/19470901/dev-10566.config.json) and open the Configuration Tab

1. Choose the Explore by Indicator tab
2. Scroll down to the Row 3, the second set of filters, and click on the tools menu to open the filters
3. Click on Filters from the left menu
4. Open the Breakdown filter and scroll down to Parent Filters
5. Add Population Survey, Topic or MPower, Indictor and Who Region and close the Breakdown filter
6. Open the Breakdown Detail filter just below the Breakdown filter
7. Add Population Survey, Topic or MPower, Indictor, and Who Region. It already has Breakdown selected and please leave that there.
8. Click OK at the bottom and then Save.
9. Reopen to check to see of the Parent Filter settings saved as they have not been saving.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
