### PR TITLE
Enhancement/dev 10538 add reset functionality to dropdowns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,4 @@ indent_size = 2
 tab_width = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
+end_of_line = crlf

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -18,6 +18,7 @@ type DashboardFilterProps = {
   showSubmit: boolean
   applyFilters: MouseEventHandler<HTMLButtonElement>
   applyFiltersButtonText?: string
+  resetFilters: Function
 }
 
 const DashboardFilters: React.FC<DashboardFilterProps> = ({
@@ -27,7 +28,8 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
   handleOnChange,
   showSubmit,
   applyFilters,
-  applyFiltersButtonText
+  applyFiltersButtonText,
+  resetFilters
 }) => {
   const nullVal = (filter: SharedFilter) => {
     const val = filter.queuedActive || filter.active
@@ -184,19 +186,31 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
         )
       })}
       {showSubmit && (
-        <button
-          className='btn btn-primary mb-1'
-          onClick={applyFilters}
-          disabled={show.some(filterIndex => {
-            const emptyFilterValues = [undefined, '', '- Select -']
-            return (
-              emptyFilterValues.includes(sharedFilters[filterIndex].queuedActive) &&
-              emptyFilterValues.includes(sharedFilters[filterIndex].active)
-            )
-          })}
-        >
-          {applyFiltersButtonText || 'GO!'}
-        </button>
+        <>
+          <button
+            className='btn btn-primary mb-1'
+            onClick={applyFilters}
+            disabled={show.some(filterIndex => {
+              const emptyFilterValues = [undefined, '', '- Select -']
+              return (
+                emptyFilterValues.includes(sharedFilters[filterIndex].queuedActive) &&
+                emptyFilterValues.includes(sharedFilters[filterIndex].active)
+              )
+            })}
+          >
+            {applyFiltersButtonText || 'GO!'}
+          </button>
+          <button
+            type='reset'
+            className='btn btn-link bg-body text-primary mb-1'
+            onClick={e => {
+              e.preventDefault()
+              resetFilters(sharedFilters)
+            }}
+          >
+            Clear Filters
+          </button>
+        </>
       )}
     </form>
   )

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
@@ -143,6 +143,21 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
       }
     }
   }
+
+  const resetFilters = sharedFitlers => {
+    const newSharedFilters = _.cloneDeep(sharedFitlers)
+    newSharedFilters.forEach((filter, index) => {
+      filter.active = ''
+      filter.queuedActive = ''
+      if (filter.subGrouping) {
+        filter.subGrouping.active = ''
+        filter.subGrouping.queuedActive = ''
+      }
+    })
+    dispatch({ type: 'SET_DATA', payload: {} })
+    dispatch({ type: 'SET_SHARED_FILTERS', payload: newSharedFilters })
+  }
+
   const [displayPanel, setDisplayPanel] = useState(true)
   const onBackClick = () => {
     setDisplayPanel(!displayPanel)
@@ -187,6 +202,7 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
               showSubmit={visualizationConfig.filterBehavior === FilterBehavior.Apply && !visualizationConfig.autoLoad}
               applyFilters={applyFilters}
               applyFiltersButtonText={visualizationConfig.applyFiltersButtonText}
+              resetFilters={resetFilters}
             />
           </div>
         </Layout.Responsive>


### PR DESCRIPTION
## Summary
Added Reset button to the Dashboard Dropdowns

## Testing Steps
Scenario: Upload [dev-10538-config.json](https://github.com/user-attachments/files/20109327/dev-10538-config.json) and navigate to Preview
Expected: 3 Dashboard Filters on top with data loaded for the page

1. Select any options in the Topic, Measure, and Sub-Measure dropdowns

2. Click View Results
Expected: Data will load on the screen

3. Click Clear Filters
Expected: The filters will return to original setting, in this case Select, and the Data on the page will be removed.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
