### PR TITLE
fix [new-50422] inputs unexpected click behavior

### DIFF
--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -196,7 +196,7 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
         />
       )}
       {config?.visualizationType !== 'Sankey' && (
-        <label>
+        <label onClick={e => e.preventDefault()}>
           <span className='edit-label column-heading mt-1'>Exclude Columns </span>
           <MultiSelect
             key={excludedColumns.join('') + 'excluded'}

--- a/packages/core/components/EditorPanel/Inputs.tsx
+++ b/packages/core/components/EditorPanel/Inputs.tsx
@@ -118,9 +118,17 @@ const CheckBox = memo((props: CheckboxProps) => {
     return <></>
   }
   return (
-    <label className='checkbox column-heading'>
+    <label
+      className='checkbox column-heading'
+      onClick={e => {
+        if (!['SPAN', 'INPUT'].includes(e.target.nodeName)) {
+          e.preventDefault()
+        }
+      }}
+    >
       <input
         type='checkbox'
+        className='edit-checkbox'
         name={fieldName}
         checked={value}
         onChange={e => {

--- a/packages/core/components/MultiSelect/multiselect.styles.css
+++ b/packages/core/components/MultiSelect/multiselect.styles.css
@@ -5,6 +5,7 @@
   .wrapper {
     display: inline-flex;
     align-items: center;
+    width: 100%;
     .selected {
       &[aria-disabled='true'] {
         background: var(--lightestGray);
@@ -12,6 +13,7 @@
       border: 1px solid var(--lightGray);
       padding: 7px;
       min-width: 200px;
+      width: 100%;
       display: inline-block;
       :is(button) {
         border: none;

--- a/packages/editor/src/CdcEditor.tsx
+++ b/packages/editor/src/CdcEditor.tsx
@@ -43,6 +43,15 @@ const CdcEditor: React.FC<WCMSProps> = ({ config: configObj, hostname, container
   useEffect(() => {
     // for testing reducer using Redux Dev Tools
     devToolsStore && devToolsStore?.init()
+    document.addEventListener('click', e => {
+      // Prevents mistaken clicks on label from triggering checkbox
+      // Can be removed once all custom checkboxes are replaced with Checkbox component from @cdc/core/components/EditorPanel/Inputs.tsx
+      if (e.target.className === 'checkbox') {
+        if (!['SPAN', 'INPUT'].includes(e.target.nodeName)) {
+          e.preventDefault()
+        }
+      }
+    })
   }, [])
 
   const [state, dispatch] = useReducer(editorReducer, initialState)


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->
clicking to the right of multiselect and checkboxes is triggering a toggle of the element.

## Testing Steps
<!-- Provide testing steps -->
"Scenario 1: Create a Dashboard DataTable visualization and map some data to it. Navigate to the Editor panel. In the Editor Panel Open the DataTable accordion. 
1) Select some columns to exclude.
2) Click the blank area just to the right of the multiselect element. 
Expected: The focus leaves the multiselect. 
Actual: The last selected option in the multiselect is removed. 

Scenario 2: In the same accordion in the editor.
1) click the area to the right of the label.
Expected: The checkbox should not uncheck.

Work around: Click anywhere away from the input area."
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
