### PR TITLE
Enhancement [NO TICKET] Add dev origin header

### DIFF
--- a/generateViteConfig.js
+++ b/generateViteConfig.js
@@ -14,7 +14,12 @@ dns.setDefaultResultOrder('verbatim')
 // - Active dev servers ('lerna run start') must be restarted in order to view the changed settings.
 const generateViteConfig = (componentName, configOptions = {}, reactOptions = {}) => {
   let configOptionsDefault = {
-    server: { port: 8080 },
+    server: {
+      port: 8080,
+      headers: {
+        'Access-Control-Allow-Origin': '*'
+      }
+    },
     build: {
       commonjsOptions: {
         include: [/@cdc\/core/, /node_modules/]


### PR DESCRIPTION
## Summary

We have a separate project where we're including COVE on a page locally like this:

```
<div class="react-container" data-config="/bird-flu.json"></div>
<script type="module" src="http://localhost:8080/src/index.tsx"></script>
```

Adding this header makes it possible.

## Testing Steps

Run COVE locally, ensure it still works.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
