### PR TITLE
Fix/new 50355 bar chart tooltip shows blank when na expected

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -244,6 +244,8 @@ export const BarChartVertical = () => {
                   )
                   // End Confidence Interval Variables
 
+                  const BAR_LABEL_PADDING = 10
+
                   return (
                     <Group key={`${barGroup.index}--${index}`}>
                       <Group key={`bar-sub-group-${barGroup.index}-${barGroup.x0}-${barY}--${index}`}>
@@ -325,7 +327,7 @@ export const BarChartVertical = () => {
                           display={displayBar ? 'block' : 'none'}
                           opacity={transparentBar ? 0.5 : 1}
                           x={hasConfidenceInterval ? barX + barWidth : barX + barWidth / 2}
-                          y={barY - 5}
+                          y={barY - BAR_LABEL_PADDING}
                           fill={labelColor}
                           textAnchor='middle'
                         >
@@ -335,7 +337,7 @@ export const BarChartVertical = () => {
                           display={displayBar ? 'block' : 'none'}
                           opacity={transparentBar ? 0.5 : 1}
                           x={barX + barWidth / 2}
-                          y={barY - 5}
+                          y={barY - BAR_LABEL_PADDING}
                           fill={labelColor}
                           textAnchor='middle'
                           fontSize={config.isLollipopChart ? null : barWidth / 2}


### PR DESCRIPTION
## Fix: New-50355

## Testing Steps
Scenario: Upload [adhap-test-test_Updated.json](https://github.com/user-attachments/files/19668819/adhap-test-test_Updated.json) and open Dashboard Preview
Expected: There is a Dashboard Filter with 3 dropdowns

Select following in the Dropdowns then Click View Results:
Location: Colorado
Category: Smoking and Alcohol Use
Indicator: Current smoking
Expected: The page loads and is displaying the data

Scroll down to the "Details for a Specific Year" section
Expected: there are 3 filter fields

Select in the Dropdowns
Year: 2022
Age Group: 50-64 years
Demographic: Race/Ethnicity - All Available
Expected: The chart displays data and there are 2 bars that have the N/A label

Hover over the first N/A Bar
Expected: The Tooltip displays:
Asian/Pacific Islander: N/A
95%_CI : null

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
