### PR TITLE
Enhancement/Fix: NEW-50375 API sourced dashboard filters editor difficult to work with

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
@@ -50,7 +50,7 @@ const APIModal: React.FC<APIModalProps> = ({
         <div className={`w-50${isNestedDropdown ? ' border border-dark p-1 m-1' : ''}`}>
           <label>
             <span>Value Selector: </span>
-            <input value={APIValueSelector || ''} onChange={e => setAPIValueSelector(e.target.value)} />
+            <input type='text' value={APIValueSelector || ''} onChange={e => setAPIValueSelector(e.target.value)} />
             <Tooltip style={{ textTransform: 'none' }}>
               <Tooltip.Target>
                 <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -63,7 +63,7 @@ const APIModal: React.FC<APIModalProps> = ({
           </label>
           <label>
             <span>Display Text Selector: </span>
-            <input value={APITextSelector || ''} onChange={e => setAPITextSelector(e.target.value)} />
+            <input type='text' value={APITextSelector || ''} onChange={e => setAPITextSelector(e.target.value)} />
             <Tooltip style={{ textTransform: 'none' }}>
               <Tooltip.Target>
                 <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -81,6 +81,7 @@ const APIModal: React.FC<APIModalProps> = ({
             <label>
               <span>Subgroup Value Selector: </span>
               <input
+                type='text'
                 value={APISubGroupValueSelector || ''}
                 onChange={e => setAPISubGroupValueSelector(e.target.value)}
               />
@@ -96,7 +97,11 @@ const APIModal: React.FC<APIModalProps> = ({
             </label>
             <label>
               <span>Subgroup Display Text Selector: </span>
-              <input value={APISubGroupTextSelector || ''} onChange={e => setAPISubGroupTextSelector(e.target.value)} />
+              <input
+                type='text'
+                value={APISubGroupTextSelector || ''}
+                onChange={e => setAPISubGroupTextSelector(e.target.value)}
+              />
               <Tooltip style={{ textTransform: 'none' }}>
                 <Tooltip.Target>
                   <Icon display='question' style={{ marginLeft: '0.5rem' }} />

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
@@ -22,10 +22,12 @@ const APIModal: React.FC<APIModalProps> = ({
   const [APIEndpoint, setAPIEndpoint] = useState(filter.apiFilter?.apiEndpoint || '')
   const [APIValueSelector, setAPIValueSelector] = useState(filter.apiFilter?.valueSelector || '')
   const [APITextSelector, setAPITextSelector] = useState(filter.apiFilter?.textSelector || '')
-  const [APISubGroupValueSelector, setAPISubGroupValueSelector] = useState(filter.apiFilter?.subgroupValueSelector)
-  const [APISubGroupTextSelector, setAPISubGroupTextSelector] = useState(filter.apiFilter?.subgroupTextSelector)
+  const [APISubGroupValueSelector, setAPISubGroupValueSelector] = useState(
+    filter.apiFilter?.subgroupValueSelector || ''
+  )
+  const [APISubGroupTextSelector, setAPISubGroupTextSelector] = useState(filter.apiFilter?.subgroupTextSelector || '')
   return (
-    <fieldset className='mb-1 px-3 cdc-open-viz-module'>
+    <fieldset className='edit-block mb-1 px-3 cdc-open-viz-module'>
       <label className='d-block'>
         <span>API Endpoint: </span>
         <textarea
@@ -59,7 +61,7 @@ const APIModal: React.FC<APIModalProps> = ({
                 <p>Value to use in the html option element</p>
               </Tooltip.Content>
             </Tooltip>
-            <p>{` * Required`}</p>
+            <div>{` * Required`}</div>
           </label>
           <label>
             <span>Display Text Selector: </span>
@@ -72,7 +74,7 @@ const APIModal: React.FC<APIModalProps> = ({
                 <p>Text to use in the html option element. If none is applied value selector will be used.</p>
               </Tooltip.Content>
             </Tooltip>
-            <p>{` * Optional`}</p>
+            <div>{` * Optional`}</div>
           </label>
         </div>
 
@@ -92,7 +94,7 @@ const APIModal: React.FC<APIModalProps> = ({
                   <p>Value to use in the html option element</p>
                 </Tooltip.Content>
               </Tooltip>
-              <p>{` * Required`}</p>
+              <div>{` * Required`}</div>
             </label>
             <label>
               <span>Subgroup Display Text Selector: </span>
@@ -105,14 +107,14 @@ const APIModal: React.FC<APIModalProps> = ({
                   <p>Text to use in the html option element. If none is applied value selector will be used.</p>
                 </Tooltip.Content>
               </Tooltip>
-              <p>{` * Optional`}</p>
+              <div>{` * Optional`}</div>
             </label>
           </div>
         )}
       </div>
       <div className='d-flex justify-content-end mt-2'>
         <button
-          className='btn btn-primary mt-2'
+          className='btn mt-2'
           onClick={() => updateAPIFilter(APIEndpoint, APIValueSelector, APITextSelector, valueSelector, textSelector)}
         >
           Save

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
@@ -112,7 +112,7 @@ const APIModal: React.FC<APIModalProps> = ({
       </div>
       <div className='d-flex justify-content-end mt-2'>
         <button
-          className='btn mt-2'
+          className='btn btn-primary mt-2'
           onClick={() => updateAPIFilter(APIEndpoint, APIValueSelector, APITextSelector, valueSelector, textSelector)}
         >
           Save

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/APIModal.tsx
@@ -22,12 +22,10 @@ const APIModal: React.FC<APIModalProps> = ({
   const [APIEndpoint, setAPIEndpoint] = useState(filter.apiFilter?.apiEndpoint || '')
   const [APIValueSelector, setAPIValueSelector] = useState(filter.apiFilter?.valueSelector || '')
   const [APITextSelector, setAPITextSelector] = useState(filter.apiFilter?.textSelector || '')
-  const [APISubGroupValueSelector, setAPISubGroupValueSelector] = useState(
-    filter.apiFilter?.subgroupValueSelector || ''
-  )
-  const [APISubGroupTextSelector, setAPISubGroupTextSelector] = useState(filter.apiFilter?.subgroupTextSelector || '')
+  const [APISubGroupValueSelector, setAPISubGroupValueSelector] = useState(filter.apiFilter?.subgroupValueSelector)
+  const [APISubGroupTextSelector, setAPISubGroupTextSelector] = useState(filter.apiFilter?.subgroupTextSelector)
   return (
-    <fieldset className='edit-block mb-1 px-3 cdc-open-viz-module'>
+    <fieldset className='mb-1 px-3 cdc-open-viz-module'>
       <label className='d-block'>
         <span>API Endpoint: </span>
         <textarea
@@ -61,7 +59,7 @@ const APIModal: React.FC<APIModalProps> = ({
                 <p>Value to use in the html option element</p>
               </Tooltip.Content>
             </Tooltip>
-            <div>{` * Required`}</div>
+            <p>{` * Required`}</p>
           </label>
           <label>
             <span>Display Text Selector: </span>
@@ -74,7 +72,7 @@ const APIModal: React.FC<APIModalProps> = ({
                 <p>Text to use in the html option element. If none is applied value selector will be used.</p>
               </Tooltip.Content>
             </Tooltip>
-            <div>{` * Optional`}</div>
+            <p>{` * Optional`}</p>
           </label>
         </div>
 
@@ -94,7 +92,7 @@ const APIModal: React.FC<APIModalProps> = ({
                   <p>Value to use in the html option element</p>
                 </Tooltip.Content>
               </Tooltip>
-              <div>{` * Required`}</div>
+              <p>{` * Required`}</p>
             </label>
             <label>
               <span>Subgroup Display Text Selector: </span>
@@ -107,7 +105,7 @@ const APIModal: React.FC<APIModalProps> = ({
                   <p>Text to use in the html option element. If none is applied value selector will be used.</p>
                 </Tooltip.Content>
               </Tooltip>
-              <div>{` * Optional`}</div>
+              <p>{` * Optional`}</p>
             </label>
           </div>
         )}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -351,54 +351,25 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                   updateField={(_section, _subSection, _key, value) => updateFilterProp('queryParameter', value)}
                 />
               )}
-              <label>
-                <span>API Endpoint: </span>
-                <textarea value={filter?.apiFilter.apiEndpoint || ''} />
-                {isNestedDropdown && (
-                  <Tooltip style={{ textTransform: 'none' }}>
-                    <Tooltip.Target>
-                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                    </Tooltip.Target>
-                    <Tooltip.Content>
-                      <p>Your API Endpoint should return both value selector values.</p>
-                    </Tooltip.Content>
-                  </Tooltip>
-                )}
-              </label>
-              <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
+              <div className='bg-secondary-subtle p-2 my-2'>
                 <label>
-                  <span>Value Selector: </span>
-                  <input value={filter?.apiFilter.valueSelector || ''} />
-                  <Tooltip style={{ textTransform: 'none' }}>
-                    <Tooltip.Target>
-                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                    </Tooltip.Target>
-                    <Tooltip.Content>
-                      <p>Value to use in the html option element</p>
-                    </Tooltip.Content>
-                  </Tooltip>
-                  {` * Required`}
+                  <span>API Endpoint: </span>
+                  <textarea value={filter?.apiFilter?.apiEndpoint || ''} disabled />
+                  {isNestedDropdown && (
+                    <Tooltip style={{ textTransform: 'none' }}>
+                      <Tooltip.Target>
+                        <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                      </Tooltip.Target>
+                      <Tooltip.Content>
+                        <p>Your API Endpoint should return both value selector values.</p>
+                      </Tooltip.Content>
+                    </Tooltip>
+                  )}
                 </label>
-                <label>
-                  <span>Display Text Selector: </span>
-                  <input value={filter?.apiFilter.textSelector || ''} />
-                  <Tooltip style={{ textTransform: 'none' }}>
-                    <Tooltip.Target>
-                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                    </Tooltip.Target>
-                    <Tooltip.Content>
-                      <p>Text to use in the html option element. If none is applied value selector will be used.</p>
-                    </Tooltip.Content>
-                  </Tooltip>
-                  {` * Optional`}
-                </label>
-              </div>
-
-              {isNestedDropdown && (
                 <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
                   <label>
-                    <span>Subgroup Value Selector: </span>
-                    <input value={filter?.apiFilter.subgroupValueSelector || ''} />
+                    <span>Value Selector: </span>
+                    <input value={filter?.apiFilter?.valueSelector || ''} disabled />
                     <Tooltip style={{ textTransform: 'none' }}>
                       <Tooltip.Target>
                         <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -407,11 +378,11 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                         <p>Value to use in the html option element</p>
                       </Tooltip.Content>
                     </Tooltip>
-                    {` * Required`}
+                    <div>{` * Required`}</div>
                   </label>
                   <label>
-                    <span>Subgroup Display Text Selector: </span>
-                    <input value={filter?.apifilter.subgroupTextSelector || ''} />
+                    <span>Display Text Selector: </span>
+                    <input value={filter?.apiFilter?.textSelector || ''} disabled />
                     <Tooltip style={{ textTransform: 'none' }}>
                       <Tooltip.Target>
                         <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -420,14 +391,48 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                         <p>Text to use in the html option element. If none is applied value selector will be used.</p>
                       </Tooltip.Content>
                     </Tooltip>
-                    {` * Optional`}
+                    <div>{` * Optional`}</div>
                   </label>
                 </div>
-              )}
 
-              <button onClick={() => handleEditAPIValues(filter, isNestedDropdown, updateAPIFilter)}>
-                Edit API Values
-              </button>
+                {isNestedDropdown && (
+                  <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
+                    <label>
+                      <span>Subgroup Value Selector: </span>
+                      <input value={filter?.apiFilter?.subgroupValueSelector || ''} disabled />
+                      <Tooltip style={{ textTransform: 'none' }}>
+                        <Tooltip.Target>
+                          <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                        </Tooltip.Target>
+                        <Tooltip.Content>
+                          <p>Value to use in the html option element</p>
+                        </Tooltip.Content>
+                      </Tooltip>
+                      <div>{` * Required`}</div>
+                    </label>
+                    <label>
+                      <span>Subgroup Display Text Selector: </span>
+                      <input value={filter?.apifilter?.subgroupTextSelector || ''} disabled />
+                      <Tooltip style={{ textTransform: 'none' }}>
+                        <Tooltip.Target>
+                          <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                        </Tooltip.Target>
+                        <Tooltip.Content>
+                          <p>Text to use in the html option element. If none is applied value selector will be used.</p>
+                        </Tooltip.Content>
+                      </Tooltip>
+                      <div>{` * Optional`}</div>
+                    </label>
+                  </div>
+                )}
+
+                <button
+                  onClick={() => handleEditAPIValues(filter, isNestedDropdown, updateAPIFilter)}
+                  className='btn mt-2'
+                >
+                  Edit API Values
+                </button>
+              </div>
 
               <label>
                 <input

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -129,19 +129,25 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
     loadColumnData()
   }, [config.datasets, config.dashboard.sharedFilters])
 
-  const updateAPIFilter = (apiEndpoint, valueSelector, textSelector, subgroupValueSelector, subgroupTextSelector) => {
+  const updateAPIFilter = (
+    APIEndpoint,
+    APIValueSelector,
+    APITextSelector,
+    APISubgroupValueSelector,
+    APISubgroupTextSelector
+  ) => {
     const newAPIFilter = !isNestedDropdown
       ? {
-          apiEndpoint,
-          valueSelector,
-          textSelector
+          apiEndpoint: APIEndpoint,
+          valueSelector: APIValueSelector,
+          textSelector: APITextSelector
         }
       : {
-          apiEndpoint,
-          valueSelector,
-          textSelector,
-          subgroupValueSelector,
-          subgroupTextSelector
+          apiEndpoint: APIEndpoint,
+          valueSelector: APIValueSelector,
+          textSelector: APITextSelector,
+          subgroupValueSelector: APISubgroupValueSelector,
+          subgroupTextSelector: APISubgroupTextSelector
         }
     updateFilterProp('apiFilter', newAPIFilter)
     overlay.actions.toggleOverlay(false)
@@ -157,17 +163,20 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
 
   const isNestedDropdown = filter.filterStyle === FILTER_STYLE.nestedDropdown
 
+  const EditAPIValues = (filter, isNestedDropdown, updateAPIFilter) => {
+    return (
+      <Modal>
+        <Modal.Content>
+          <APIModal filter={filter} isNestedDropdown={isNestedDropdown} updateAPIFilter={updateAPIFilter} />
+        </Modal.Content>
+      </Modal>
+    )
+  }
   const { overlay } = useGlobalContext()
 
   const handleEditAPIValues = (filter, isNestedDropdown, updateAPIFilter) => {
     {
-      overlay.actions.openOverlay(
-        <Modal>
-          <Modal.Content>
-            <APIModal filter={filter} isNestedDropdown={isNestedDropdown} updateAPIFilter={updateAPIFilter} />
-          </Modal.Content>
-        </Modal>
-      )
+      overlay.actions.openOverlay(EditAPIValues(filter, isNestedDropdown, updateAPIFilter))
     }
   }
 
@@ -342,25 +351,54 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                   updateField={(_section, _subSection, _key, value) => updateFilterProp('queryParameter', value)}
                 />
               )}
-              <div className='bg-secondary-subtle p-2 my-2'>
+              <label>
+                <span>API Endpoint: </span>
+                <textarea value={filter?.apiFilter.apiEndpoint || ''} />
+                {isNestedDropdown && (
+                  <Tooltip style={{ textTransform: 'none' }}>
+                    <Tooltip.Target>
+                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                    </Tooltip.Target>
+                    <Tooltip.Content>
+                      <p>Your API Endpoint should return both value selector values.</p>
+                    </Tooltip.Content>
+                  </Tooltip>
+                )}
+              </label>
+              <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
                 <label>
-                  <span>API Endpoint: </span>
-                  <textarea value={filter?.apiFilter?.apiEndpoint || ''} disabled />
-                  {isNestedDropdown && (
-                    <Tooltip style={{ textTransform: 'none' }}>
-                      <Tooltip.Target>
-                        <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                      </Tooltip.Target>
-                      <Tooltip.Content>
-                        <p>Your API Endpoint should return both value selector values.</p>
-                      </Tooltip.Content>
-                    </Tooltip>
-                  )}
+                  <span>Value Selector: </span>
+                  <input value={filter?.apiFilter.valueSelector || ''} />
+                  <Tooltip style={{ textTransform: 'none' }}>
+                    <Tooltip.Target>
+                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                    </Tooltip.Target>
+                    <Tooltip.Content>
+                      <p>Value to use in the html option element</p>
+                    </Tooltip.Content>
+                  </Tooltip>
+                  {` * Required`}
                 </label>
+                <label>
+                  <span>Display Text Selector: </span>
+                  <input value={filter?.apiFilter.textSelector || ''} />
+                  <Tooltip style={{ textTransform: 'none' }}>
+                    <Tooltip.Target>
+                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                    </Tooltip.Target>
+                    <Tooltip.Content>
+                      <p>Text to use in the html option element. If none is applied value selector will be used.</p>
+                    </Tooltip.Content>
+                  </Tooltip>
+                  {` * Optional`}
+                </label>
+              </div>
+
+              {isNestedDropdown && (
                 <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
                   <label>
-                    <span>Value Selector: </span>
-                    <input value={filter?.apiFilter?.valueSelector || ''} disabled />
+                    <span>Subgroup Value Selector: </span>
+                    <input value={filter?.apiFilter.subgroupValueSelector || ''} />
                     <Tooltip style={{ textTransform: 'none' }}>
                       <Tooltip.Target>
                         <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -369,11 +407,11 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                         <p>Value to use in the html option element</p>
                       </Tooltip.Content>
                     </Tooltip>
-                    <div>{` * Required`}</div>
+                    {` * Required`}
                   </label>
                   <label>
-                    <span>Display Text Selector: </span>
-                    <input value={filter?.apiFilter?.textSelector || ''} disabled />
+                    <span>Subgroup Display Text Selector: </span>
+                    <input value={filter?.apifilter.subgroupTextSelector || ''} />
                     <Tooltip style={{ textTransform: 'none' }}>
                       <Tooltip.Target>
                         <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -382,48 +420,14 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                         <p>Text to use in the html option element. If none is applied value selector will be used.</p>
                       </Tooltip.Content>
                     </Tooltip>
-                    <div>{` * Optional`}</div>
+                    {` * Optional`}
                   </label>
                 </div>
+              )}
 
-                {isNestedDropdown && (
-                  <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
-                    <label>
-                      <span>Subgroup Value Selector: </span>
-                      <input value={filter?.apiFilter?.subgroupValueSelector || ''} disabled />
-                      <Tooltip style={{ textTransform: 'none' }}>
-                        <Tooltip.Target>
-                          <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                        </Tooltip.Target>
-                        <Tooltip.Content>
-                          <p>Value to use in the html option element</p>
-                        </Tooltip.Content>
-                      </Tooltip>
-                      <div>{` * Required`}</div>
-                    </label>
-                    <label>
-                      <span>Subgroup Display Text Selector: </span>
-                      <input value={filter?.apifilter?.subgroupTextSelector || ''} disabled />
-                      <Tooltip style={{ textTransform: 'none' }}>
-                        <Tooltip.Target>
-                          <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                        </Tooltip.Target>
-                        <Tooltip.Content>
-                          <p>Text to use in the html option element. If none is applied value selector will be used.</p>
-                        </Tooltip.Content>
-                      </Tooltip>
-                      <div>{` * Optional`}</div>
-                    </label>
-                  </div>
-                )}
-
-                <button
-                  onClick={() => handleEditAPIValues(filter, isNestedDropdown, updateAPIFilter)}
-                  className='btn btn-primary mt-2'
-                >
-                  Edit API Values
-                </button>
-              </div>
+              <button onClick={() => handleEditAPIValues(filter, isNestedDropdown, updateAPIFilter)}>
+                Edit API Values
+              </button>
 
               <label>
                 <input

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -419,7 +419,7 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
 
                 <button
                   onClick={() => handleEditAPIValues(filter, isNestedDropdown, updateAPIFilter)}
-                  className='btn mt-2'
+                  className='btn btn-primary mt-2'
                 >
                   Edit API Values
                 </button>

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -360,7 +360,7 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                 <div className={isNestedDropdown ? 'border border-dark p-1 my-1' : ''}>
                   <label>
                     <span>Value Selector: </span>
-                    <input value={filter?.apiFilter?.valueSelector || ''} disabled />
+                    <input type='text' value={filter?.apiFilter?.valueSelector || ''} disabled />
                     <Tooltip style={{ textTransform: 'none' }}>
                       <Tooltip.Target>
                         <Icon display='question' style={{ marginLeft: '0.5rem' }} />
@@ -373,7 +373,7 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
                   </label>
                   <label>
                     <span>Display Text Selector: </span>
-                    <input value={filter?.apiFilter?.textSelector || ''} disabled />
+                    <input type='text' value={filter?.apiFilter?.textSelector || ''} disabled />
                     <Tooltip style={{ textTransform: 'none' }}>
                       <Tooltip.Target>
                         <Icon display='question' style={{ marginLeft: '0.5rem' }} />

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersEditor/components/FilterEditor.tsx
@@ -129,25 +129,19 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
     loadColumnData()
   }, [config.datasets, config.dashboard.sharedFilters])
 
-  const updateAPIFilter = (
-    APIEndpoint,
-    APIValueSelector,
-    APITextSelector,
-    APISubgroupValueSelector,
-    APISubgroupTextSelector
-  ) => {
+  const updateAPIFilter = (apiEndpoint, valueSelector, textSelector, subgroupValueSelector, subgroupTextSelector) => {
     const newAPIFilter = !isNestedDropdown
       ? {
-          apiEndpoint: APIEndpoint,
-          valueSelector: APIValueSelector,
-          textSelector: APITextSelector
+          apiEndpoint,
+          valueSelector,
+          textSelector
         }
       : {
-          apiEndpoint: APIEndpoint,
-          valueSelector: APIValueSelector,
-          textSelector: APITextSelector,
-          subgroupValueSelector: APISubgroupValueSelector,
-          subgroupTextSelector: APISubgroupTextSelector
+          apiEndpoint,
+          valueSelector,
+          textSelector,
+          subgroupValueSelector,
+          subgroupTextSelector
         }
     updateFilterProp('apiFilter', newAPIFilter)
     overlay.actions.toggleOverlay(false)
@@ -163,20 +157,17 @@ const FilterEditor: React.FC<FilterEditorProps> = ({
 
   const isNestedDropdown = filter.filterStyle === FILTER_STYLE.nestedDropdown
 
-  const EditAPIValues = (filter, isNestedDropdown, updateAPIFilter) => {
-    return (
-      <Modal>
-        <Modal.Content>
-          <APIModal filter={filter} isNestedDropdown={isNestedDropdown} updateAPIFilter={updateAPIFilter} />
-        </Modal.Content>
-      </Modal>
-    )
-  }
   const { overlay } = useGlobalContext()
 
   const handleEditAPIValues = (filter, isNestedDropdown, updateAPIFilter) => {
     {
-      overlay.actions.openOverlay(EditAPIValues(filter, isNestedDropdown, updateAPIFilter))
+      overlay.actions.openOverlay(
+        <Modal>
+          <Modal.Content>
+            <APIModal filter={filter} isNestedDropdown={isNestedDropdown} updateAPIFilter={updateAPIFilter} />
+          </Modal.Content>
+        </Modal>
+      )
     }
   }
 


### PR DESCRIPTION
## Summary
Added type="text" to inputs to make the text boxes have the correct styling

## Testing Steps
Scenario: Upload [NEW-50375-config.json](https://github.com/user-attachments/files/19448884/NEW-50375-config.json), open the Configuration Tab, and click on the tools icon on the top Filter Dropdowns widget.
Expected: Dashboard Filters Editor opens with 2 filters: Location and Time Period

Open the Filters Accordion tab and open the Location filter

Scroll down to the gray area that has the API Endpoint

Click on the Edit API Values button.
Expected: A module pops up with 3 text inputs: API Endpoint, Value Selector, and Display Text Selector

Change the text in the boxes

Then click the Save button
Expected: The values in the gray box will reflect the changes made in the module.

Scroll up to Filter Style and change it to Nested-Dropdown

Scroll back to the gray area and click the Edit API Values button
Expected: The module pops up with 5 inputs, the same as the other one but with subgroup values.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
