### PR TITLE
Fix [NEW-50395] Fix missing x-axis ticks

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -259,7 +259,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     data.length && isDateTime
       ? [0, data.length - 1].map(i => parseDate(data[i][dataKey])).reduce((a, b) => Math.abs(a - b)) / MONTH_AS_MS
       : 0
-  const useDateSpanMonths = isDateTime && dateSpanMonths > xTickCount
+  const useDateSpanMonths = isDateTime && dateSpanMonths > xTickCount && !config.runtime.xAxis.manual
 
   // GETTERS & FUNCTIONS
   const handleLeftTickFormatting = (tick, index, ticks) => {


### PR DESCRIPTION
## Summary

This PR fixes a bug where the "manual ticks" option sometimes resulted in missing x-axis ticks.

## Testing Steps

The attached config will be missing x-axis ticks on `dev` but will show them on this branch.

[trends-nhsn-broken2.json](https://github.com/user-attachments/files/19782767/trends-nhsn-broken2.json)

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
