### PR TITLE
fix: border colors on map visual panel

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
@@ -23,6 +23,7 @@ import { useEditorPanelContext } from '../../EditorPanelContext.js'
 import ConfigContext from '../../../../ConfigContext.js'
 import { PanelProps } from '../PanelProps'
 import { LineChartConfig } from '../../../../types/ChartConfig'
+import './panelVisual.styles.css'
 
 const PanelVisual: FC<PanelProps> = props => {
   const { config, updateConfig, colorPalettes, twoColorPalette } = useContext<ChartContext>(ConfigContext)

--- a/packages/chart/src/components/EditorPanel/components/Panels/panelVisual.styles.css
+++ b/packages/chart/src/components/EditorPanel/components/Panels/panelVisual.styles.css
@@ -1,0 +1,8 @@
+.type-chart .sidebar .color-palette button:not(.selected) {
+  border:  var(--cool-gray-30) 2px solid !important;
+
+}
+
+.type-chart .sidebar .color-palette button.selected {
+  border:  black 2px solid !important;
+}


### PR DESCRIPTION
## Summary
This pull request introduces a new stylesheet to enhance the visual styling of the `PanelVisual` component in the chart editor. The most notable changes include the addition of CSS rules for color palette buttons and the import of the new stylesheet into the `PanelVisual` component.

**Styling Enhancements:**
* [`packages/chart/src/components/EditorPanel/components/Panels/panelVisual.styles.css`](diffhunk://#diff-a15f7f939c24bf140b88dbe590f4fc0c5ba6447d0aca5909ea02b2ddff86bf02R1-R8): Added CSS rules to style color palette buttons in the sidebar, with distinct borders for selected and unselected states.

**Code Integration:**
* [`packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx`](diffhunk://#diff-cfcd80d3247de95ad2b2a2acc3fe79e9e0cd9f1b3af8bfdc884a9a26e82b09c8R26): Imported the new `panelVisual.styles.css` file to apply the updated styles to the `PanelVisual` component.

## Testing Steps
On Chart Color Palettes:
* Unselected color palette items should have cool-gray-30 borders applied on charts
* Selected color palette item should have black borders applied on charts

