### PR TITLE
Feature: [DEV-50383] - Add Table Cell Min Width for Maps

### DIFF
--- a/packages/core/components/DataTable/components/MapHeader.tsx
+++ b/packages/core/components/DataTable/components/MapHeader.tsx
@@ -36,6 +36,7 @@ const MapHeader = ({ columns, config, indexTitle, sortBy, setSortBy, rightAligne
           return (
             <th
               style={{
+                minWidth: (config.table.cellMinWidth || 0) + 'px',
                 textAlign: rightAlignedCols && rightAlignedCols[index] ? 'right' : '',
                 paddingRight: '1.3em'
               }}

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -2819,6 +2819,18 @@ const EditorPanel = () => {
                     max='500'
                   />
                 )}
+
+                <TextField
+                  value={table.cellMinWidth}
+                  updateField={updateField}
+                  section='table'
+                  fieldName='cellMinWidth'
+                  label='Table Cell Min Width'
+                  type='number'
+                  min='0'
+                  max='500'
+                />
+
                 <label className='checkbox'>
                   <input
                     type='checkbox'

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -88,7 +88,8 @@ export default {
     showFullGeoNameInCSV: false,
     forceDisplay: true,
     download: false,
-    indexLabel: ''
+    indexLabel: '',
+    cellMinWidth: '0'
   },
   tooltips: {
     appearanceType: 'hover',

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -169,6 +169,7 @@ export type MapConfig = Visualization & {
     forceDisplay: boolean
     download: boolean
     indexLabel: string
+    cellMinWidth: string
   }
   tooltips: {
     appearanceType: 'hover' | 'click'


### PR DESCRIPTION
## [Replace With Ticket Number]

<!-- Provide a brief description of the changes made in this PR -->

## Testing Steps
Open Maps
Under Data table panel added new "Table Cell Min Width" 
It is used to have for charts and now Maps support.
See attached image: 
![Screenshot 2025-03-27 at 14 42 08](https://github.com/user-attachments/assets/68b760a0-199e-439b-a433-b130efd1ca8d)

<!-- Provide testing steps and reference storybook stories if necessary -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
