### PR TITLE
Fix: NEW-50380 Data Table: Add order column configuration

### DIFF
--- a/packages/core/helpers/pivotData.ts
+++ b/packages/core/helpers/pivotData.ts
@@ -20,16 +20,16 @@ export const pivotData = (
   const columns = getColumns(data, columnName, pivot, excludeColumns)
   const newColumns = {}
   // there should be one row for every aggregate row
-  const aggregateRows = data.reduce((acc, row) => {
-    const key = getKeyFromRow(row, columns)
+  const aggregateRows = data.reduce((acc, row, index) => {
+    const key = getKeyFromRow(row, columns) + index
     if (!acc[key]) {
       acc[key] = {}
     }
     return acc
   }, {})
 
-  data.forEach(row => {
-    const key = getKeyFromRow(row, columns)
+  data.forEach((row, index) => {
+    const key = getKeyFromRow(row, columns) + index
     if (pivot.length > 1) {
       pivot.forEach(pivotColumn => {
         const toAdd = _.omit(row, [columnName, ...pivot])

--- a/packages/core/helpers/pivotData.ts
+++ b/packages/core/helpers/pivotData.ts
@@ -19,9 +19,16 @@ export const pivotData = (
 ): Record<string, any>[] => {
   const columns = getColumns(data, columnName, pivot, excludeColumns)
   const newColumns = {}
+  data.map(row => {
+    newColumns[row[columnName]] = ''
+  })
+  // if there is only one column header, we need to avoid duplicate values overwriting each other other values in the row
+  const isSingleColumn = Object.keys(newColumns).length === 1
+
   // there should be one row for every aggregate row
   const aggregateRows = data.reduce((acc, row, index) => {
-    const key = getKeyFromRow(row, columns) + index
+    const keyIndex = isSingleColumn ? index : ''
+    const key = getKeyFromRow(row, columns) + keyIndex
     if (!acc[key]) {
       acc[key] = {}
     }
@@ -29,7 +36,8 @@ export const pivotData = (
   }, {})
 
   data.forEach((row, index) => {
-    const key = getKeyFromRow(row, columns) + index
+    const keyIndex = isSingleColumn ? index : ''
+    const key = getKeyFromRow(row, columns) + keyIndex
     if (pivot.length > 1) {
       pivot.forEach(pivotColumn => {
         const toAdd = _.omit(row, [columnName, ...pivot])
@@ -50,8 +58,6 @@ export const pivotData = (
         _pivotedFrom: _pivot
       }
     }
-
-    newColumns[row[columnName]] = ''
   })
 
   if (pivot.length > 1) {

--- a/packages/core/helpers/tests/pivotData.test.ts
+++ b/packages/core/helpers/tests/pivotData.test.ts
@@ -51,4 +51,78 @@ describe('pivotData', () => {
       { city: 'San Francisco', Jane: 'yellow', John: 'green', _pivotedFrom: 'color' }
     ])
   })
+  it('should allow for duplicate data when there is 1 Column Header but different columnName data', () => {
+    // when there are multiple pivot value columns, if any other data is present it will break the pivot.
+    // so we need to tell it which columns to exclude from the pivot.
+    // 'other' is added here as an example.
+    const data = [
+      { name: 'John', age: 27, color: 'blue', city: 'New York', other: 'yes' },
+      { name: 'Jane', age: 27, color: 'red', city: 'New York', other: 'no' },
+      { name: 'Bob', age: 31, color: 'yellow', city: 'New York', other: 'yes' },
+      { name: 'Betty', age: 31, color: 'green', city: 'New York', other: 'no' },
+      { name: 'Jane', age: 31, color: 'yellow', city: 'New York', other: 'yes' },
+      { name: 'John', age: 31, color: 'green', city: 'New York', other: 'no' },
+      { name: 'Bob', age: 27, color: 'blue', city: 'New York', other: 'yes' },
+      { name: 'Betty', age: 27, color: 'red', city: 'New York', other: 'no' }
+    ]
+    const result = pivotData(data, 'city', ['name'], [])
+    expect(result).toEqual([
+      {
+        'New York': 'John',
+        age: 27,
+        color: 'blue',
+        other: 'yes',
+        _pivotedFrom: 'name'
+      },
+      {
+        'New York': 'Jane',
+        age: 27,
+        color: 'red',
+        other: 'no',
+        _pivotedFrom: 'name'
+      },
+      {
+        'New York': 'Bob',
+        age: 31,
+        color: 'yellow',
+        other: 'yes',
+        _pivotedFrom: 'name'
+      },
+      {
+        'New York': 'Betty',
+        age: 31,
+        color: 'green',
+        other: 'no',
+        _pivotedFrom: 'name'
+      },
+      {
+        'New York': 'Jane',
+        age: 31,
+        color: 'yellow',
+        other: 'yes',
+        _pivotedFrom: 'name'
+      },
+      {
+        'New York': 'John',
+        age: 31,
+        color: 'green',
+        other: 'no',
+        _pivotedFrom: 'name'
+      },
+      {
+        'New York': 'Bob',
+        age: 27,
+        color: 'blue',
+        other: 'yes',
+        _pivotedFrom: 'name'
+      },
+      {
+        'New York': 'Betty',
+        age: 27,
+        color: 'red',
+        other: 'no',
+        _pivotedFrom: 'name'
+      }
+    ])
+  })
 })


### PR DESCRIPTION
## NEW-50380

Under the Never Pivot column there were missing Ethnicities and they were out of order. 

## Testing Steps
Scenario: Upload [new-50380.config.json](https://github.com/user-attachments/files/19474985/new-50380.config.json) and open Dashboard Preview
Expected: A row of Filters

1. 1st Row Dashboard filters selected:
Dataset: Nationwide
Location: State-California
Class: Health care access
Topic: Last checkup
Question Year (Labeled as Year): 2022
Question: The only question that would show.

2. Click View Results
Expected: 2 more filters appear

3. 2nd Row Dashboard filters selected:
View By: Race / Ethnicity
Expected: The Chart below the filter will populate data

4. Click the Table toggle button
Expected: Under each pivot category the Categories below will be there and in order. Double check "Never" since this one was the main issue.
White, non-Hispanic
Black, non-Hispanic
American India or Alaskan Native, non-Hispanic
Asian, non-Hispanic
Native Hawaiian or other Pacific Islander, non-Hispanic
Other, non-Hispanic
Multiracial, non-Hispanic
Hispanic

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
