### PR TITLE
[DEV-8148] fix: equal number opt in button

### DIFF
--- a/packages/map/src/_stories/CdcMap.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.stories.tsx
@@ -14,6 +14,7 @@ type Story = StoryObj<typeof CdcMap>
 
 export const Equal_Interval_Map: Story = {
   args: {
+    isEditor: true,
     configUrl: 'https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/page-elements/equal-interval-map.json'
   }
 }
@@ -26,6 +27,7 @@ export const Equal_Number_Opt_In: Story = {
 
 export const Equal_Number_Map: Story = {
   args: {
+    isEditor: true,
     configUrl: 'https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/page-elements/equal-number-map.json'
   }
 }

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -344,37 +344,6 @@ const EditorPanel = () => {
           }
         })
         break
-      case 'legendType':
-        let testForType = Number(typeof config.data[0][config.columns.primary.name])
-        let hasValue = config.data[0][config.columns.primary.name]
-        let messages = []
-
-        if (!hasValue) {
-          messages.push(
-            `There appears to be values missing for data in the primary column ${config.columns.primary.name}`
-          )
-        }
-
-        if (testForType === 'string' && isNaN(testForType) && value !== 'category') {
-          messages.push(
-            'Error with legend. Primary columns that are text must use a categorical legend type. Try changing the legend type to DEV-12345categorical.'
-          )
-        } else {
-          messages = []
-        }
-
-        setConfig({
-          ...config,
-          legend: {
-            ...config.legend,
-            type: value
-          },
-          runtime: {
-            ...config.runtime,
-            editorErrorMessage: messages
-          }
-        })
-        break
       case 'legendNumber':
         setConfig({
           ...config,
@@ -2082,7 +2051,29 @@ const EditorPanel = () => {
                       { value: 'equalinterval', label: 'Equal Interval' }
                     ]}
                     onChange={event => {
-                      handleEditorChanges('legendType', event.target.value)
+                      let testForType = Number(typeof config.data[0][config.columns.primary.name])
+                      let hasValue = config.data[0][config.columns.primary.name]
+                      let messages = []
+
+                      if (!hasValue) {
+                        messages.push(
+                          `There appears to be values missing for data in the primary column ${config.columns.primary.name}`
+                        )
+                      }
+
+                      if (testForType === 'string' && isNaN(testForType) && value !== 'category') {
+                        messages.push(
+                          'Error with legend. Primary columns that are text must use a categorical legend type. Try changing the legend type to DEV-12345categorical.'
+                        )
+                      } else {
+                        messages = []
+                      }
+
+                      const _newConfig = _.cloneDeep(config)
+                      _newConfig.general.equalNumberOptIn = true
+                      _newConfig.legend.type = event.target.value
+                      _newConfig.runtime.editorErrorMessage = messages
+                      setConfig(_newConfig)
                     }}
                   />
                 )}
@@ -2306,32 +2297,7 @@ const EditorPanel = () => {
                     </span>
                   </label>
                 )}
-                {/* Temp Checkbox */}
-                {config.legend.type === 'equalnumber' && (
-                  <label className='checkbox'>
-                    <input
-                      type='checkbox'
-                      checked={config.general.equalNumberOptIn}
-                      onChange={event => {
-                        const _newConfig = _.clone(config)
-                        _newConfig.general.equalNumberOptIn = event.target.checked
-                        setConfig(_newConfig)
-                      }}
-                    />
-                    <span className='edit-label column-heading'>Use new quantile legend</span>
-                    <Tooltip style={{ textTransform: 'none' }}>
-                      <Tooltip.Target>
-                        <Icon
-                          display='question'
-                          style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
-                        />
-                      </Tooltip.Target>
-                      <Tooltip.Content>
-                        <p>This prevents numbers from being used in more than one category (ie. 0-1, 1-2, 2-3) </p>
-                      </Tooltip.Content>
-                    </Tooltip>
-                  </label>
-                )}
+
                 {'category' !== legend.type && (
                   <Select
                     label={


### PR DESCRIPTION
## Summary
When legends are set to equal number the numbers shouldn't repeat, ie [10-11, 11-12, 12-13]. Instead they should start at the next number [10-11, 12-13, 14-15]

## Testing Steps
- Open story: http://localhost:6006/?path=/story/components-templates-map--equal-number-map
- The legend items should repeat [12-40, 40-55]
- Under legend type > change the legend to equal interval, then back to quantile. They shouldn't repeat now.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
