### PR TITLE
[DEV-50379] fix state labels

### DIFF
--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -532,7 +532,7 @@ const UsaMap = () => {
     if (undefined === abbr) return null
 
     // HI background is always white since it is off to the side
-    if ((abbr === 'US-HI' && !general.displayAsHex) || Object.keys(offsets).includes(abbr)) {
+    if ((abbr === 'US-HI' && !general.displayAsHex) || (Object.keys(offsets).includes(abbr) && !general.displayAsHex)) {
       bgColor = '#FFF'
     }
     const { textColor, strokeColor } = outlinedTextColor(bgColor)

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -526,13 +526,13 @@ const UsaMap = () => {
   }
 
   const geoLabel = (geo, bgColor = '#FFFFFF', projection) => {
-    let centroid = projection ? projection(geoCentroid(geo)) : [22, 17.5]
-    let abbr = geo.properties.iso
+    const centroid = projection ? projection(geoCentroid(geo)) : [22, 17.5]
+    const abbr = geo.properties.iso
 
     if (undefined === abbr) return null
 
     // HI background is always white since it is off to the side
-    if (abbr === 'US-HI' && !general.displayAsHex) {
+    if ((abbr === 'US-HI' && !general.displayAsHex) || Object.keys(offsets).includes(abbr)) {
       bgColor = '#FFF'
     }
     const { textColor, strokeColor } = outlinedTextColor(bgColor)


### PR DESCRIPTION
State labels were missing on state maps:

While viewing a standalone map:

- Open Type > Show State Labels
- Under Visual > Make the map dark
- Verify the black color shows out in the ocean
- Switch to Type > Display as hex map
- Make sure white shows on dark hex tiles