### PR TITLE
Fix [new-50449] tooltips dynamic series chart

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Series.tsx
@@ -627,6 +627,7 @@ const SeriesItem = props => {
     ['Bar', 'Line'].includes(config.visualizationType) &&
     config.visualizationSubType !== 'Stacked' &&
     !config.series.find(s => s.dynamicCategory && s.dataKey !== series.dataKey)
+  const SELECT = '- Select -'
   return (
     <Draggable key={series.dataKey} draggableId={`draggableFilter-${series.dataKey}`} index={i}>
       {(provided, snapshot) => (
@@ -661,9 +662,9 @@ const SeriesItem = props => {
                       <Select
                         label='Dynamic Category'
                         value={series.dynamicCategory}
-                        options={['- Select - ', ...getColumns().filter(col => series.dataKey !== col)]}
+                        options={[SELECT, ...getColumns().filter(col => series.dataKey !== col)]}
                         updateField={(_section, _subsection, _fieldName, value) => {
-                          if (value === '- Select -') value = ''
+                          if (value === SELECT) value = ''
                           updateSeries(i, value, 'dynamicCategory')
                         }}
                         tooltip={


### PR DESCRIPTION
## Summary
Tooltips stop working if Dynamic Category is changed back to '- Select -'

<!-- Provide a brief explanation of the changes -->

## Testing Steps
<!-- Provide testing steps -->
Scenario: Upload 
[tooltips-dynamic-category.config.json](https://github.com/user-attachments/files/20353897/tooltips-dynamic-category.config.json) and open, configuration tab, and click on the tools icon on the bar graph visualization
Expected: There is a bar graph with all 50 states and the tooltip appears if you hover any of the bars. 

1, Open the Data Series accordion
2. Open Rate
3. Change Dynamic Category to Select
4. Hover over the bars in the chart

Expected: Tooltip displays with data about the state
Actual: No Tooltip is displayed

<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
