### PR TITLE
Enhancement: NEW-50393 Line Chart Tooltip Enhancement

### DIFF
--- a/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
+++ b/packages/chart/src/components/LineChart/components/LineChart.Circle.tsx
@@ -1,22 +1,15 @@
-import React from 'react'
 import chroma from 'chroma-js'
 import { LineChartConfig, type ChartConfig } from '../../../types/ChartConfig'
 import { GlyphDiamond, GlyphCircle, GlyphSquare, GlyphTriangle, GlyphCross, Glyph as CustomGlyph } from '@visx/glyph'
 import { Text } from '@visx/text'
 
 type LineChartCircleProps = {
-  circleData: object[]
   config: ChartConfig
   data: object[]
   tableData: object[]
   d?: Object
   displayArea: boolean
   seriesKey: string
-  tooltipData: {
-    data: []
-    tooltipDataX: number
-    tooltipDataY: number
-  }
   xScale: any
   yScale: any
   yScaleRight: any
@@ -25,7 +18,14 @@ type LineChartCircleProps = {
   seriesAxis: string
   dataIndex: number
   seriesIndex: number
-  mode: 'ISOLATED_POINTS' | 'HOVER_POINTS' | 'ALWAYS_SHOW_POINTS'
+  mode: 'ISOLATED_POINTS' | 'HOVER_POINTS' | 'ALWAYS_SHOW_POINTS' | 'TOOLTIP_POINTS'
+  tooltipPoint: {
+    xValue: string | number
+    yValue: string | number
+    color: string
+  }
+  handleTooltipMouseOver?: Function
+  handleTooltipMouseOff?: Function
 }
 const Glyphs = [
   GlyphCircle,
@@ -47,20 +47,20 @@ const LineChartCircle = (props: LineChartCircleProps) => {
   const {
     config,
     d: pointData,
-    tableData,
     displayArea,
     seriesKey,
-    tooltipData,
     xScale,
     yScale,
     colorScale,
     parseDate,
     yScaleRight,
     data,
-    circleData,
+    tooltipPoint,
     dataIndex,
     mode,
-    seriesIndex
+    seriesIndex,
+    handleTooltipMouseOver,
+    handleTooltipMouseOff
   } = props
   const { isolatedDotsSameSize, lineDatapointStyle, visual } = config as LineChartConfig
   const filtered = config?.series.filter(s => s.dataKey === seriesKey)?.[0]
@@ -69,127 +69,57 @@ const LineChartCircle = (props: LineChartCircleProps) => {
       config.visual.lineDatapointSymbol === 'standard' && seriesIndex < visual.maximumShapeAmount ? seriesIndex : 0
     ]
   const isReversedTriangle = seriesIndex === 4
-  const transformShape = (top, left) => `translate(${left}, ${top})${isReversedTriangle ? ' rotate(180)' : ''}`
   const LARGE_DOT_SIZE = 124
   const REGULAR_DOT_SIZE = 55
   const dotSize = isolatedDotsSameSize ? REGULAR_DOT_SIZE : LARGE_DOT_SIZE
 
-  // If we're not showing the circle, simply return
-  const getColor = (
-    displayArea: boolean,
-    colorScale: Function,
-    config: ChartConfig,
-    hoveredKey: string,
-    seriesKey: string
-  ) => {
-    const seriesLabels = config.runtime.seriesLabels || []
-    const seriesLabelsAll = config.runtime.seriesLabelsAll || []
-    let color = displayArea ? colorScale(seriesLabels[hoveredKey] || seriesLabelsAll[seriesIndex]) : ' transparent'
-    if (config.lineDatapointColor === 'Lighter than Line' && color !== 'transparent' && color) {
-      color = chroma(color).brighten(1)
-    }
-    return color
-  }
   const getXPos = hoveredXValue => {
     return (
       (config.xAxis.type === 'categorical' ? xScale(hoveredXValue) : xScale(parseDate(hoveredXValue))) +
       (xScale.bandwidth ? xScale.bandwidth() / 2 : 0)
     )
   }
-  if (mode === 'ALWAYS_SHOW_POINTS' && lineDatapointStyle !== 'hidden') {
-    if (lineDatapointStyle === 'always show') {
-      const isMatch = circleData?.some(
-        cd => cd[config.xAxis.dataKey] === pointData[config.xAxis.dataKey] && cd[seriesKey] === pointData[seriesKey]
-      )
 
-      if (
-        isMatch ||
-        !filtered ||
-        (visual.maximumShapeAmount === seriesIndex && visual.lineDatapointSymbol === 'standard')
-      )
-        return <></>
-      const positionLeft = getXPos(pointData[config.xAxis.dataKey])
-      const positionTop =
-        filtered.axis === 'Right' ? yScaleRight(pointData[filtered.dataKey]) : yScale(pointData[filtered.dataKey])
+  const transformShape = (xValue, yValue) => {
+    const positionLeft = getXPos(xValue)
+    const positionTop = filtered?.axis === 'Right' ? yScaleRight(yValue) : yScale(yValue)
 
-      return (
-        <g transform={transformShape(positionTop, positionLeft)}>
-          <Shape
-            opacity={pointData[seriesKey] ? 1 : 0}
-            fillOpacity={1}
-            fill={getColor(displayArea, colorScale, config, seriesKey, seriesKey)}
-            style={{ filter: 'unset', opacity: 1 }}
-          />
-        </g>
-      )
-    }
+    return `translate(${positionLeft}, ${positionTop})${isReversedTriangle ? ' rotate(180)' : ''}`
   }
 
-  if (mode === 'HOVER_POINTS') {
-    if (lineDatapointStyle === 'hover') {
-      if (!tooltipData) return
-      if (!seriesKey) return
-      if (!tooltipData.data) return
-      let hoveredXValue = tooltipData?.data?.[0]?.[1]
-      if (!hoveredXValue) return
-
-      let hoveredSeriesValue
-      let hoveredSeriesData = tooltipData.data.filter(d => d[0] === seriesKey)
-      let hoveredSeriesKey = hoveredSeriesData?.[0]?.[0]
-      let hoveredSeriesAxis = hoveredSeriesData?.[0]?.[2]
-      const dynamicSeriesConfig = config.runtime.series.find(s => s.dynamicCategory)
-      const originalDataKey = dynamicSeriesConfig?.originalDataKey ?? seriesKey
-
-      if (!hoveredSeriesKey) return
-      hoveredSeriesValue = tableData?.find(d => {
-        const dynamicCategory = dynamicSeriesConfig?.dynamicCategory
-        const matchingXValue = d[config.xAxis.dataKey] === hoveredXValue
-        if (!matchingXValue) return false
-        if (dynamicCategory) {
-          const match = d[dynamicCategory] === hoveredSeriesKey
-          return match
-        }
-        return true
-      })?.[originalDataKey]
-
-      //    hoveredSeriesValue = extractNumber(hoveredSeriesValue)
-      return tooltipData?.data.map((tooltipItem, index) => {
-        if (isNaN(hoveredSeriesValue)) return <></>
-        const isMatch = circleData?.some(cd => cd[config.xAxis.dataKey] === hoveredXValue)
-
-        if (
-          isMatch ||
-          !hoveredSeriesValue ||
-          (visual.maximumShapeAmount === seriesIndex && visual.lineDatapointSymbol === 'standard')
-        ) {
-          return <></>
-        }
-
-        const positionTop = hoveredSeriesAxis === 'right' ? yScaleRight(hoveredSeriesValue) : yScale(hoveredSeriesValue)
-        const positionLeft = getXPos(hoveredXValue)
-        return (
-          <g transform={transformShape(positionTop, positionLeft)}>
-            <Shape
-              size={55}
-              opacity={1}
-              fillOpacity={1}
-              fill={getColor(displayArea, colorScale, config, hoveredSeriesKey, seriesKey)}
-              style={{ filter: 'unset', opacity: 1 }}
-            />
-          </g>
-        )
-      })
+  // If we're not showing the circle, simply return
+  const getColor = (displayArea: boolean, colorScale: Function, config: ChartConfig, hoveredKey: string) => {
+    const seriesLabels = config.runtime.seriesLabels || []
+    const seriesLabelsAll = config.runtime.seriesLabelsAll || []
+    let color = displayArea ? colorScale(seriesLabels[hoveredKey] || seriesLabelsAll[seriesIndex]) : 'transparent'
+    if (config.lineDatapointColor === 'Lighter than Line' && color !== 'transparent' && color) {
+      color = chroma(color).brighten(1)
     }
+    return color
   }
+
+  if (['ALWAYS_SHOW_POINTS', 'HOVER_POINTS'].includes(mode)) {
+    if (!filtered || (visual.maximumShapeAmount === seriesIndex && visual.lineDatapointSymbol === 'standard'))
+      return <></>
+    return (
+      <g
+        transform={transformShape(pointData[config.xAxis.dataKey], pointData[filtered?.dataKey])}
+        className={`visx-glyph-group${displayArea ? '' : '-hidden'}`}
+        data-seriesIndex={seriesIndex}
+      >
+        <Shape
+          fillOpacity={mode === 'ALWAYS_SHOW_POINTS' ? 1 : 0}
+          fill={getColor(displayArea, colorScale, config, seriesKey)}
+        />
+      </g>
+    )
+  }
+
   if (mode === 'ISOLATED_POINTS') {
     const drawIsolatedPoints = (currentIndex, seriesKey) => {
       const currentPoint = data[currentIndex]
       const previousPoint = data[currentIndex - 1] || {}
       const nextPoint = data[currentIndex + 1] || {}
-
-      const isMatch = circleData.some(item => item?.data[seriesKey] === currentPoint[seriesKey])
-      if (isMatch) return false
-
       const isFirstPoint = currentIndex === 0 && !nextPoint[seriesKey]
       const isLastPoint = currentIndex === data.length - 1 && !previousPoint[seriesKey]
       const isMiddlePoint =
@@ -206,17 +136,37 @@ const LineChartCircle = (props: LineChartCircleProps) => {
       : dataIndex
 
     if (drawIsolatedPoints(_dataIndex, seriesKey)) {
-      const positionTop =
-        filtered?.axis === 'Right' ? yScaleRight(pointData[filtered?.dataKey]) : yScale(pointData[filtered?.dataKey])
-      const positionLeft = getXPos(pointData[config.xAxis?.dataKey])
       const color = colorScale(config.runtime.seriesLabelsAll[seriesIndex])
 
       return (
-        <g transform={transformShape(positionTop, positionLeft)}>
+        <g
+          transform={transformShape(pointData[config.xAxis?.dataKey], pointData[filtered?.dataKey])}
+          className={`visx-glyph-group${displayArea ? '' : '-hidden'}`}
+          data-seriesIndex={seriesIndex}
+        >
           <Shape size={dotSize} stroke={color} fill={color} />
         </g>
       )
     }
+  }
+
+  if (mode === 'TOOLTIP_POINTS' && displayArea === true) {
+    return (
+      <g
+        transform={transformShape(tooltipPoint.xValue, tooltipPoint.yValue)}
+        className='visx-glyph-circle'
+        onMouseOver={e => {
+          handleTooltipMouseOver(e)
+          if (lineDatapointStyle == 'hover') (e.target as HTMLElement).style.fillOpacity = '1'
+        }}
+        onMouseOut={e => {
+          handleTooltipMouseOff()
+          if (lineDatapointStyle == 'hover') (e.target as HTMLElement).style.fillOpacity = '0'
+        }}
+      >
+        <Shape size={55} fill={tooltipPoint.color} fillOpacity={'0'} />
+      </g>
+    )
   }
 
   return null

--- a/packages/chart/src/components/LineChart/index.tsx
+++ b/packages/chart/src/components/LineChart/index.tsx
@@ -14,7 +14,7 @@ import ConfigContext from '../../ConfigContext'
 import useRightAxis from '../../hooks/useRightAxis'
 
 // Local helpers and components
-import { filterCircles, createStyles, createDataSegments } from './helpers'
+import { createStyles, createDataSegments } from './helpers'
 import LineChartCircle from './components/LineChart.Circle'
 import LineChartBumpCircle from './components/LineChart.BumpCircle'
 import isNumber from '@cdc/core/helpers/isNumber'
@@ -28,7 +28,6 @@ const LineChart = (props: LineChartProps) => {
   const {
     getXAxisData,
     getYAxisData,
-    handleTooltipClick,
     handleTooltipMouseOff,
     handleTooltipMouseOver,
     tooltipData,
@@ -36,31 +35,29 @@ const LineChart = (props: LineChartProps) => {
     xScale,
     yMax,
     yScale,
-  } = props
+    } = props
 
   // prettier-ignore
   const { colorScale, config, formatNumber, handleLineType, parseDate, seriesHighlight, tableData, transformedData, updateConfig, brushConfig,clean  } = useContext<ChartContext>(ConfigContext)
   const { yScaleRight } = useRightAxis({ config, yMax, data: transformedData, updateConfig })
-  if (!handleTooltipMouseOver) return
+  const showSingleSeries = config.tooltips.singleSeries
 
   const DEBUG = false
   const { lineDatapointStyle, showLineSeriesLabels, legend } = config
-  let data = transformedData
-  let tableD = tableData
+  const isBrushOn = brushConfig.data.length > 0 && config.brush?.active
   // if brush on use brush data and clean
-  if (brushConfig.data.length > 0 && config.brush?.active) {
-    data = clean(brushConfig.data)
-    tableD = clean(brushConfig.data)
-  }
+  const data = isBrushOn ? clean(brushConfig.data) : transformedData
+  const _tableData = isBrushOn ? clean(brushConfig.data) : tableData
 
   const xPos = d => {
     return xScale(getXAxisData(d)) + (xScale.bandwidth ? xScale.bandwidth() / 2 : 0)
   }
 
+  const tooltipPoints = []
+
   return (
     <ErrorBoundary component='LineChart'>
-      <Group left={Number(config.runtime.yAxis.size)}>
-        {' '}
+      <Group left={Number(config.runtime.yAxis.size)} className='line-chart-group'>
         {/* left - expects a number not a string */}
         {(config.runtime.lineSeriesKeys || config.runtime.seriesKeys).map((seriesKey, index) => {
           const seriesData = config.runtime.series.find(item => item.dataKey === seriesKey)
@@ -82,7 +79,6 @@ const LineChart = (props: LineChartProps) => {
             ? data.filter(d => d[seriesData.dynamicCategory] === seriesKey)
             : data
           const _seriesKey = seriesData.dynamicCategory ? seriesData.originalDataKey : seriesKey
-          const circleData = filterCircles(config?.preliminaryData, tableD, _seriesKey)
           return (
             <Group
               key={`series-${seriesKey}-${index}`}
@@ -108,11 +104,15 @@ const LineChart = (props: LineChartProps) => {
                 height={Number(yMax)}
                 fill={DEBUG ? 'red' : 'transparent'}
                 fillOpacity={0.05}
-                onMouseMove={e => handleTooltipMouseOver(e, tableData)}
-                onMouseOut={handleTooltipMouseOff}
-                onClick={e => handleTooltipClick(e, data)}
               />
               {_data.map((d, dataIndex) => {
+                tooltipPoints.push({
+                  color: colorScale(config.runtime.seriesLabels[seriesKey]),
+                  seriesKey: _seriesKey,
+                  seriesIndex: index,
+                  xValue: d[config.xAxis.dataKey],
+                  yValue: d[_seriesKey]
+                })
                 return (
                   isNumber(d[_seriesKey]) && (
                     <React.Fragment key={`series-${seriesKey}-point-${dataIndex}`}>
@@ -136,7 +136,6 @@ const LineChart = (props: LineChartProps) => {
                         <LineChartCircle
                           mode='ALWAYS_SHOW_POINTS'
                           dataIndex={dataIndex}
-                          circleData={circleData}
                           tableData={tableData}
                           data={_data}
                           d={d}
@@ -155,18 +154,37 @@ const LineChart = (props: LineChartProps) => {
                         />
                       )}
 
+                      {(lineDatapointStyle === 'hover' || lineDatapointStyle === 'hidden') && (
+                        <LineChartCircle
+                          mode='HOVER_POINTS'
+                          dataIndex={dataIndex}
+                          tableData={tableData}
+                          data={_data}
+                          d={d}
+                          config={config}
+                          seriesKey={_seriesKey}
+                          displayArea={displayArea}
+                          xScale={xScale}
+                          yScale={yScale}
+                          colorScale={colorScale}
+                          parseDate={parseDate}
+                          yScaleRight={yScaleRight}
+                          seriesAxis={seriesAxis}
+                          seriesIndex={index}
+                          key={`line-hover-circle--${dataIndex}`}
+                        />
+                      )}
+
                       <LineChartCircle
                         mode='ISOLATED_POINTS'
                         seriesIndex={index}
                         dataIndex={dataIndex}
                         tableData={tableData}
-                        circleData={circleData}
                         data={_data}
                         d={d}
                         config={config}
                         seriesKey={_seriesKey}
                         displayArea={displayArea}
-                        tooltipData={tooltipData}
                         xScale={xScale}
                         yScale={yScale}
                         colorScale={colorScale}
@@ -179,28 +197,6 @@ const LineChart = (props: LineChartProps) => {
                   )
                 )
               })}
-              <>
-                {lineDatapointStyle === 'hover' && (
-                  <LineChartCircle
-                    seriesIndex={index}
-                    tableData={tableData}
-                    dataIndex={0}
-                    mode='HOVER_POINTS'
-                    circleData={circleData}
-                    data={_data}
-                    config={config}
-                    seriesKey={seriesKey}
-                    displayArea={displayArea}
-                    tooltipData={tooltipData}
-                    xScale={xScale}
-                    yScale={yScale}
-                    colorScale={colorScale}
-                    parseDate={parseDate}
-                    yScaleRight={yScaleRight}
-                    seriesAxis={seriesAxis}
-                  />
-                )}
-              </>
 
               {/* SPLIT LINE */}
               {isSplitLine ? (
@@ -217,7 +213,7 @@ const LineChart = (props: LineChartProps) => {
                     }
                     styles={createStyles({
                       preliminaryData: config.preliminaryData,
-                      data: tableD,
+                      data: _tableData,
                       stroke: colorScale(config.runtime.seriesLabels[seriesKey]),
                       strokeWidth: seriesData.weight || 2,
                       handleLineType,
@@ -269,6 +265,7 @@ const LineChart = (props: LineChartProps) => {
                           return (
                             <AreaClosed
                               key={`area-closed-${seriesKey}-${categoryIndex}`}
+                              className='confidence-interval'
                               data={categoryData}
                               x={d => xPos(d)}
                               y0={d => yScale(d[config.confidenceKeys.lower])} // Lower bound of the confidence interval
@@ -335,31 +332,6 @@ const LineChart = (props: LineChartProps) => {
                   />
                 </>
               )}
-
-              {/* circles for preliminaryData data */}
-              {circleData.map((item, i) => {
-                return (
-                  <circle
-                    key={i}
-                    cx={xPos(item.data)}
-                    cy={
-                      seriesAxis === 'Right'
-                        ? yScaleRight(getYAxisData(item.data, _seriesKey))
-                        : yScale(Number(getYAxisData(item.data, _seriesKey)))
-                    }
-                    r={item.size}
-                    strokeWidth={seriesData.weight || 2}
-                    stroke={colorScale ? colorScale(config.runtime.seriesLabels[seriesKey]) : '#000'}
-                    fill={
-                      item.isFilled
-                        ? colorScale
-                          ? colorScale(config.runtime.seriesLabels[seriesKey])
-                          : '#000'
-                        : '#fff'
-                    }
-                  />
-                )
-              })}
 
               {/* ANIMATED LINE */}
               {config.animate && (
@@ -431,6 +403,52 @@ const LineChart = (props: LineChartProps) => {
             {config.legend.dynamicLegendChartMessage}
           </Text>
         )}
+      </Group>
+      <Group left={Number(config.runtime.yAxis.size)} className='glyph-tooltip-group'>
+        <Group key={`tooltip-group`} display={'block'}>
+          {/* tooltips */}
+          <Bar
+            key={'tooltip bars'}
+            width={Number(xMax)}
+            height={Number(yMax)}
+            fill={DEBUG ? 'red' : 'transparent'}
+            fillOpacity={0.05}
+            onMouseMove={e => {
+              if (showSingleSeries) return
+              handleTooltipMouseOver(e, tableData)
+            }}
+            onMouseOut={handleTooltipMouseOff}
+          />
+          {tooltipPoints.map((d, dataIndex) => {
+            const { _data, seriesKey, seriesIndex, color } = d
+            return (
+              <React.Fragment key={`series-${seriesKey}-point-${dataIndex}`}>
+                <LineChartCircle
+                  mode='TOOLTIP_POINTS'
+                  dataIndex={dataIndex}
+                  tooltipPoint={d}
+                  tableData={tableData}
+                  data={_data}
+                  d={d}
+                  config={config}
+                  seriesKey={seriesKey}
+                  displayArea={true}
+                  tooltipData={tooltipData}
+                  xScale={xScale}
+                  yScale={yScale}
+                  colorScale={colorScale}
+                  parseDate={parseDate}
+                  yScaleRight={yScaleRight}
+                  seriesAxis={'[circle]'}
+                  seriesIndex={seriesIndex}
+                  key={`line-circle--${dataIndex}`}
+                  handleTooltipMouseOver={handleTooltipMouseOver}
+                  handleTooltipMouseOff={handleTooltipMouseOff}
+                />
+              </React.Fragment>
+            )
+          })}
+        </Group>
       </Group>
       {config.visualizationType === 'Bump Chart' && (
         <LineChartBumpCircle config={config} xScale={xScale} yScale={yScale} />

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -5,7 +5,6 @@ import { AxisLeft, AxisBottom, AxisRight, AxisTop } from '@visx/axis'
 import { Group } from '@visx/group'
 import { Line, Bar } from '@visx/shape'
 import { Text } from '@visx/text'
-import { Tooltip as ReactTooltip } from 'react-tooltip'
 import { useTooltip, TooltipWithBounds } from '@visx/tooltip'
 import _ from 'lodash'
 
@@ -755,9 +754,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               chartRef={svgRef}
             />
           )}
-          {((visualizationType === 'Line' && !convertLineToBarGraph) ||
-            visualizationType === 'Combo' ||
-            visualizationType === 'Bump Chart') && (
+          {(visualizationType === 'Combo' || visualizationType === 'Bump Chart') && (
             <LineChart
               xScale={xScale}
               yScale={yScale}
@@ -771,7 +768,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               handleTooltipClick={handleTooltipClick}
               tooltipData={tooltipData}
               showTooltip={showTooltip}
-              //chartRef={svgRef}
             />
           )}
           {(visualizationType === 'Forecasting' || visualizationType === 'Combo') && (
@@ -828,6 +824,9 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                   xMax={xMax}
                   yMax={yMax}
                   seriesStyle={config.runtime.series}
+                  tooltipData={tooltipData}
+                  handleTooltipMouseOver={handleTooltipMouseOver}
+                  handleTooltipMouseOff={handleTooltipMouseOff}
                 />
               </>
             )}


### PR DESCRIPTION
## NEW-50393
Hovering over data points show tooltip for specific data point

## Testing Steps
Scenario: Upload [NEW-50393-config.json](https://github.com/user-attachments/files/19980751/NEW-50393-config.json), open the configuration tab, and then click the tools icon on the Line Visualization.
Expected: A Line Chart with multiple lines and isolated points

1. Hover over any point
Expected: The tooltip shows with the correct information for all data on the x-Axis.

2. Open the Visual accordion on the left 
3. Test that hovering displays tooltip for all options of the following:
  a. Line Datapoint Symbols
  b. Line Datapoint Style
  c. Line Datapoint Color
Expected: The tooltip shows with the correct information for all data on the x-Axis

4. In the Visual accordion, scroll down to the Show Hover for single data series
5. Click the checkbox 
6. Repeat the tests in step 3
Expected: The tooltip shows with the correct information for just that one data point.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
