### PR TITLE
Feat [new-50418] dashboard data override

### DIFF
--- a/packages/dashboard/Override_Data.md
+++ b/packages/dashboard/Override_Data.md
@@ -1,0 +1,39 @@
+# Manually Overriding Dashboard Data
+
+It is possible to override any data which has been uploaded as a file.
+
+## Configure Visualization with Placeholder Data
+
+1. Upload either a .csv or .json dataset in the Import Data tab under the Upload File section. Record the Data Source Name as it will be used later.
+
+2. Map the data to a visualization. This will act as placeholder data allowing you to configure the visualization.
+
+3. Complete the COVE configuration and save.
+
+## Use CustomEvent to Override Data
+
+1. In an area on the page where you can input custom javascript code you will be able to dispatch a [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) to reset the data in your visualization.
+
+2. You'll need to structure your data as an array of flat objects. Each object being a row of data. Each row should have the same columns as what was provided in the placeholder Data.
+
+3. Create an Object which will be the dataset Override for the placeholder data. Each Data Override will have a key which matches the placeholder data's Data Source Name, i.e. `sample_data.csv`, and a value equal to the new data greated.
+
+```
+   const dataOverride = {
+        "sample_data.csv": [{state: 'Alabama', rate: 123}, {state: 'Alaska', rate: 135}]
+   }
+```
+
+4. Now create a CustomEvent with the event type set to `cove_set_data` and the options detail set to the `dataOverride`
+
+```
+    const customEvent = new CustomEvent('cove_set_data', {detail: dataOverride})
+```
+
+5. dispatch the event to the document.
+
+```
+document.dispatchEvent(customEvent)
+```
+
+You should see the data update immediately. Note: you can add as many datasets as you want in the dataOverride and they will all be updated in the same event.

--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -66,6 +66,7 @@ import { loadAPIFiltersFactory } from './helpers/loadAPIFilters'
 import Loader from '@cdc/core/components/Loader'
 import Alert from '@cdc/core/components/Alert'
 import { shouldLoadAllFilters } from './helpers/shouldLoadAllFilters'
+import { subscribe, unsubscribe } from '@cdc/core/helpers/events'
 
 type DashboardProps = Omit<WCMSProps, 'configUrl'> & {
   initialState: InitialState
@@ -273,6 +274,29 @@ export default function CdcDashboard({ initialState, isEditor = false, isDebug =
     dispatch({ type: 'SET_CONFIG', payload: newConfig })
     dispatch({ type: 'SET_SHARED_FILTERS', payload: newConfig.dashboard.sharedFilters })
   }
+
+  const setEventData = ({ detail }) => {
+    try {
+      const newDatasets = Object.keys(detail).reduce((acc, key) => {
+        if (state.data[key] !== undefined) {
+          acc[key] = detail[key]
+        }
+        return acc
+      }, {})
+      const filteredData = { ...state.filteredData, ...newDatasets }
+      dispatch({ type: 'SET_FILTERED_DATA', payload: filteredData })
+      dispatch({ type: 'SET_DATA', payload: { ...state.data, ...newDatasets } })
+    } catch (e) {
+      console.error('Error setting event data: ', e)
+    }
+  }
+
+  useEffect(() => {
+    subscribe('cove_set_data', setEventData)
+    return () => {
+      unsubscribe('cove_set_data', setEventData)
+    }
+  }, [])
 
   useEffect(() => {
     const { config } = state


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->
This feature basically allows and external application to hijack a dataset on the config and reset the data. below you'll see {'local_test.csv': newData} this looks for the dataset with the key of local_test.csv and resets its data in dashboard.
## Testing Steps
<!-- Provide testing steps -->
Scenario: load the standalone dashboard package with
[local_test.json](https://github.com/user-attachments/files/20093506/local_test.json)

in browser console paste the following:

const newData = [{category: 'a', data: 1}]
const customEvent = new CustomEvent('cove_set_data', {detail: {'local_test.csv': newData}})
document.dispatchEvent(customEvent)
Expected: The table should reduce to just one row of data.
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
