### PR TITLE
feature: legend block spaces

### DIFF
--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -94,6 +94,7 @@ export type Legend = CoreLegend & {
     topBottom: boolean
   }
   groupBy: string
+  spaces?: string
 }
 
 type Visual = {

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -94,7 +94,7 @@ export type Legend = CoreLegend & {
     topBottom: boolean
   }
   groupBy: string
-  spaces?: string
+  separators?: string
 }
 
 type Visual = {

--- a/packages/core/components/Legend/Legend.Gradient.tsx
+++ b/packages/core/components/Legend/Legend.Gradient.tsx
@@ -4,15 +4,12 @@ import { type MapConfig } from '@cdc/map/src/types/MapConfig'
 import { type ChartConfig } from '@cdc/chart/src/types/ChartConfig'
 import { getTextWidth } from '../../helpers/getTextWidth'
 import { DimensionsType } from '../../types/Dimensions'
-import { clamp } from 'lodash'
+import useLegendSeparators from '@cdc/map/src/hooks/useLegendSeparators'
 
 const MARGIN = 1
 const BORDER_SIZE = 1
 const BORDER_COLOR = '#d3d3d3'
 const MOBILE_BREAKPOINT = 576
-const LEGEND_SEPARATOR_SIZE = 0.02
-const LEGEND_SEPARATOR_SIZE_MAX = 20
-const LEGEND_SEPARATOR_SIZE_MIN = 8
 
 type CombinedConfig = MapConfig | ChartConfig
 
@@ -42,13 +39,8 @@ const LegendGradient = ({
   const uniqueID = `${uid}-${Date.now()}`
 
   // Legend separators logic
-  const legendSeparators = isLinearBlocks
-    ? separators?.replace(' ', '').split(',').map(Number).filter(Boolean) || []
-    : []
-  const separatorSize = clamp(legendWidth * LEGEND_SEPARATOR_SIZE, LEGEND_SEPARATOR_SIZE_MIN, LEGEND_SEPARATOR_SIZE_MAX)
-  const legendSeparatorsToSubtract = legendSeparators.length * separatorSize
-  const getTickSeparatorsAdjustment = (index: number) =>
-    legendSeparators.reduce((acc, separators) => (index >= separators ? acc + separatorSize : acc), 0)
+  const { legendSeparators, separatorSize, legendSeparatorsToSubtract, getTickSeparatorsAdjustment } =
+    useLegendSeparators(separators, legendWidth, isLinearBlocks)
 
   const numTicks = colors?.length
 

--- a/packages/core/components/Legend/Legend.Gradient.tsx
+++ b/packages/core/components/Legend/Legend.Gradient.tsx
@@ -10,9 +10,9 @@ const MARGIN = 1
 const BORDER_SIZE = 1
 const BORDER_COLOR = '#d3d3d3'
 const MOBILE_BREAKPOINT = 576
-const LEGEND_SPACE_SIZE = 0.02
-const LEGEND_SPACE_SIZE_MAX = 20
-const LEGEND_SPACE_SIZE_MIN = 8
+const LEGEND_SEPARATOR_SIZE = 0.02
+const LEGEND_SEPARATOR_SIZE_MAX = 20
+const LEGEND_SEPARATOR_SIZE_MIN = 8
 
 type CombinedConfig = MapConfig | ChartConfig
 
@@ -32,7 +32,7 @@ const LegendGradient = ({
   parentPaddingToSubtract = 0
 }: GradientProps): JSX.Element => {
   const { uid, legend, type } = config
-  const { tickRotation, position, style, subStyle, spaces } = legend
+  const { tickRotation, position, style, subStyle, separators } = legend
 
   const isLinearBlocks = subStyle === 'linear blocks'
   let [width] = dimensions
@@ -41,12 +41,14 @@ const LegendGradient = ({
   const legendWidth = Number(width) - parentPaddingToSubtract - MARGIN * 2 - BORDER_SIZE * 2
   const uniqueID = `${uid}-${Date.now()}`
 
-  // Legend spacer logic
-  const legendSpaces = isLinearBlocks ? spaces?.replace(' ', '').split(',').map(Number).filter(Boolean) || [] : []
-  const spaceSize = clamp(legendWidth * LEGEND_SPACE_SIZE, LEGEND_SPACE_SIZE_MIN, LEGEND_SPACE_SIZE_MAX)
-  const legendSpacesToSubtract = legendSpaces.length * spaceSize
-  const getTickSpaceAdjustment = (index: number) =>
-    legendSpaces.reduce((acc, space) => (index >= space ? acc + spaceSize : acc), 0)
+  // Legend separators logic
+  const legendSeparators = isLinearBlocks
+    ? separators?.replace(' ', '').split(',').map(Number).filter(Boolean) || []
+    : []
+  const separatorSize = clamp(legendWidth * LEGEND_SEPARATOR_SIZE, LEGEND_SEPARATOR_SIZE_MIN, LEGEND_SEPARATOR_SIZE_MAX)
+  const legendSeparatorsToSubtract = legendSeparators.length * separatorSize
+  const getTickSeparatorsAdjustment = (index: number) =>
+    legendSeparators.reduce((acc, separators) => (index >= separators ? acc + separatorSize : acc), 0)
 
   const numTicks = colors?.length
 
@@ -69,8 +71,8 @@ const LegendGradient = ({
 
   // render ticks and labels
   const ticks = labels.map((key, index) => {
-    const segmentWidth = (legendWidth - legendSpacesToSubtract) / numTicks
-    const xPositionX = index * segmentWidth + segmentWidth + MARGIN + getTickSpaceAdjustment(index)
+    const segmentWidth = (legendWidth - legendSeparatorsToSubtract) / numTicks
+    const xPositionX = index * segmentWidth + segmentWidth + MARGIN + getTickSeparatorsAdjustment(index)
     const textAnchor = rotationAngle ? 'end' : 'middle'
     const verticalAnchor = rotationAngle ? 'middle' : 'start'
     const lastTick = index === labels.length - 1
@@ -125,8 +127,8 @@ const LegendGradient = ({
         {subStyle === 'linear blocks' && (
           <>
             {colors.map((color, index) => {
-              const segmentWidth = (legendWidth - legendSpacesToSubtract) / numTicks
-              const xPosition = index * segmentWidth + MARGIN + getTickSpaceAdjustment(index)
+              const segmentWidth = (legendWidth - legendSeparatorsToSubtract) / numTicks
+              const xPosition = index * segmentWidth + MARGIN + getTickSeparatorsAdjustment(index)
               return (
                 <Group>
                   <rect
@@ -142,18 +144,18 @@ const LegendGradient = ({
                 </Group>
               )
             })}
-            {/* Legend space */}
-            {legendSpaces.map((spaceAfter, index) => {
-              const segmentWidth = (legendWidth - legendSpacesToSubtract) / numTicks
-              const xPosition = spaceAfter * segmentWidth + MARGIN + getTickSpaceAdjustment(spaceAfter - 1)
+            {/* Legend separators */}
+            {legendSeparators.map((separatorAfter, index) => {
+              const segmentWidth = (legendWidth - legendSeparatorsToSubtract) / numTicks
+              const xPosition = separatorAfter * segmentWidth + MARGIN + getTickSeparatorsAdjustment(separatorAfter - 1)
               return (
                 <Group>
-                  {/* Space block */}
+                  {/* Separators block */}
                   <rect
                     key={index}
                     x={xPosition}
                     y={MARGIN / 2}
-                    width={spaceSize}
+                    width={separatorSize}
                     height={boxHeight + MARGIN}
                     fill={'white'}
                     stroke={'white'}
@@ -163,8 +165,8 @@ const LegendGradient = ({
                   {/* Dotted dividing line */}
                   <line
                     key={index}
-                    x1={xPosition + spaceSize / 2}
-                    x2={xPosition + spaceSize / 2}
+                    x1={xPosition + separatorSize / 2}
+                    x2={xPosition + separatorSize / 2}
                     y1={-3}
                     y2={boxHeight + MARGIN + 3}
                     stroke={'var(--colors-gray-cool-40'}

--- a/packages/core/components/Legend/Legend.Gradient.tsx
+++ b/packages/core/components/Legend/Legend.Gradient.tsx
@@ -4,10 +4,15 @@ import { type MapConfig } from '@cdc/map/src/types/MapConfig'
 import { type ChartConfig } from '@cdc/chart/src/types/ChartConfig'
 import { getTextWidth } from '../../helpers/getTextWidth'
 import { DimensionsType } from '../../types/Dimensions'
+import { clamp } from 'lodash'
 
 const MARGIN = 1
 const BORDER_SIZE = 1
+const BORDER_COLOR = '#d3d3d3'
 const MOBILE_BREAKPOINT = 576
+const LEGEND_SPACE_SIZE = 0.02
+const LEGEND_SPACE_SIZE_MAX = 20
+const LEGEND_SPACE_SIZE_MIN = 8
 
 type CombinedConfig = MapConfig | ChartConfig
 
@@ -27,7 +32,7 @@ const LegendGradient = ({
   parentPaddingToSubtract = 0
 }: GradientProps): JSX.Element => {
   const { uid, legend, type } = config
-  const { tickRotation, position, style, subStyle, hideBorder } = legend
+  const { tickRotation, position, style, subStyle, spaces } = legend
 
   const isLinearBlocks = subStyle === 'linear blocks'
   let [width] = dimensions
@@ -35,6 +40,13 @@ const LegendGradient = ({
   const smallScreen = width <= MOBILE_BREAKPOINT
   const legendWidth = Number(width) - parentPaddingToSubtract - MARGIN * 2 - BORDER_SIZE * 2
   const uniqueID = `${uid}-${Date.now()}`
+
+  // Legend spacer logic
+  const legendSpaces = isLinearBlocks ? spaces?.replace(' ', '').split(',').map(Number).filter(Boolean) || [] : []
+  const spaceSize = clamp(legendWidth * LEGEND_SPACE_SIZE, LEGEND_SPACE_SIZE_MIN, LEGEND_SPACE_SIZE_MAX)
+  const legendSpacesToSubtract = legendSpaces.length * spaceSize
+  const getTickSpaceAdjustment = (index: number) =>
+    legendSpaces.reduce((acc, space) => (index >= space ? acc + spaceSize : acc), 0)
 
   const numTicks = colors?.length
 
@@ -57,8 +69,8 @@ const LegendGradient = ({
 
   // render ticks and labels
   const ticks = labels.map((key, index) => {
-    const segmentWidth = legendWidth / numTicks
-    const xPositionX = index * segmentWidth + segmentWidth + MARGIN
+    const segmentWidth = (legendWidth - legendSpacesToSubtract) / numTicks
+    const xPositionX = index * segmentWidth + segmentWidth + MARGIN + getTickSpaceAdjustment(index)
     const textAnchor = rotationAngle ? 'end' : 'middle'
     const verticalAnchor = rotationAngle ? 'middle' : 'start'
     const lastTick = index === labels.length - 1
@@ -94,7 +106,7 @@ const LegendGradient = ({
     return (
       <svg className={'w-100 overflow-visible'} height={newHeight}>
         {/* background border*/}
-        <rect x={0} y={0} width={legendWidth + MARGIN * 2} height={boxHeight + MARGIN * 2} fill='#d3d3d3' />
+        <rect x={0} y={0} width={legendWidth + MARGIN * 2} height={boxHeight + MARGIN * 2} fill={BORDER_COLOR} />
         {/* Define the gradient */}
         <linearGradient id={`gradient-smooth-${uniqueID}`} x1='0%' y1='0%' x2='100%' y2='0%'>
           {stops}
@@ -110,25 +122,62 @@ const LegendGradient = ({
           />
         )}
 
-        {subStyle === 'linear blocks' &&
-          colors.map((color, index) => {
-            const segmentWidth = legendWidth / numTicks
-            const xPosition = index * segmentWidth + MARGIN
-            return (
-              <Group>
-                <rect
-                  key={index}
-                  x={xPosition}
-                  y={MARGIN}
-                  width={segmentWidth}
-                  height={boxHeight}
-                  fill={color}
-                  stroke='white'
-                  strokeWidth='0'
-                />
-              </Group>
-            )
-          })}
+        {subStyle === 'linear blocks' && (
+          <>
+            {colors.map((color, index) => {
+              const segmentWidth = (legendWidth - legendSpacesToSubtract) / numTicks
+              const xPosition = index * segmentWidth + MARGIN + getTickSpaceAdjustment(index)
+              return (
+                <Group>
+                  <rect
+                    key={index}
+                    x={xPosition}
+                    y={MARGIN}
+                    width={segmentWidth}
+                    height={boxHeight}
+                    fill={color}
+                    stroke='white'
+                    strokeWidth='0'
+                  />
+                </Group>
+              )
+            })}
+            {/* Legend space */}
+            {legendSpaces.map((spaceAfter, index) => {
+              const segmentWidth = (legendWidth - legendSpacesToSubtract) / numTicks
+              const xPosition = spaceAfter * segmentWidth + MARGIN + getTickSpaceAdjustment(spaceAfter - 1)
+              return (
+                <Group>
+                  {/* Space block */}
+                  <rect
+                    key={index}
+                    x={xPosition}
+                    y={MARGIN / 2}
+                    width={spaceSize}
+                    height={boxHeight + MARGIN}
+                    fill={'white'}
+                    stroke={'white'}
+                    strokeWidth={MARGIN}
+                  />
+
+                  {/* Dotted dividing line */}
+                  <line
+                    key={index}
+                    x1={xPosition + spaceSize / 2}
+                    x2={xPosition + spaceSize / 2}
+                    y1={-3}
+                    y2={boxHeight + MARGIN + 3}
+                    stroke={'var(--colors-gray-cool-40'}
+                    strokeWidth={1}
+                    strokeDasharray='5,3'
+                    strokeDashoffset={1}
+                  />
+                </Group>
+              )
+            })}
+          </>
+        )}
+
         {/* Ticks and labels */}
         <g>{ticks}</g>
       </svg>

--- a/packages/map/src/_stories/CdcMap.Legend.Gradient.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Legend.Gradient.stories.tsx
@@ -33,6 +33,16 @@ export const Gradient_With_Box: Story = {
   }
 }
 
+export const Gradient_With_Space: Story = {
+  args: {
+    config: editConfigKeys(UsGradient, [
+      { path: ['legend', 'subStyle'], value: 'linear blocks' },
+      { path: ['legend', 'spaces'], value: '2' },
+      { path: ['legend', 'hideBorder'], value: false }
+    ])
+  }
+}
+
 export const Gradient_With_Text: Story = {
   args: {
     config: editConfigKeys(UsGradient, [

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -116,6 +116,8 @@ const EditorPanel = () => {
     specialClasses = legend.specialClasses || []
   }
 
+  const allowLegendSpaces = legend.style === 'gradient' && legend.subStyle === 'linear blocks'
+
   const getCityStyleOptions = target => {
     switch (target) {
       case 'value': {
@@ -2167,6 +2169,26 @@ const EditorPanel = () => {
                       <option value='smooth'>smooth</option>
                     </select>
                   </label>
+                )}
+                {allowLegendSpaces && (
+                  <TextField
+                    value={legend.spaces}
+                    updateField={updateField}
+                    section='legend'
+                    fieldName='spaces'
+                    label='Legend Spaces'
+                    placeholder='ex: 1,4'
+                    tooltip={
+                      <Tooltip style={{ textTransform: 'none' }}>
+                        <Tooltip.Target>
+                          <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                        </Tooltip.Target>
+                        <Tooltip.Content>
+                          <p>Spaces between legend items represented by the legend item numbers separated by commas.</p>
+                        </Tooltip.Content>
+                      </Tooltip>
+                    }
+                  />
                 )}
                 {'navigation' !== config.general.type && config.legend.style === 'gradient' && (
                   <label>

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -116,7 +116,7 @@ const EditorPanel = () => {
     specialClasses = legend.specialClasses || []
   }
 
-  const allowLegendSpaces = legend.style === 'gradient' && legend.subStyle === 'linear blocks'
+  const allowLegendSeparators = legend.style === 'gradient' && legend.subStyle === 'linear blocks'
 
   const getCityStyleOptions = target => {
     switch (target) {
@@ -2170,13 +2170,13 @@ const EditorPanel = () => {
                     </select>
                   </label>
                 )}
-                {allowLegendSpaces && (
+                {allowLegendSeparators && (
                   <TextField
-                    value={legend.spaces}
+                    value={legend.separators}
                     updateField={updateField}
                     section='legend'
-                    fieldName='spaces'
-                    label='Legend Spaces'
+                    fieldName='separators'
+                    label='Legend Separators'
                     placeholder='ex: 1,4'
                     tooltip={
                       <Tooltip style={{ textTransform: 'none' }}>
@@ -2184,7 +2184,9 @@ const EditorPanel = () => {
                           <Icon display='question' style={{ marginLeft: '0.5rem' }} />
                         </Tooltip.Target>
                         <Tooltip.Content>
-                          <p>Spaces between legend items represented by the legend item numbers separated by commas.</p>
+                          <p>
+                            Separators between legend items represented by the legend item numbers separated by commas.
+                          </p>
                         </Tooltip.Content>
                       </Tooltip>
                     }

--- a/packages/map/src/hooks/useLegendSeparators.ts
+++ b/packages/map/src/hooks/useLegendSeparators.ts
@@ -1,0 +1,26 @@
+import { clamp } from 'lodash'
+
+// TODO: generalize this to be used in legends other than linear block gradient
+
+const LEGEND_SEPARATOR_SIZE = 0.02
+const LEGEND_SEPARATOR_SIZE_MAX = 20
+const LEGEND_SEPARATOR_SIZE_MIN = 8
+
+const useLegendSeparators = (separators, legendWidth, allowsLegendSeparators) => {
+  const legendSeparators = allowsLegendSeparators
+    ? separators?.replace(' ', '').split(',').map(Number).filter(Boolean) || []
+    : []
+  const separatorSize = clamp(legendWidth * LEGEND_SEPARATOR_SIZE, LEGEND_SEPARATOR_SIZE_MIN, LEGEND_SEPARATOR_SIZE_MAX)
+  const legendSeparatorsToSubtract = legendSeparators.length * separatorSize
+  const getTickSeparatorsAdjustment = (index: number) =>
+    legendSeparators.reduce((acc, separators) => (index >= separators ? acc + separatorSize : acc), 0)
+
+  return {
+    legendSeparators,
+    separatorSize,
+    legendSeparatorsToSubtract,
+    getTickSeparatorsAdjustment
+  }
+}
+
+export default useLegendSeparators

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -158,6 +158,7 @@ export type MapConfig = Visualization & {
     tickRotation: string
     hideBorder: false
     singleColumnLegend: false
+    spaces?: string
   }
   table: {
     label: string

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -158,7 +158,7 @@ export type MapConfig = Visualization & {
     tickRotation: string
     hideBorder: false
     singleColumnLegend: false
-    spaces?: string
+    separators?: string
   }
   table: {
     label: string


### PR DESCRIPTION
## Summary
Option to allow the adding of spaces between linear block gradient legend items 

## Testing Steps
1. Create of view map with gradient linear block legend in editor
2. Add comma separated number to "Legend Spaces" field 
3. Observe legend has spaces with dotted line after specified legend items

### Storybook Links
http://localhost:6006/?path=/story/components-templates-map-legend-gradient--gradient-with-space

### Screenshots
<img width="868" alt="Screenshot 2025-05-09 at 2 13 23 PM" src="https://github.com/user-attachments/assets/8e0a8d42-f567-4ae5-ad44-6921f6da2eda" />
