### PR TITLE
Fix [new-50440] Chart Horizontal Label Offset

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -284,8 +284,8 @@ const CdcChart: React.FC<CdcChartProps> = ({
       (newConfig.visualizationType === 'Bar' && newConfig.orientation === 'horizontal') ||
       ['Deviation Bar', 'Paired Bar', 'Forest Plot'].includes(newConfig.visualizationType)
     ) {
-      newConfig.runtime.xAxis = newConfig.yAxis['yAxis'] ? newConfig.yAxis['yAxis'] : newConfig.yAxis
-      newConfig.runtime.yAxis = newConfig.xAxis['xAxis'] ? newConfig.xAxis['xAxis'] : newConfig.xAxis
+      newConfig.runtime.xAxis = _.cloneDeep(newConfig.yAxis.yAxis || newConfig.yAxis)
+      newConfig.runtime.yAxis = _.cloneDeep(newConfig.xAxis.xAxis || newConfig.xAxis)
       newConfig.runtime.yAxis.labelOffset *= -1
 
       newConfig.runtime.horizontal = false


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

horizontal bar charts were toggling negative when you changed the labelOffset

## Testing Steps
<!-- Provide testing steps -->

1) Start storybook.
2) navigate to Templates > Chart > Dynamic Series > Bar Horizontal
3) toggle edit mode.
4) add a label
5) change the label offset

Expected: the label offset should respond with the value you are incrementing it to.

<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
