### PR TITLE
Fix/NEW-50448 Line Chart clickable legend unselect issue

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -514,7 +514,11 @@ const CdcChart: React.FC<CdcChartProps> = ({
 
   // Called on legend click, highlights/unhighlights the data series with the given label
   const highlight = (label: Label): void => {
-    if (seriesHighlight.length + 1 === config.runtime.seriesKeys.length && config.visualizationType !== 'Forecasting') {
+    if (
+      seriesHighlight.length + 1 === config.runtime.seriesKeys.length &&
+      config.visualizationType !== 'Forecasting' &&
+      !seriesHighlight.includes(label.datum)
+    ) {
       return handleShowAll()
     }
 


### PR DESCRIPTION
## Summary
We expect after we unselect a single legend item that was previously selected, it will show lines for the remaining selected legend items. Instead, it shows lines for all legend items. 

## Testing Steps
Scenario: Upload [new-50448-config.json](https://github.com/user-attachments/files/20302330/new-50448-config.json) and open the Dashboard Preview

Expected: 3 Dashboard filters are present

1. Choose the first option for all 3 filters
2. Press View Results
Expected: A Line Chart will appear with 3 options in the legend. 

3. In the Legend, click Overall and 50-64 years
Expected: The line chart only shows Overall and 50-64 years

4. In the Legend, click Overall again
Expected: The Overall Line in no longer showing and the option in the legend is grayed out. 

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
