### PR TITLE
FIX: [DEV-10586a] Update prepareData and useEffect

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -390,11 +390,11 @@ const CdcChart: React.FC<CdcChartProps> = ({
         if (newData) {
           newConfig.data = newData
         }
-      } else if (newConfig.formattedData) {
-        newConfig.data = newConfig.formattedData
       } else if (newConfig.dataDescription) {
         newConfig.data = transform.autoStandardize(newConfig.data)
         newConfig.data = transform.developerStandardize(newConfig.data, newConfig.dataDescription)
+      } else if (newConfig.formattedData) {
+        newConfig.data = newConfig.formattedData
       }
     } catch (err) {
       console.log('Error on prepareData function ', err)
@@ -407,7 +407,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
       try {
         if (configObj) {
           const preparedConfig = await prepareConfig(configObj)
-          let preppedData = await prepareData(preparedConfig)
+          const preppedData = await prepareData(preparedConfig)
           dispatch({ type: 'SET_STATE_DATA', payload: preppedData.data })
           dispatch({ type: 'SET_EXCLUDED_DATA', payload: preppedData.data })
           updateConfig(preparedConfig, preppedData.data)
@@ -418,7 +418,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
     }
 
     load()
-  }, [configObj?.data?.length ? configObj.data : null])
+  }, [configObj])
 
   /**
    * When cove has a config and container ref publish the cove_loaded event.


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
Added file to test it on Dashboards.
Whole logic behind this fix is : when we are on Dashboards and add data description the CdcChart component was not adding transform.developerStandardize(newData, newConfig.dataDescription) and also dashboard also was not adding transform.developerStandardize(newData, newConfig.dataDescription) on first render. This fixes issue but may or may not create issue for other charts as dependency was changes on useEffect. i did test multiple files and seems working.
[dev-10586-rebuild.json](https://github.com/user-attachments/files/19985906/dev-10586-rebuild.json)

<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
