### PR TITLE
FIX : [DEV-50354] - Fix table cell overlap issue

### DIFF
--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -356,7 +356,8 @@ const DataTable = (props: DataTableProps) => {
                 }`,
                 'aria-live': 'assertive',
                 'aria-rowcount': config?.data?.length ? config.data.length : -1,
-                hidden: !expanded
+                hidden: !expanded,
+                cellMinWidth: 100
               }}
               rightAlignedCols={rightAlignedCols}
             />

--- a/packages/core/components/Table/components/Row.tsx
+++ b/packages/core/components/Table/components/Row.tsx
@@ -43,7 +43,7 @@ const Row: FC<RowProps> = props => {
           <Cell
             ariaLabel={style?.color ? 'suppressed data' : ''}
             key={rowKey + '__' + i}
-            style={{ whiteSpace, minWidth, textAlign, ...style }}
+            style={{ whiteSpace, minWidth, textAlign, textOverflow: 'ellipsis', ...style }}
             isBold={isTotal}
           >
             {child}


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
This issue is happening on production, so for local we cannot test it. here is the link for prod :https://wwwdev.cdc.gov/nwss/rv/COVID19-currentlevels.html
Issue is overlap for table cells as shown in the image : 
![image (2)](https://github.com/user-attachments/assets/bcae0bf7-52f5-49f5-beae-274fb9468a8b)

<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
