### PR TITLE
fix [dev-10553] csv special chars

### DIFF
--- a/packages/core/components/DownloadButton.tsx
+++ b/packages/core/components/DownloadButton.tsx
@@ -9,7 +9,12 @@ type DownloadButtonProps = {
 
 const DownloadButton = ({ rawData, fileName, headerColor, skipId }: DownloadButtonProps) => {
   const csvData = Papa.unparse(rawData)
-  const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' })
+  // Prepend a Byte Order Mark (BOM) to the CSV data.
+  // The BOM is a special marker that helps applications like Excel recognize the file as UTF-8 encoded.
+  // Adding the BOM ensures that Excel interprets special characters correctly.
+  const bom = '\uFEFF'
+  const utf8EncodedCsvData = new TextEncoder().encode(bom + csvData)
+  const blob = new Blob([utf8EncodedCsvData], { type: 'text/csv;charset=utf-8;' })
 
   const saveBlob = () => {
     //@ts-ignore
@@ -20,7 +25,17 @@ const DownloadButton = ({ rawData, fileName, headerColor, skipId }: DownloadButt
   }
 
   return (
-    <a download={fileName} type='button' onClick={saveBlob} href={URL.createObjectURL(blob)} aria-label='Download this data in a CSV file format.' className={`${headerColor} no-border`} id={`${skipId}`} data-html2canvas-ignore role='button'>
+    <a
+      download={fileName}
+      type='button'
+      onClick={saveBlob}
+      href={URL.createObjectURL(blob)}
+      aria-label='Download this data in a CSV file format.'
+      className={`${headerColor} no-border`}
+      id={`${skipId}`}
+      data-html2canvas-ignore
+      role='button'
+    >
       Download Data (CSV)
     </a>
   )


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps

Scenario: upload 
[adhap-test.json](https://github.com/user-attachments/files/19492082/adhap-test-test_1.1.1.1.json) and navigate to dashboard preview.

1) Select: Northeast, Caregiving, Duration of Caregiving Among older adults 
2) View "Trends over Time" line graph -- select "All Available" Age Groups and "Overall-Overall" in the Demographic dropdown
3) Go to table view (via toggle)

Expected: symbol renders properly in table.

4) Click "Download Data (CSV)" 
5) View downloaded file. 

Expected: See the superscripted symbol "~~" in the download render Properly

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
