### PR TITLE
Fix/ [NEW-50398] tooltips horizontal bar charts

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react'
 
 // Local context and hooks
 import ConfigContext from '../../../ConfigContext'
-import { useBarChart } from '../../../hooks/useBarChart'
 import { useHighlightedBars } from '../../../hooks/useHighlightedBars'
 
 // VisX library imports
@@ -27,7 +26,24 @@ import _ from 'lodash'
 import { getBarData } from '../helpers/getBarData'
 
 export const BarChartHorizontal = () => {
-  const { xScale, yScale, yMax, seriesScale } = useContext<BarChartContextValues>(BarChartContext)
+  const { xScale, yScale, yMax, seriesScale, barChart } = useContext<BarChartContextValues>(BarChartContext)
+  const {
+    isHorizontal,
+    barBorderWidth,
+    updateBars,
+    assignColorsToValues,
+    section,
+    isLabelBelowBar,
+    lollipopBarWidth,
+    lollipopShapeSize,
+    getHighlightedBarColorByValue,
+    getHighlightedBarByValue,
+    getAdditionalColumn,
+    hoveredBar,
+    onMouseLeaveBar,
+    onMouseOverBar
+  } = barChart
+
   const {
     transformedData: data,
     tableData,
@@ -40,31 +56,12 @@ export const BarChartHorizontal = () => {
     setSharedFilter,
     isNumber
   } = useContext<ChartContext>(ConfigContext)
-  const {
-    isHorizontal,
-    barBorderWidth,
-    updateBars,
-    assignColorsToValues,
-    section,
-    isLabelBelowBar,
-    displayNumbersOnBar,
-    lollipopBarWidth,
-    lollipopShapeSize,
-    getHighlightedBarColorByValue,
-    getHighlightedBarByValue,
-    getAdditionalColumn,
-    hoveredBar,
-    onMouseLeaveBar,
-    onMouseOverBar
-  } = useBarChart()
 
   const { HighLightedBarUtils } = useHighlightedBars(config)
 
   const hasConfidenceInterval = Object.keys(config.confidenceKeys).length > 0
 
   const _data = getBarData(config, data, hasConfidenceInterval)
-
-  const root = document.documentElement
 
   return (
     config.visualizationSubType !== 'stacked' &&
@@ -242,7 +239,7 @@ export const BarChartHorizontal = () => {
                           height: numbericBarHeight,
                           x: barX,
                           y: barHeight * bar.index,
-                          onMouseOver: () => onMouseOverBar(xAxisValue, bar.key),
+                          onMouseOver: e => onMouseOverBar(xAxisValue, bar.key, e, data),
                           onMouseLeave: onMouseLeaveBar,
                           tooltipHtml: tooltip,
                           tooltipId: `cdc-open-viz-tooltip-${config.runtime.uniqueId}`,

--- a/packages/chart/src/components/BarChart/components/BarChart.StackedHorizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.StackedHorizontal.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react'
 import ConfigContext from '../../../ConfigContext'
-import { useBarChart } from '../../../hooks/useBarChart'
 import { BarStackHorizontal } from '@visx/shape'
 import { Group } from '@visx/group'
 import { Text } from '@visx/text'
@@ -15,7 +14,7 @@ import { type ChartContext } from '../../../types/ChartContext'
 import createBarElement from '@cdc/core/components/createBarElement'
 
 const BarChartStackedHorizontal = () => {
-  const { yMax, yScale, xScale } = useContext<BarChartContextValues>(BarChartContext)
+  const { yMax, yScale, xScale, barChart } = useContext<BarChartContextValues>(BarChartContext)
 
   // prettier-ignore
   const {
@@ -30,8 +29,18 @@ const BarChartStackedHorizontal = () => {
     transformedData: data
   } = useContext<ChartContext>(ConfigContext)
 
-  // prettier-ignore
-  const { barBorderWidth, displayNumbersOnBar, getAdditionalColumn, hoveredBar, isHorizontal, isLabelBelowBar, onMouseLeaveBar, onMouseOverBar, updateBars, barStackedSeriesKeys } = useBarChart()
+  const {
+    barBorderWidth,
+    displayNumbersOnBar,
+    getAdditionalColumn,
+    hoveredBar,
+    isHorizontal,
+    isLabelBelowBar,
+    onMouseLeaveBar,
+    onMouseOverBar,
+    updateBars,
+    barStackedSeriesKeys
+  } = barChart
 
   const { orientation, visualizationSubType } = config
   return (
@@ -101,7 +110,7 @@ const BarChartStackedHorizontal = () => {
                         height: bar.height,
                         x: bar.x,
                         y: bar.y,
-                        onMouseOver: () => onMouseOverBar(yAxisValue, bar.key),
+                        onMouseOver: e => onMouseOverBar(yAxisValue, bar.key, e, data),
                         onMouseLeave: onMouseLeaveBar,
                         tooltipHtml: tooltip,
                         tooltipId: `cdc-open-viz-tooltip-${config.runtime.uniqueId}`,

--- a/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useState } from 'react'
 import ConfigContext from '../../../ConfigContext'
-import { useBarChart } from '../../../hooks/useBarChart'
 import { BarStack } from '@visx/shape'
 import { Group } from '@visx/group'
 import { Text } from '@visx/text'
@@ -12,19 +11,19 @@ import createBarElement from '@cdc/core/components/createBarElement'
 
 const BarChartStackedVertical = () => {
   const [barWidth, setBarWidth] = useState(0)
-  const { xScale, yScale, seriesScale, xMax, yMax } = useContext(BarChartContext)
-  const { transformedData, colorScale, seriesHighlight, config, formatNumber, formatDate, parseDate, setSharedFilter } =
-    useContext(ConfigContext)
+  const { xScale, yScale, seriesScale, xMax, yMax, barChart } = useContext(BarChartContext)
   const {
     isHorizontal,
     barBorderWidth,
-    applyRadius,
     hoveredBar,
     getAdditionalColumn,
     onMouseLeaveBar,
     onMouseOverBar,
     barStackedSeriesKeys
-  } = useBarChart()
+  } = barChart
+  const { transformedData, colorScale, seriesHighlight, config, formatNumber, formatDate, parseDate, setSharedFilter } =
+    useContext(ConfigContext)
+
   const { orientation } = config
 
   const data = config.brush?.active && config.brush.data?.length ? config.brush.data : transformedData
@@ -98,7 +97,7 @@ const BarChartStackedVertical = () => {
                         height: bar.height,
                         x: barX,
                         y: bar.y,
-                        onMouseOver: () => onMouseOverBar(xAxisValue, bar.key),
+                        onMouseOver: e => onMouseOverBar(xAxisValue, bar.key, e, data),
                         onMouseLeave: onMouseLeaveBar,
                         tooltipHtml: tooltip,
                         tooltipId: `cdc-open-viz-tooltip-${config.runtime.uniqueId}`,

--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useState } from 'react'
 import ConfigContext from '../../../ConfigContext'
 import BarChartContext, { type BarChartContextValues } from './context'
 // Local hooks
-import { useBarChart } from '../../../hooks/useBarChart'
 import { useHighlightedBars } from '../../../hooks/useHighlightedBars'
 import { getBarConfig, testZeroValue } from '../helpers'
 // VisX library imports
@@ -25,14 +24,9 @@ import _ from 'lodash'
 import { getBarData } from '../helpers/getBarData'
 
 export const BarChartVertical = () => {
-  const { xScale, yScale, xMax, yMax, seriesScale, convertLineToBarGraph } =
+  const { xScale, yScale, xMax, yMax, seriesScale, convertLineToBarGraph, barChart } =
     useContext<BarChartContextValues>(BarChartContext)
-
-  const [barWidth, setBarWidth] = useState(0)
-  const [totalBarsInGroup, setTotalBarsInGroup] = useState(0)
-  // prettier-ignore
   const {
-    // prettier-ignore
     assignColorsToValues,
     barBorderWidth,
     getAdditionalColumn,
@@ -43,10 +37,24 @@ export const BarChartVertical = () => {
     onMouseLeaveBar,
     onMouseOverBar,
     section
-  } = useBarChart()
+  } = barChart
 
-  // prettier-ignore
-  const { colorScale, config, dashboardConfig, tableData, formatDate, formatNumber, parseDate, seriesHighlight, setSharedFilter, transformedData, brushConfig } = useContext<ChartContext>(ConfigContext)
+  const [barWidth, setBarWidth] = useState(0)
+  const [totalBarsInGroup, setTotalBarsInGroup] = useState(0)
+
+  const {
+    colorScale,
+    config,
+    dashboardConfig,
+    tableData,
+    formatDate,
+    formatNumber,
+    parseDate,
+    seriesHighlight,
+    setSharedFilter,
+    transformedData,
+    brushConfig
+  } = useContext<ChartContext>(ConfigContext)
 
   const { HighLightedBarUtils } = useHighlightedBars(config)
 
@@ -261,7 +269,7 @@ export const BarChartVertical = () => {
                           height: barHeight,
                           x: barX,
                           y: barY,
-                          onMouseOver: () => onMouseOverBar(xAxisValue, bar.key),
+                          onMouseOver: e => onMouseOverBar(xAxisValue, bar.key, e, data),
                           onMouseLeave: onMouseLeaveBar,
                           tooltipHtml: tooltip,
                           tooltipId: `cdc-open-viz-tooltip-${config.runtime.uniqueId}`,

--- a/packages/chart/src/components/BarChart/components/BarChart.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { MouseEventHandler, useContext, useState } from 'react'
 
 // visx
 import { Group } from '@visx/group'
@@ -9,8 +9,21 @@ import BarChartType from './BarChartType'
 import ErrorBoundary from '@cdc/core/components/ErrorBoundary'
 import ConfigContext from '../../../ConfigContext'
 import BarChartContext from './context'
+import { useBarChart } from '../helpers/useBarChart'
+import { PositionScale } from '@visx/shape/lib/types'
 
-const BarChart = ({
+type BarChartProps = {
+  xScale: PositionScale
+  yScale: PositionScale
+  seriesScale: PositionScale
+  xMax: number
+  yMax: number
+  handleTooltipMouseOver: MouseEventHandler<SVGRectElement>
+  handleTooltipMouseOff: MouseEventHandler<SVGRectElement>
+  handleTooltipClick: MouseEventHandler<SVGRectElement>
+}
+
+const BarChart: React.FC<BarChartProps> = ({
   xScale,
   yScale,
   seriesScale,
@@ -20,7 +33,9 @@ const BarChart = ({
   handleTooltipMouseOff,
   handleTooltipClick
 }) => {
-  const { transformedData: data, config, convertLineToBarGraph } = useContext(ConfigContext)
+  const configContext = useContext(ConfigContext)
+  const { transformedData: data, config, convertLineToBarGraph } = configContext
+  const barChart = useBarChart(handleTooltipMouseOver, handleTooltipMouseOff, configContext)
 
   const contextValues = {
     xScale,
@@ -28,7 +43,8 @@ const BarChart = ({
     xMax,
     yMax,
     seriesScale,
-    convertLineToBarGraph
+    convertLineToBarGraph,
+    barChart
   }
 
   return (
@@ -46,7 +62,9 @@ const BarChart = ({
             height={Number(yMax)}
             fill={'transparent'}
             fillOpacity={0.05}
-            onMouseMove={e => handleTooltipMouseOver(e, data)}
+            onMouseMove={e => {
+              handleTooltipMouseOver(e, data)
+            }}
             onMouseOut={handleTooltipMouseOff}
             onClick={e => handleTooltipClick(e, data)}
           />

--- a/packages/chart/src/components/BarChart/components/context.tsx
+++ b/packages/chart/src/components/BarChart/components/context.tsx
@@ -1,3 +1,4 @@
+import { PositionScale } from '@visx/shape/lib/types'
 import { createContext } from 'react'
 
 const BarChartContext = createContext(null)
@@ -5,10 +6,28 @@ const BarChartContext = createContext(null)
 export type BarChartContextValues = {
   xMax: number
   yMax: number
-  xScale: Function
-  yScale: Function
+  xScale: PositionScale
+  yScale: PositionScale
   seriesScale: Function
   convertLineToBarGraph: boolean
+  barChart: {
+    assignColorsToValues: Function
+    barBorderWidth: number
+    getAdditionalColumn: Function
+    getHighlightedBarByValue: Function
+    getHighlightedBarColorByValue: Function
+    lollipopBarWidth: number
+    lollipopShapeSize: number
+    onMouseLeaveBar: Function
+    onMouseOverBar: Function
+    section: string
+    hoveredBar: string
+    isHorizontal: boolean
+    isLabelBelowBar: boolean
+    displayNumbersOnBar: boolean
+    updateBars: Function
+    barStackedSeriesKeys: string[]
+  }
 }
 
 export default BarChartContext

--- a/packages/chart/src/components/BarChart/helpers/useBarChart.ts
+++ b/packages/chart/src/components/BarChart/helpers/useBarChart.ts
@@ -1,12 +1,12 @@
 import React, { useContext, useEffect, useState } from 'react'
-import ConfigContext, { ChartDispatchContext } from '../ConfigContext'
+import { ChartDispatchContext } from '../../../ConfigContext'
 import { formatNumber as formatColNumber } from '@cdc/core/helpers/cove/number'
 import { APP_FONT_SIZE } from '@cdc/core/helpers/constants'
-export const useBarChart = () => {
-  const { config, colorPalettes, tableData, updateConfig, parseDate, formatDate, setSeriesHighlight, seriesHighlight } =
-    useContext(ConfigContext)
-  const dispatch = useContext(ChartDispatchContext)
+
+export const useBarChart = (handleTooltipMouseOver, handleTooltipMouseOff, configContext) => {
+  const { config, colorPalettes, tableData, updateConfig, parseDate, formatDate, seriesHighlight } = configContext
   const { orientation } = config
+  const dispatch = useContext(ChartDispatchContext)
   const [hoveredBar, setHoveredBar] = useState(null)
 
   const isHorizontal = orientation === 'horizontal'
@@ -226,17 +226,18 @@ export const useBarChart = () => {
     return additionalTooltipItems
   }
 
-  const onMouseOverBar = (categoryValue, barKey) => {
+  const onMouseOverBar = (categoryValue, barKey, event, data) => {
     if (config.legend.highlightOnHover && config.legend.behavior === 'highlight' && barKey) {
       dispatch({ type: 'SET_SERIES_HIGHLIGHT', payload: [barKey] })
     }
-
+    handleTooltipMouseOver(event, data)
     setHoveredBar(categoryValue)
   }
   const onMouseLeaveBar = () => {
     if (config.legend.highlightOnHover && config.legend.behavior === 'highlight') {
       dispatch({ type: 'SET_SERIES_HIGHLIGHT', payload: [] })
     }
+    handleTooltipMouseOff()
   }
 
   return {

--- a/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
+++ b/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
@@ -358,10 +358,7 @@ export const useEditorPermissions = () => {
 
   const visSupportsReactTooltip = () => {
     if (config.yAxis.type === 'categorical') return true
-    if (
-      ['Deviation Bar', 'Box Plot', 'Scatter Plot', 'Paired Bar'].includes(visualizationType) ||
-      (visualizationType === 'Bar' && config.tooltips.singleSeries)
-    ) {
+    if (['Deviation Bar', 'Box Plot', 'Scatter Plot', 'Paired Bar'].includes(visualizationType)) {
       return true
     }
   }


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

Tool tips were not working on horizontal bar charts which were using a toggle in dashboard on the initial render. I tracked that down to an issue with two separate mouse event handlers in different hooks. I combined the handlers in the useBarChart hook so that they are both called together. 

## Testing Steps
<!-- Provide testing steps -->

upload: 
[new-50398-tooltip.json](https://github.com/user-attachments/files/19851589/new-50398-tooltip.json)

1) navigate to preview page.
2) toggle the bar chart.
3) hover over one of the bars.

Expected: you should see a tooltip with corresponding information. 


<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
