### PR TITLE
feature [new-50339]: only show legend items with data

### DIFF
--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -3999,6 +3999,29 @@ const EditorPanel = () => {
                     fieldName='description'
                     label='Legend Description'
                   />
+                  <CheckBox
+                    value={config.legend.unified}
+                    section='legend'
+                    fieldName='unified'
+                    label='Unified Legend'
+                    updateField={updateField}
+                    tooltip={
+                      <Tooltip style={{ textTransform: 'none' }}>
+                        <Tooltip.Target>
+                          <Icon
+                            display='question'
+                            style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
+                          />
+                        </Tooltip.Target>
+                        <Tooltip.Content>
+                          <p>
+                            For a chart with filters, check this option if you want the legend to contain an item for
+                            every series in the data set, including those that are filtered.
+                          </p>
+                        </Tooltip.Content>
+                      </Tooltip>
+                    }
+                  />
                 </AccordionItemPanel>
               </AccordionItem>
             )}

--- a/packages/chart/src/components/Legend/Legend.Component.tsx
+++ b/packages/chart/src/components/Legend/Legend.Component.tsx
@@ -56,7 +56,7 @@ const Legend: React.FC<LegendProps> = forwardRef(
     const { series } = runtime
 
     const seriesWithData = getSeriesWithData(config)
-    const dontFilterLegendItems = !series.length || legend.unified
+    const dontFilterLegendItems = !series.length || legend.unified || !seriesWithData.length
 
     const isLegendBottom =
       legend?.position === 'bottom' ||

--- a/packages/chart/src/components/Legend/Legend.Component.tsx
+++ b/packages/chart/src/components/Legend/Legend.Component.tsx
@@ -16,6 +16,7 @@ import { DimensionsType } from '@cdc/core/types/Dimensions'
 import { isLegendWrapViewport } from '@cdc/core/helpers/viewports'
 import LegendLineShape from './LegendLine.Shape'
 import LegendGroup from './LegendGroup'
+import { getSeriesWithData } from '../../helpers/dataHelpers'
 
 const LEGEND_PADDING = 36
 
@@ -52,6 +53,10 @@ const Legend: React.FC<LegendProps> = forwardRef(
   ) => {
     const { innerClasses, containerClasses } = getLegendClasses(config)
     const { runtime, legend } = config
+    const { series } = runtime
+
+    const seriesWithData = getSeriesWithData(config)
+    const dontFilterLegendItems = !series.length || legend.unified
 
     const isLegendBottom =
       legend?.position === 'bottom' ||
@@ -94,71 +99,73 @@ const Legend: React.FC<LegendProps> = forwardRef(
             return (
               <>
                 <div className={innerClasses.join(' ')}>
-                  {formatLabels(labels as Label[]).map((label, i) => {
-                    let className = ['legend-item', `legend-text--${label.text.replace(' ', '').toLowerCase()}`]
-                    let itemName = label.datum
+                  {formatLabels(labels as Label[])
+                    .filter(label => dontFilterLegendItems || seriesWithData.includes(label.datum))
+                    .map((label, i) => {
+                      let className = ['legend-item', `legend-text--${label.text.replace(' ', '').toLowerCase()}`]
+                      let itemName = label.datum
 
-                    // Filter excluded data keys from legend
-                    if (config.exclusions.active && config.exclusions.keys?.includes(itemName)) {
-                      return null
-                    }
-
-                    if (runtime.seriesLabels) {
-                      let index = config.runtime.seriesLabelsAll.indexOf(itemName)
-                      itemName = config.runtime.seriesKeys[index]
-
-                      if (runtime?.forecastingSeriesKeys?.length > 0) {
-                        itemName = label.text
+                      // Filter excluded data keys from legend
+                      if (config.exclusions.active && config.exclusions.keys?.includes(itemName)) {
+                        return null
                       }
-                    }
 
-                    if (seriesHighlight.length) {
-                      if (!seriesHighlight.includes(itemName)) {
-                        className.push('inactive')
-                      } else className.push('highlighted')
-                    }
+                      if (runtime.seriesLabels) {
+                        let index = config.runtime.seriesLabelsAll.indexOf(itemName)
+                        itemName = config.runtime.seriesKeys[index]
 
-                    if (config.legend.style === 'gradient' || config.legend.groupBy) {
-                      return <></>
-                    }
+                        if (runtime?.forecastingSeriesKeys?.length > 0) {
+                          itemName = label.text
+                        }
+                      }
 
-                    return (
-                      <LegendItem
-                        className={className.join(' ')}
-                        tabIndex={0}
-                        key={`legend-quantile-${i}`}
-                        onKeyDown={e => {
-                          if (e.key === 'Enter') {
+                      if (seriesHighlight.length) {
+                        if (!seriesHighlight.includes(itemName)) {
+                          className.push('inactive')
+                        } else className.push('highlighted')
+                      }
+
+                      if (config.legend.style === 'gradient' || config.legend.groupBy) {
+                        return <></>
+                      }
+
+                      return (
+                        <LegendItem
+                          className={className.join(' ')}
+                          tabIndex={0}
+                          key={`legend-quantile-${i}`}
+                          onKeyDown={e => {
+                            if (e.key === 'Enter') {
+                              e.preventDefault()
+                              highlight(label)
+                            }
+                          }}
+                          onClick={e => {
                             e.preventDefault()
                             highlight(label)
-                          }
-                        }}
-                        onClick={e => {
-                          e.preventDefault()
-                          highlight(label)
-                        }}
-                        role='button'
-                      >
-                        <>
-                          {config.visualizationType === 'Line' && config.legend.style === 'lines' ? (
-                            <React.Fragment>
-                              <LegendLineShape index={i} label={label} config={config} />
-                            </React.Fragment>
-                          ) : (
-                            <>
-                              <LegendShape
-                                shape={config.legend.style === 'boxes' ? 'square' : 'circle'}
-                                fill={label.value}
-                              />
-                            </>
-                          )}
-                        </>
-                        <LegendLabel align='left' className='m-0'>
-                          {parse(label.text)}
-                        </LegendLabel>
-                      </LegendItem>
-                    )
-                  })}
+                          }}
+                          role='button'
+                        >
+                          <>
+                            {config.visualizationType === 'Line' && config.legend.style === 'lines' ? (
+                              <React.Fragment>
+                                <LegendLineShape index={i} label={label} config={config} />
+                              </React.Fragment>
+                            ) : (
+                              <>
+                                <LegendShape
+                                  shape={config.legend.style === 'boxes' ? 'square' : 'circle'}
+                                  fill={label.value}
+                                />
+                              </>
+                            )}
+                          </>
+                          <LegendLabel align='left' className='m-0'>
+                            {parse(label.text)}
+                          </LegendLabel>
+                        </LegendItem>
+                      )
+                    })}
 
                   {highLightedLegendItems.map((bar, i) => {
                     // if duplicates only return first item

--- a/packages/chart/src/helpers/dataHelpers.ts
+++ b/packages/chart/src/helpers/dataHelpers.ts
@@ -1,0 +1,10 @@
+import { ChartConfig } from '../types/ChartConfig'
+
+export const getSeriesWithData = (config: ChartConfig) => {
+  const { filters, data, runtime } = config
+  const { series } = runtime
+
+  const filteredData = data.filter(d => filters.every(f => d[f.columnName] === f.active))
+
+  return series.filter(s => filteredData.some(d => d[s.dynamicCategory || s.dataKey])).map(s => s.name || s.dataKey)
+}

--- a/packages/chart/src/helpers/dataHelpers.ts
+++ b/packages/chart/src/helpers/dataHelpers.ts
@@ -1,10 +1,31 @@
+import { Series } from '@cdc/core/types/Series'
 import { ChartConfig } from '../types/ChartConfig'
 
 export const getSeriesWithData = (config: ChartConfig) => {
-  const { filters, data, runtime } = config
+  const { filters, data, runtime, legend } = config
+  const { colorCode } = legend
   const { series } = runtime
 
   const filteredData = data.filter(d => filters.every(f => d[f.columnName] === f.active))
+  const colorCodeSeries = colorCode && Array.from(new Set(filteredData.map(d => d[colorCode])))
 
-  return series.filter(s => filteredData.some(d => d[s.dynamicCategory || s.dataKey])).map(s => s.name || s.dataKey)
+  const result = series
+    .flatMap(s => {
+      if (!colorCode || s.type !== 'Bar') return s
+      return colorCodeSeries.map(c => ({ ...s, colorCodeSeries: c }))
+    })
+    .map(s => ({
+      ...s,
+      data: filteredData
+        .filter(d => !s.dynamicCategory || d[s.dynamicCategory] === s.dataKey)
+        .filter(d => !s.colorCodeSeries || d[colorCode] === s.colorCodeSeries)
+        .filter(d => {
+          const key = s.dynamicCategory ? s.originalDataKey : s.dataKey
+          return d[key] || d[key] === 0
+        })
+    }))
+    .filter(s => s.data.length)
+    .map(s => s.colorCodeSeries || s.name || s.dataKey)
+
+  return result
 }

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -80,7 +80,7 @@ type Exclusions = {
 
 export type Legend = CoreLegend & {
   seriesHighlight: string[]
-
+  unified: boolean
   hideSuppressionLink: boolean
   style: 'circles' | 'boxes' | 'gradient' | 'lines'
   subStyle: 'linear blocks' | 'smooth'

--- a/packages/core/helpers/coveUpdateWorker.ts
+++ b/packages/core/helpers/coveUpdateWorker.ts
@@ -13,6 +13,7 @@ import update_4_24_10 from './ver/4.24.10'
 import update_4_24_11 from './ver/4.24.11'
 import update_4_25_1 from './ver/4.25.1'
 import update_4_25_3 from './ver/4.25.3'
+import update_4_25_4 from './ver/4.25.4'
 
 export const coveUpdateWorker = (config, multiDashboardVersion?) => {
   let genConfig = config
@@ -28,7 +29,8 @@ export const coveUpdateWorker = (config, multiDashboardVersion?) => {
     ['4.24.10', update_4_24_10, true],
     ['4.24.11', update_4_24_11],
     ['4.25.1', update_4_25_1],
-    ['4.25.3', update_4_25_3]
+    ['4.25.3', update_4_25_3],
+    ['4.25.4', update_4_25_4],
   ]
 
   versions.forEach(([version, updateFunction, alwaysRun]: [string, UpdateFunction, boolean?]) => {

--- a/packages/core/helpers/ver/4.25.4.ts
+++ b/packages/core/helpers/ver/4.25.4.ts
@@ -1,0 +1,30 @@
+import _ from 'lodash'
+
+export const makeChartLegendsUnified = config => {
+  if (config.type === 'chart') {
+    config.legend = config.legend || {}
+    config.legend.unified = true
+  } else if (config.type === 'dashboard') {
+    if (config.multiDashboards) {
+      config.multiDashboards.forEach(dashboard => {
+        Object.values(dashboard.visualizations).forEach(visualization => {
+          makeChartLegendsUnified(visualization)
+        })
+      })
+    } else {
+      Object.values(config.visualizations).forEach(visualization => {
+        makeChartLegendsUnified(visualization)
+      })
+    }
+  }
+}
+
+const update_4_25_4 = config => {
+  const ver = '4.25.4'
+  const newConfig = _.cloneDeep(config)
+  makeChartLegendsUnified(newConfig)
+  newConfig.version = ver
+  return newConfig
+}
+
+export default update_4_25_4

--- a/packages/core/helpers/ver/tests/4.25.4.test.ts
+++ b/packages/core/helpers/ver/tests/4.25.4.test.ts
@@ -1,0 +1,49 @@
+import { expect, describe, it } from 'vitest'
+import { makeChartLegendsUnified } from '../4.25.4'
+import { ChartConfig } from '@cdc/chart/src/types/ChartConfig'
+import { DashboardConfig } from '@cdc/dashboard/src/types/DashboardConfig'
+import { MultiDashboard, MultiDashboardConfig } from '@cdc/dashboard/src/types/MultiDashboard'
+
+describe('makeChartLegendsUnified(config) ', () => {
+  it('sets chart legends unified to true', () => {
+    const mockConfig = { type: 'chart', legend: { unified: false } } as Partial<ChartConfig>
+    makeChartLegendsUnified(mockConfig)
+    expect(mockConfig.legend?.unified).toBe(true)
+  })
+  it('sets dashboard nested chart legends unified to true', () => {
+    const mockConfig = {
+      type: 'dashboard',
+      visualizations: {
+        '1': { type: 'chart', legend: { unified: false } } as ChartConfig,
+        '2': { type: 'chart', legend: { unified: false } } as ChartConfig
+      }
+    } as Partial<DashboardConfig>
+    makeChartLegendsUnified(mockConfig)
+    expect(mockConfig.visualizations['1'].legend?.unified).toBe(true)
+    expect(mockConfig.visualizations['2'].legend?.unified).toBe(true)
+  })
+  it('sets multiDashboard nested chart legends unified to true', () => {
+    const mockConfig = {
+      type: 'dashboard',
+      multiDashboards: [
+        {
+          visualizations: {
+            '1': { type: 'chart', legend: { unified: false } },
+            '2': { type: 'chart', legend: { unified: false } }
+          }
+        },
+        {
+          visualizations: {
+            '3': { type: 'chart', legend: { unified: false } },
+            '4': { type: 'chart', legend: { unified: false } }
+          }
+        }
+      ] as unknown as MultiDashboard[]
+    } as Partial<MultiDashboardConfig>
+    makeChartLegendsUnified(mockConfig)
+    expect(mockConfig.multiDashboards[0].visualizations['1'].legend?.unified).toBe(true)
+    expect(mockConfig.multiDashboards[0].visualizations['2'].legend?.unified).toBe(true)
+    expect(mockConfig.multiDashboards[1].visualizations['3'].legend?.unified).toBe(true)
+    expect(mockConfig.multiDashboards[1].visualizations['4'].legend?.unified).toBe(true)
+  })
+})


### PR DESCRIPTION
## 50339

Only show legend items with data.

## Testing Steps
open line chart with multiple legend items
activate filter that has on results for series or remove data for a series
confirm there is no legend item for series without data

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing
