### PR TITLE
Fix/NEW-50438 Navigation Map Bugs/Improvements

### DIFF
--- a/packages/map/src/components/NavigationMenu.tsx
+++ b/packages/map/src/components/NavigationMenu.tsx
@@ -24,7 +24,7 @@ const NavigationMenu = ({ data, navigationHandler, options, columns, displayGeoN
       navGo = 'Ir'
       break
     default:
-      navSelect = 'Select an Item'
+      navSelect = 'Select a Location'
       navGo = 'Go'
   }
 
@@ -55,15 +55,17 @@ const NavigationMenu = ({ data, navigationHandler, options, columns, displayGeoN
       <form onSubmit={handleSubmit} type='get'>
         <label htmlFor={mapTabbingID.replace('#', '')}>
           <div className='select-heading'>{navSelect}</div>
-          <select value={activeGeo} id={mapTabbingID.replace('#', '')} onChange={e => setActiveGeo(e.target.value)}>
-            {Object.keys(dropdownItems).map(key => (
-              <option key={key} value={key}>
-                {key}
-              </option>
-            ))}
-          </select>
+          <div className='d-flex'>
+            <select value={activeGeo} id={mapTabbingID.replace('#', '')} onChange={e => setActiveGeo(e.target.value)}>
+              {Object.keys(dropdownItems).map(key => (
+                <option key={key} value={key}>
+                  {key}
+                </option>
+              ))}
+            </select>
+            <input type='submit' value={navGo} className={`${options.headerColor} btn`} id='cdcnavmap-dropdown-go' />
+          </div>
         </label>
-        <input type='submit' value={navGo} className={`${options.headerColor} btn`} id='cdcnavmap-dropdown-go' />
       </form>
     </section>
   )

--- a/packages/map/src/helpers/titleCase.ts
+++ b/packages/map/src/helpers/titleCase.ts
@@ -22,7 +22,7 @@ export const titleCase = string => {
       // just return with each word uppercase
       return string
         .split(' ')
-        .map(word => word.charAt(0).toUpperCase() + word.substring(1).toLowerCase())
+        .map(word => (word === 'of' ? word : word.charAt(0).toUpperCase() + word.substring(1).toLowerCase()))
         .join(' ')
     }
   }


### PR DESCRIPTION
## Summary
Four issues with the Navigation Map
1) Select an Item - Change this to "Select a Location"
2) District Of Columbia - The "o" in District Of Columbia should be lowercase (District of Columbia)
3) The "Go" button is misaligned with the dropdown
4) The .csv doesn't work and isn't necessary - remove

## Testing Steps
Scenario: Upload [new-50438-config.json](https://github.com/user-attachments/files/20208989/new-50438-config.json) and open Configuration
Expected: There is a map of the US. At the bottom there is a drop down labeled "Select a Location", the Go button is aligned with the dropdown and there is no link to the csv.

1. Click on the dropdown
Expected: a list of states and the District of Columbia, where the "of" in DC is lowercased.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
