### PR TITLE
Enhancement/NEW-50364 Unable to determine the row number without counting

### DIFF
--- a/packages/dashboard/src/components/Row.tsx
+++ b/packages/dashboard/src/components/Row.tsx
@@ -239,7 +239,7 @@ const Row: React.FC<RowProps> = ({ row, idx: rowIdx, uuid }) => {
     <>
       <div className='builder-row' data-row-id={rowIdx}>
         <RowMenu rowIdx={rowIdx} />
-        <p className='position-absolute top-0 left-0 d-block mt-1'>Row - {rowIdx + 1}</p>
+        <p className='ml-2 mt-n3'>Row - {rowIdx + 1}</p>
         <button
           title='Configure Data'
           className='btn btn-configure-row'


### PR DESCRIPTION
---
name: Unable to determine the row number without counting
about: 
---

## [NEW-50364] Summary
Moved the row label out from behind the Visualization


## Testing Steps
Scenario: upload [NEW-50364-config.json](https://github.com/user-attachments/files/19668238/NEW-50364-config.json) and open the Configuration tab.
Expected: There are 4 rows and the row are labeled with Row - {row number}

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->










