### PR TITLE
Fix [NEW 50417] select is grey on mobile

### DIFF
--- a/packages/core/components/Filters/components/Dropdown.tsx
+++ b/packages/core/components/Filters/components/Dropdown.tsx
@@ -17,7 +17,7 @@ const Dropdown: React.FC<DropdownProps> = ({ index: outerIndex, label, filter, c
       id={`filter-${outerIndex}`}
       name={label}
       aria-label={`Filter by ${label}`}
-      className={`cove-form-select ${DROPDOWN_STYLES}`}
+      className={`cove-form-select ${DROPDOWN_STYLES} bg-white`}
       data-index='0'
       value={queuedActive || active}
       onChange={e => {


### PR DESCRIPTION
## Summary
Select is grey on mobile

## Testing Steps
1. Open dropdown filter on mobile
2. Confirm background is white
