### PR TITLE
Fix [DEV-10399] Add more characters to data table alignment

### DIFF
--- a/packages/core/helpers/isRightAlignedTableValue.js
+++ b/packages/core/helpers/isRightAlignedTableValue.js
@@ -12,7 +12,7 @@ export default function isRightAlignedTableValue(value = '') {
     if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(value)) {
       return false
     }
-    return numericStrings.includes(value) || /^[\$\d\.\%\,\-\s\(\)CI]*$/.test(value)
+    return numericStrings.includes(value) || /^[\$\d\.\%\,\-\s\(\)CI<>]*$/.test(value)
   }
   return false
 }


### PR DESCRIPTION
## Summary

Adds `<` and `>` to regex for determining data table column alignment.

## Testing Steps

Create a data table with `<` in a column, ensure that it's right-aligned.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
