### PR TITLE
Fix [NEW-50385] Swap css/component import order

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
@@ -66,8 +66,6 @@ export const BarChartHorizontal = () => {
 
   const root = document.documentElement
 
-  const coolGray90 = getComputedStyle(root).getPropertyValue('--cool-gray-90')
-
   return (
     config.visualizationSubType !== 'stacked' &&
     config.visualizationType === 'Bar' &&
@@ -390,7 +388,7 @@ export const BarChartHorizontal = () => {
                         {hasConfidenceInterval && (
                           <path
                             key={`confidence-interval-h-${yPos}-${datum[config.runtime.originalXAxis.dataKey]}`}
-                            stroke={coolGray90}
+                            stroke={APP_FONT_COLOR}
                             strokeWidth='px'
                             d={`
                                 M${lowerPos} ${yPos - tickWidth}

--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -16,6 +16,7 @@ import Regions from '../../Regions'
 import { isDateScale } from '@cdc/core/helpers/cove/date'
 import isNumber from '@cdc/core/helpers/isNumber'
 import createBarElement from '@cdc/core/components/createBarElement'
+import { APP_FONT_COLOR } from '@cdc/core/helpers/constants'
 // Third party libraries
 import chroma from 'chroma-js'
 // Types
@@ -50,8 +51,6 @@ export const BarChartVertical = () => {
   const { HighLightedBarUtils } = useHighlightedBars(config)
 
   const root = document.documentElement
-
-  const coolGray90 = getComputedStyle(root).getPropertyValue('--cool-gray-90')
 
   let data = transformedData
   // check if user add suppression
@@ -376,7 +375,7 @@ export const BarChartVertical = () => {
                         {hasConfidenceInterval && bar.value !== undefined && datum && (
                           <path
                             key={`confidence-interval-v-${datum[config.runtime.originalXAxis.dataKey]}`}
-                            stroke={coolGray90}
+                            stroke={APP_FONT_COLOR}
                             strokeWidth='px'
                             d={`M${xPos - tickWidth} ${upperPos}
                                 L${xPos + tickWidth} ${upperPos}

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -441,6 +441,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   }, [maxValue])
 
   useEffect(() => {
+    if (!yScale?.ticks) return
     const ticks = yScale.ticks(handleNumTicks)
     if (orientation === 'horizontal' || !labelsOverflow || config.yAxis?.max || ticks.length === 0) {
       setYAxisAutoPadding(0)

--- a/packages/chart/src/index.jsx
+++ b/packages/chart/src/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
-import CdcChart from './CdcChart'
 import './coreStyles_chart.scss'
-
 import '@cdc/core/styles/cove-main.scss'
 import 'react-tooltip/dist/react-tooltip.css'
+
+import CdcChart from './CdcChart'
 
 let isEditor = window.location.href.includes('editor=true')
 let isDebug = window.location.href.includes('debug=true')

--- a/packages/dashboard/src/index.tsx
+++ b/packages/dashboard/src/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
-import MultiDashboardWrapper from './CdcDashboard'
 import '@cdc/core/styles/cove-main.scss'
 import './coreStyles_dashboard.scss'
+
+import MultiDashboardWrapper from './CdcDashboard'
 
 let isEditor = window.location.href.includes('editor=true')
 let isDebug = window.location.href.includes('debug=true')

--- a/packages/data-bite/src/index.jsx
+++ b/packages/data-bite/src/index.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
-import CdcDataBite from './CdcDataBite'
 import '@cdc/core/styles/cove-main.scss'
 import './coreStyles_databite.scss'
+
+import CdcDataBite from './CdcDataBite'
 
 let isEditor = window.location.href.includes('editor=true')
 

--- a/packages/editor/src/index.jsx
+++ b/packages/editor/src/index.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
-import CdcEditor from './CdcEditor'
 import '@cdc/core/styles/cove-main.scss'
 import './coreStyles_editor.scss'
+
+import CdcEditor from './CdcEditor'
 
 // Allow URL query to preselect a tab in standalone mode
 const standaloneParams = new URLSearchParams(window.location.search)

--- a/packages/filtered-text/src/index.jsx
+++ b/packages/filtered-text/src/index.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
-import CdcFilteredText from './CdcFilteredText'
 import '@cdc/core/styles/cove-main.scss'
 import './coreStyles_filteredtext.scss'
+
+import CdcFilteredText from './CdcFilteredText'
 
 //@ts-ignore
 let isEditor = window.location.href.includes('editor=true')

--- a/packages/map/src/index.jsx
+++ b/packages/map/src/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
-import CdcMap from './CdcMap'
-
 import '@cdc/core/styles/cove-main.scss'
 import 'react-tooltip/dist/react-tooltip.css'
 import './coreStyles_map.scss'
+
+import CdcMap from './CdcMap'
 
 let isEditor = window.location.href.includes('editor=true')
 let isDebug = window.location.href.includes('debug=true')

--- a/packages/markup-include/src/index.jsx
+++ b/packages/markup-include/src/index.jsx
@@ -3,10 +3,10 @@ import ReactDOM from 'react-dom/client'
 
 import { GlobalContextProvider } from '@cdc/core/components/GlobalContext'
 
-import CdcMarkupInclude from './CdcMarkupInclude'
-
 import '@cdc/core/styles/cove-main.scss'
 import './coreStyles_markupinclude.scss'
+
+import CdcMarkupInclude from './CdcMarkupInclude'
 
 let isEditor = window.location.href.includes('editor=true')
 

--- a/packages/waffle-chart/src/index.jsx
+++ b/packages/waffle-chart/src/index.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
-import CdcWaffleChart from './CdcWaffleChart'
-
 import '@cdc/core/styles/cove-main.scss'
 import './coreStyles_wafflechart.scss'
+
+import CdcWaffleChart from './CdcWaffleChart'
 
 let isEditor = window.location.href.includes('editor=true')
 


### PR DESCRIPTION
## [NEW-50385]

This imports CSS before components in all packages. It makes it possible to use css variables anywhere in the codebase, [like here](https://github.com/CDCgov/cdc-open-viz/blob/dev/packages/core/helpers/constants.ts#L3).

## Testing Steps

Run the map package locally. The default map does not work in `dev`, but works in this branch.

## Self Review

- I have added testing steps for reviewers
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests are passing

## Screenshots (if applicable)

<!-- Add screenshots to help explain the changes made in this PR -->

## Additional Notes

<!-- Add any additional notes about this PR -->
