### PR TITLE
Enhancement [NEW-50450] dynamic tooltip inline title

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -612,8 +612,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
         rightSuffix,
         bottomPrefix,
         bottomSuffix,
-        bottomAbbreviated,
-        onlyShowTopPrefixSuffix
+        bottomAbbreviated
       }
     } = config
 
@@ -706,9 +705,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
     if (addColPrefix && axis === 'left') {
       result = addColPrefix + result
     } else {
-      // if onlyShowTopPrefixSuffix only show top prefix
-      const suppressAllButLast = onlyShowTopPrefixSuffix && length - 1 !== index
-      if (prefix && axis === 'left' && !suppressAllButLast) {
+      if (prefix && axis === 'left') {
         result += prefix
       }
     }
@@ -727,7 +724,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
     if (addColSuffix && axis === 'left') {
       result += addColSuffix
     } else {
-      if (suffix && axis === 'left' && !onlyShowTopPrefixSuffix) {
+      if (suffix && axis === 'left') {
         result += suffix
       }
     }

--- a/packages/chart/src/_stories/ChartPrefixSuffix.stories.tsx
+++ b/packages/chart/src/_stories/ChartPrefixSuffix.stories.tsx
@@ -15,49 +15,55 @@ const meta: Meta<typeof Chart> = {
 
 type Story = StoryObj<typeof Chart>
 
-export const Top_Suffix: Story = {
+export const Inline_Label: Story = {
   args: {
     config: editConfigKeys(barConfig, [
-      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
-      { path: ['dataFormat', 'suffix'], value: ' Somethings per Something' },
+      { path: ['yAxis', 'inlineLabel'], value: ' Somethings per Something' },
+      { path: ['yAxis', 'gridLines'], value: true }
+    ])
+  }
+}
+export const Inline_Label_With_Suffix: Story = {
+  args: {
+    config: editConfigKeys(barConfig, [
+      { path: ['yAxis', 'inlineLabel'], value: ' Somethings per Something' },
+      { path: ['dataFormat', 'suffix'], value: '%' },
       { path: ['yAxis', 'gridLines'], value: true }
     ])
   }
 }
 
-export const Top_Suffix_Worst_Case: Story = {
+export const Inline_Label_Worst_Case: Story = {
   args: {
-    config: editConfigKeys(annotationConfig, [
-      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
-      { path: ['dataFormat', 'suffix'], value: ' Somethings per Something' }
-    ])
+    config: editConfigKeys(annotationConfig, [{ path: ['yAxis', 'inlineLabel'], value: ' Somethings per Something' }])
   }
 }
 
-export const Top_Suffix_With_Options: Story = {
+export const Inline_Label_With_Options: Story = {
   args: {
     config: editConfigKeys(annotationConfig, [
-      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
+      { path: ['yAxis', 'inlineLabel'], value: ' units' },
+      { path: ['dataFormat', 'suffix'], value: '' },
       { path: ['yAxis', 'tickRotation'], value: 45 },
       { path: ['yAxis', 'tickLabelColor'], value: 'red' }
     ])
   }
 }
 
-export const Top_Suffix_No_Space: Story = {
+export const Inline_Label_No_Space: Story = {
   args: {
     config: editConfigKeys(annotationConfig, [
-      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
-      { path: ['dataFormat', 'suffix'], value: 'lbs' }
+      { path: ['yAxis', 'inlineLabel'], value: 'lbs' },
+      { path: ['dataFormat', 'suffix'], value: '' }
     ])
   }
 }
 
-export const Top_Suffix_With_Space: Story = {
+export const Inline_Label_With_Space: Story = {
   args: {
     config: editConfigKeys(annotationConfig, [
-      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
-      { path: ['dataFormat', 'suffix'], value: 'lbs of something' }
+      { path: ['yAxis', 'inlineLabel'], value: 'lbs of something' },
+      { path: ['dataFormat', 'suffix'], value: '' }
     ])
   }
 }
@@ -67,15 +73,7 @@ export const Suffix: Story = {
     config: annotationConfig
   }
 }
-export const Top_Prefix: Story = {
-  args: {
-    config: editConfigKeys(annotationConfig, [
-      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
-      { path: ['dataFormat', 'prefix'], value: '$' },
-      { path: ['dataFormat', 'suffix'], value: '' }
-    ])
-  }
-}
+
 export const Prefix: Story = {
   args: {
     config: editConfigKeys(areaPrefix, [
@@ -85,10 +83,10 @@ export const Prefix: Story = {
   }
 }
 
-export const Top_Prefix_And_Suffix: Story = {
+export const Prefix_Suffix_And_Inline_Title: Story = {
   args: {
     config: editConfigKeys(annotationConfig, [
-      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
+      { path: ['yAxis', 'inlineLabel'], value: 'lbs of something' },
       { path: ['dataFormat', 'prefix'], value: '$' }
     ])
   }
@@ -102,11 +100,11 @@ export const Horizontal_Bar: Story = {
   }
 }
 
-export const Top_Suffix_On_Line: Story = {
+export const Inline_Title_On_Line: Story = {
   args: {
     config: editConfigKeys(barConfig, [
-      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
-      { path: ['dataFormat', 'suffix'], value: ' Somethings per Something' },
+      { path: ['yAxis', 'inlineLabel'], value: 'lbs of something' },
+      { path: ['dataFormat', 'suffix'], value: '' },
       { path: ['yAxis', 'gridLines'], value: true },
       { path: ['yAxis', 'labelsAboveGridlines'], value: true },
       { path: ['yAxis', 'hideAxis'], value: true }
@@ -128,9 +126,8 @@ export const Values_On_Line_All_Suffix: Story = {
 export const Values_on_Line_Top_Suffix_Only_Area_Worst_Case: Story = {
   args: {
     config: editConfigKeys(annotationConfig, [
-      { path: ['dataFormat', 'onlyShowTopPrefixSuffix'], value: true },
+      { path: ['yAxis', 'inlineLabel'], value: ' of something' },
       { path: ['dataFormat', 'prefix'], value: 'pre' },
-      { path: ['dataFormat', 'suffix'], value: ' Somethings per Something' },
       { path: ['yAxis', 'labelsAboveGridlines'], value: true },
       { path: ['yAxis', 'gridLines'], value: true }
     ])

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1656,6 +1656,44 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
                           </Tooltip>
                         }
                       />
+                      <TextField
+                        display={!visHasCategoricalAxis()}
+                        value={config.yAxis.inlineLabel}
+                        section='yAxis'
+                        fieldName='inlineLabel'
+                        label='Inline Label'
+                        updateField={updateField}
+                        maxLength={35}
+                        tooltip={
+                          <Tooltip style={{ textTransform: 'none' }}>
+                            <Tooltip.Target>
+                              <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                            </Tooltip.Target>
+                            <Tooltip.Content>
+                              <p>35 character limit</p>
+                            </Tooltip.Content>
+                          </Tooltip>
+                        }
+                      />
+                      <TextField
+                        display={!visHasCategoricalAxis()}
+                        value={config.yAxis.inlineLabel}
+                        section='yAxis'
+                        fieldName='inlineLabel'
+                        label='Inline Label'
+                        updateField={updateFieldDeprecated}
+                        maxLength={35}
+                        tooltip={
+                          <Tooltip style={{ textTransform: 'none' }}>
+                            <Tooltip.Target>
+                              <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                            </Tooltip.Target>
+                            <Tooltip.Content>
+                              <p>35 character limit</p>
+                            </Tooltip.Content>
+                          </Tooltip>
+                        }
+                      />
                       {config.runtime.seriesKeys &&
                         config.runtime.seriesKeys.length === 1 &&
                         !['Box Plot', 'Deviation Bar', 'Forest Plot'].includes(config.visualizationType) && (
@@ -2000,14 +2038,6 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
                   ) : (
                     config.visualizationType !== 'Pie' && (
                       <>
-                        <CheckBox
-                          display={!visHasCategoricalAxis()}
-                          value={config.dataFormat.onlyShowTopPrefixSuffix}
-                          section='dataFormat'
-                          fieldName='onlyShowTopPrefixSuffix'
-                          label='Only Show Top Prefix/Suffix'
-                          updateField={updateFieldDeprecated}
-                        />
                         <CheckBox
                           display={!visHasCategoricalAxis()}
                           value={config.yAxis.hideAxis}

--- a/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
+++ b/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
@@ -381,7 +381,7 @@ export const useEditorPermissions = () => {
   }
 
   const visSupportsYPadding = () => {
-    return !config.dataFormat.onlyShowTopPrefixSuffix || !config.dataFormat.suffix?.includes(' ')
+    return !config.yAxis.inlineLabel || !config.yAxis.inlineLabel?.includes(' ')
   }
 
   const visHasSingleSeriesTooltip = () => {

--- a/packages/chart/src/components/Legend/helpers/index.ts
+++ b/packages/chart/src/components/Legend/helpers/index.ts
@@ -36,7 +36,7 @@ export const getMarginBottom = (isLegendBottom, config) => {
 
   if (isLegendTop) marginBottom = 27
 
-  if (isLegendTop && config.dataFormat?.onlyShowTopPrefixSuffix) marginBottom += 9
+  if (isLegendTop && config.yAxis?.inlineLabel) marginBottom += 9
 
   if (isLegendBottom) marginBottom += 9
 

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -473,10 +473,17 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   useEffect(() => {
     if (!tooltipOpen) return
     if (!tooltipRef.current) return
+
     const { dataXPosition } = tooltipData as { [key: string]: number }
+
     if (!dataXPosition) return
-    const rightSide = dataXPosition > parentWidth / 2
-    const maxWidth = rightSide ? dataXPosition - 10 : parentWidth - (dataXPosition + 6) // 20px padding
+
+    const { width: tooltipWidth } = tooltipRef.current.node.getBoundingClientRect()
+
+    const rightSideRemainingSpace = parentWidth - dataXPosition
+
+    const rightSide = rightSideRemainingSpace <= tooltipWidth && dataXPosition > parentWidth / 2 - 10
+    const maxWidth = rightSide ? dataXPosition - 10 : parentWidth - (dataXPosition + 6)
     tooltipRef.current.node.style.maxWidth = `${maxWidth}px`
   }, [tooltipOpen, tooltipData])
 
@@ -1022,7 +1029,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       />
                     )}
                     {props.ticks.map((tick, i) => {
-                      console.log('🧙‍♂️ ✨ {props.ticks.map ✨ tick.formattedValue:', tick.formattedValue)
                       const minY = props.ticks[0].to.y
                       const barMinHeight = 15 // 15 is the min height for bars by default
                       const showTicks = String(tick.value).startsWith('1') || tick.value === 0.1 ? 'block' : 'none'
@@ -1031,6 +1037,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
 
                       // Vertical value/suffix vars
                       const lastTick = props.ticks.length - 1 === i
+                      const useInlineLabel = lastTick && inlineLabel
                       const hideTopTick = lastTick && inlineLabel && !inlineLabelHasNoSpace
                       const valueOnLinePadding = hideAxis ? -8 : -12
                       const labelXPadding = labelsAboveGridlines ? valueOnLinePadding : TICK_LABEL_MARGIN_RIGHT
@@ -1039,6 +1046,9 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       const labelY = tick.to.y - labelYPadding
                       const labelVerticalAnchor = labelsAboveGridlines ? 'end' : 'middle'
                       const combineDomInlineLabelWithValue = inlineLabel && labelsAboveGridlines && lastTick
+                      const formattedValue = useInlineLabel
+                        ? tick.formattedValue.replace(config.dataFormat.suffix, '')
+                        : tick.formattedValue
 
                       return (
                         <Group key={`vx-tick-${tick.value}-${i}`} className={'vx-axis-tick'}>
@@ -1200,7 +1210,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                   style={{ whiteSpace: 'pre-wrap' }} // prevents leading spaces from being trimmed
                                   fontSize={tickLabelFontSize}
                                 >
-                                  {`${tick.formattedValue}${combineDomInlineLabelWithValue ? inlineLabel : ''}`}
+                                  {`${formattedValue}${combineDomInlineLabelWithValue ? inlineLabel : ''}`}
                                 </BlurStrokeText>
                               </>
                             )}

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -98,8 +98,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     dataFormat,
     debugSvg
   } = config
-  const { suffix, onlyShowTopPrefixSuffix } = dataFormat
-  const { labelsAboveGridlines, hideAxis } = config.yAxis
+  const { labelsAboveGridlines, hideAxis, inlineLabel } = config.yAxis
 
   // HOOKS  % STATES
   const { minValue, maxValue, existPositiveValue, isAllLine } = useReduceData(config, data)
@@ -120,6 +119,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   const xAxisTitleRef = useRef(null)
   const lastMaxValue = useRef(maxValue)
   const gridLineRefs = useRef([])
+  const tooltipRef = useRef(null)
 
   const dataRef = useIntersectionObserver(triggerRef, {
     freezeOnceVisible: false
@@ -131,8 +131,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   const isLogarithmicAxis = config.yAxis.type === 'logarithmic'
   const isForestPlot = visualizationType === 'Forest Plot'
   const isDateTime = config.xAxis.type === 'date-time'
-  const suffixHasNoSpace = !suffix.includes(' ')
-  const labelsOverflow = onlyShowTopPrefixSuffix && !suffixHasNoSpace
+  const inlineLabelHasNoSpace = !inlineLabel?.includes(' ')
+  const labelsOverflow = inlineLabel && !inlineLabelHasNoSpace
   const padding = orientation === 'horizontal' ? Number(config.xAxis.size) : Number(config.yAxis.size)
   const yLabelOffset = isNaN(parseInt(`${runtime.yAxis.labelOffset}`)) ? 0 : parseInt(`${runtime.yAxis.labelOffset}`)
   const tickLabelFontSize = isMobileHeightViewport(currentViewport) ? TICK_LABEL_FONT_SIZE_SMALL : TICK_LABEL_FONT_SIZE
@@ -374,7 +374,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     if (!suffixEl) return setSuffixWidth(0)
     const suffixElWidth = suffixEl.getBBox().width
     setSuffixWidth(suffixElWidth)
-  }, [config.dataFormat.suffix, config.dataFormat.onlyShowTopPrefixSuffix])
+  }, [config.dataFormat.suffix, inlineLabel])
 
   // forest plot x-axis label positioning
   useEffect(() => {
@@ -469,6 +469,16 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     d3 still doesn't show the tick. we add 0.1 to ensure to tip it over the edge */
     setYAxisAutoPadding(newPadding * 100 + 0.1)
   }, [maxValue, labelsOverflow, yScale, handleNumTicks])
+
+  useEffect(() => {
+    if (!tooltipOpen) return
+    if (!tooltipRef.current) return
+    const { dataXPosition } = tooltipData as { [key: string]: number }
+    if (!dataXPosition) return
+    const rightSide = dataXPosition > parentWidth / 2
+    const maxWidth = rightSide ? dataXPosition - 10 : parentWidth - (dataXPosition + 6) // 20px padding
+    tooltipRef.current.node.style.maxWidth = `${maxWidth}px`
+  }, [tooltipOpen, tooltipData])
 
   // Render Functions
   const generatePairedBarAxis = () => {
@@ -1012,6 +1022,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       />
                     )}
                     {props.ticks.map((tick, i) => {
+                      console.log('🧙‍♂️ ✨ {props.ticks.map ✨ tick.formattedValue:', tick.formattedValue)
                       const minY = props.ticks[0].to.y
                       const barMinHeight = 15 // 15 is the min height for bars by default
                       const showTicks = String(tick.value).startsWith('1') || tick.value === 0.1 ? 'block' : 'none'
@@ -1020,15 +1031,14 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
 
                       // Vertical value/suffix vars
                       const lastTick = props.ticks.length - 1 === i
-                      const hideTopTick = lastTick && onlyShowTopPrefixSuffix && suffix && !suffixHasNoSpace
+                      const hideTopTick = lastTick && inlineLabel && !inlineLabelHasNoSpace
                       const valueOnLinePadding = hideAxis ? -8 : -12
                       const labelXPadding = labelsAboveGridlines ? valueOnLinePadding : TICK_LABEL_MARGIN_RIGHT
                       const labelYPadding = labelsAboveGridlines ? 4 : 0
                       const labelX = tick.to.x - labelXPadding
                       const labelY = tick.to.y - labelYPadding
                       const labelVerticalAnchor = labelsAboveGridlines ? 'end' : 'middle'
-                      const combineDomSuffixWithValue =
-                        onlyShowTopPrefixSuffix && labelsAboveGridlines && suffix && lastTick
+                      const combineDomInlineLabelWithValue = inlineLabel && labelsAboveGridlines && lastTick
 
                       return (
                         <Group key={`vx-tick-${tick.value}-${i}`} className={'vx-axis-tick'}>
@@ -1147,11 +1157,11 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             visualizationType !== 'Bump Chart' &&
                             !config.yAxis.hideLabel && (
                               <>
-                                {/* TOP ONLY SUFFIX: Dom suffix for 'show only top suffix' behavior */}
-                                {/* top suffix is shown alone and is allowed to 'overflow' to the right */}
-                                {/* SPECIAL ONE CHAR CASE: a one character top-only suffix does not overflow */}
+                                {/* INLINE LABEL BEHAVIOR: Dom suffix for 'inlineLabel' behavior */}
+                                {/* inline label is shown alone and is allowed to 'overflow' to the right */}
+                                {/* SPECIAL ONE CHAR CASE: a one character inlineLabel does not overflow */}
                                 {/* IF VALUES ON LINE: suffix is combined with value to avoid having to calculate varying (now left-aligned) value widths */}
-                                {onlyShowTopPrefixSuffix && lastTick && !labelsAboveGridlines && (
+                                {inlineLabel && lastTick && !labelsAboveGridlines && (
                                   <BlurStrokeText
                                     innerRef={suffixRef}
                                     display={isLogarithmicAxis ? showTicks : 'block'}
@@ -1160,7 +1170,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                     y={labelY}
                                     angle={-Number(config.yAxis.tickRotation) || 0}
                                     verticalAnchor={labelVerticalAnchor}
-                                    textAnchor={suffixHasNoSpace ? 'end' : 'start'}
+                                    textAnchor={inlineLabelHasNoSpace ? 'end' : 'start'}
                                     fill={config.yAxis.tickLabelColor}
                                     stroke={'#fff'}
                                     paintOrder={'stroke'} // keeps stroke under fill
@@ -1168,7 +1178,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                     style={{ whiteSpace: 'pre-wrap' }} // prevents leading spaces from being trimmed
                                     fontSize={tickLabelFontSize}
                                   >
-                                    {suffix}
+                                    {inlineLabel}
                                   </BlurStrokeText>
                                 )}
 
@@ -1177,7 +1187,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                   innerRef={el => lastTick && (topYLabelRef.current = el)}
                                   display={isLogarithmicAxis ? showTicks : 'block'}
                                   dx={isLogarithmicAxis ? -6 : 0}
-                                  x={suffixHasNoSpace ? labelX - suffixWidth : labelX}
+                                  x={inlineLabelHasNoSpace ? labelX - suffixWidth : labelX}
                                   y={labelY + (config.runtime.horizontal ? horizontalTickOffset : 0)}
                                   angle={-Number(config.yAxis.tickRotation) || 0}
                                   verticalAnchor={config.runtime.horizontal ? 'start' : labelVerticalAnchor}
@@ -1190,7 +1200,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                   style={{ whiteSpace: 'pre-wrap' }} // prevents leading spaces from being trimmed
                                   fontSize={tickLabelFontSize}
                                 >
-                                  {`${tick.formattedValue}${combineDomSuffixWithValue ? suffix : ''}`}
+                                  {`${tick.formattedValue}${combineDomInlineLabelWithValue ? inlineLabel : ''}`}
                                 </BlurStrokeText>
                               </>
                             )}
@@ -1501,6 +1511,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               }) !important;`}</style>
               <style>{`.tooltip {max-width:300px} !important; word-wrap: break-word; `}</style>
               <TooltipWithBounds
+                ref={tooltipRef}
                 key={Math.random()}
                 className={'tooltip cdc-open-viz-module'}
                 left={tooltipLeft}

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -572,7 +572,7 @@ export const useTooltip = props => {
     const style = displayGray ? { color: '#8b8b8a' } : {}
 
     if (index == 1 && config.yAxis?.inlineLabel) {
-      newValue = `${config.dataFormat.prefix}${newValue}${config.dataFormat.suffix}${config.yAxis?.inlineLabel}`
+      newValue = `${config.dataFormat.prefix}${newValue}${config.dataFormat.suffix}`
     }
     const activeLabel = getSeriesNameFromLabel(key)
     const displayText = activeLabel ? `${activeLabel}: ${newValue}` : newValue

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -571,14 +571,14 @@ export const useTooltip = props => {
     let newValue = label || value
     const style = displayGray ? { color: '#8b8b8a' } : {}
 
-    if (index == 1 && config.dataFormat.onlyShowTopPrefixSuffix) {
-      newValue = `${config.dataFormat.prefix}${newValue}${config.dataFormat.suffix}`
+    if (index == 1 && config.yAxis?.inlineLabel) {
+      newValue = `${config.dataFormat.prefix}${newValue}${config.dataFormat.suffix}${config.yAxis?.inlineLabel}`
     }
     const activeLabel = getSeriesNameFromLabel(key)
     const displayText = activeLabel ? `${activeLabel}: ${newValue}` : newValue
 
     return (
-      <li style={style} className='tooltip-body'>
+      <li style={style} className='tooltip-body mb-1'>
         {displayText}
       </li>
     )

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -70,7 +70,6 @@ type DataFormat = {
   rightSuffix: string
   roundTo: number
   suffix: string
-  onlyShowTopPrefixSuffix?: boolean
 }
 
 type Exclusions = {

--- a/packages/core/helpers/cove/number.ts
+++ b/packages/core/helpers/cove/number.ts
@@ -54,7 +54,6 @@ const formatNumber = (num, axis, shouldAbbreviate = false, config = null, addCol
       bottomSuffix,
       bottomComas,
       commas,
-      onlyShowTopPrefixSuffix,
       prefix,
       rightPrefix,
       rightRoundTo,
@@ -63,6 +62,7 @@ const formatNumber = (num, axis, shouldAbbreviate = false, config = null, addCol
       suffix
     }
   } = config
+  const { inlineLabel } = config.yAxis || {}
 
   // destructure Additional Col dataformat values
   const { addColCommas, addColRoundTo, addColPrefix, addColSuffix } = addColParams || {}
@@ -154,7 +154,7 @@ const formatNumber = (num, axis, shouldAbbreviate = false, config = null, addCol
     num = abbreviateNumber(parseFloat(num))
   }
 
-  if (!onlyShowTopPrefixSuffix) {
+  if (!inlineLabel) {
     if (addColPrefix !== undefined && axis === 'left') {
       result = addColPrefix + result
     } else {
@@ -174,7 +174,7 @@ const formatNumber = (num, axis, shouldAbbreviate = false, config = null, addCol
 
   result += num
 
-  if (!onlyShowTopPrefixSuffix) {
+  if (!inlineLabel) {
     if (addColSuffix !== undefined && axis === 'left') {
       result += addColSuffix
     } else {

--- a/packages/core/helpers/coveUpdateWorker.ts
+++ b/packages/core/helpers/coveUpdateWorker.ts
@@ -14,6 +14,7 @@ import update_4_24_11 from './ver/4.24.11'
 import update_4_25_1 from './ver/4.25.1'
 import update_4_25_3 from './ver/4.25.3'
 import update_4_25_4 from './ver/4.25.4'
+import update_4_25_6 from './ver/4.25.6'
 
 export const coveUpdateWorker = (config, multiDashboardVersion?) => {
   let genConfig = config
@@ -31,6 +32,7 @@ export const coveUpdateWorker = (config, multiDashboardVersion?) => {
     ['4.25.1', update_4_25_1],
     ['4.25.3', update_4_25_3],
     ['4.25.4', update_4_25_4],
+    ['4.25.6', update_4_25_6]
   ]
 
   versions.forEach(([version, updateFunction, alwaysRun]: [string, UpdateFunction, boolean?]) => {

--- a/packages/core/helpers/ver/4.25.6.ts
+++ b/packages/core/helpers/ver/4.25.6.ts
@@ -1,0 +1,29 @@
+import _ from 'lodash'
+
+// *NOTE: This ends support for only showing the top prefix
+export const changeOnlyShowTopSuffixToInlineLabel = config => {
+  if (!config.dataFormat?.suffix) return config
+  if (!config.dataFormat.onlyShowTopPrefixSuffix) return config
+
+  delete config.dataFormat.onlyShowTopPrefixSuffix
+
+  if (!config.yAxis) config.yAxis = {}
+
+  if (!config.yAxis?.inlineLabel) {
+    config.yAxis.inlineLabel = config.dataFormat.suffix
+  }
+
+  config.dataFormat.suffix = ''
+
+  return config
+}
+
+const update_4_25_6 = config => {
+  const ver = '4.25.6'
+  const newConfig = _.cloneDeep(config)
+  changeOnlyShowTopSuffixToInlineLabel(newConfig)
+  newConfig.version = ver
+  return newConfig
+}
+
+export default update_4_25_6

--- a/packages/core/helpers/ver/tests/4.25.6.test.ts
+++ b/packages/core/helpers/ver/tests/4.25.6.test.ts
@@ -1,0 +1,52 @@
+import { expect, describe, it } from 'vitest'
+import { changeOnlyShowTopSuffixToInlineLabel } from '../4.25.6'
+
+describe('changeOnlyShowTopSuffixToInlineLabel(config) ', () => {
+  it("should'nt change config if no suffix", () => {
+    const config = {
+      dataFormat: {
+        onlyShowTopPrefixSuffix: true,
+        suffix: ''
+      }
+    }
+    const newConfig = changeOnlyShowTopSuffixToInlineLabel(config)
+    expect(newConfig).toEqual(config)
+  })
+  it("should't change suffix if onlyShowTopPrefixSuffix is false", () => {
+    const config = {
+      dataFormat: {
+        onlyShowTopPrefixSuffix: false,
+        suffix: 'test'
+      }
+    }
+    const newConfig = changeOnlyShowTopSuffixToInlineLabel(config)
+    expect(newConfig).toEqual(config)
+  })
+  it('should change suffix to inlineLabel if onlyShowTopPrefixSuffix is true', () => {
+    const config = {
+      dataFormat: {
+        onlyShowTopPrefixSuffix: true,
+        suffix: 'test'
+      }
+    }
+    const newConfig = changeOnlyShowTopSuffixToInlineLabel(config)
+    expect(newConfig.yAxis.inlineLabel).toBe('test')
+    expect(newConfig.dataFormat.onlyShowTopPrefixSuffix).toBe(undefined)
+    expect(newConfig.dataFormat.suffix).toBe('')
+  })
+  it("should't overwrite existing yAxis inlineLabel", () => {
+    const config = {
+      dataFormat: {
+        onlyShowTopPrefixSuffix: true,
+        suffix: 'test'
+      },
+      yAxis: {
+        inlineLabel: 'test2'
+      }
+    }
+    const newConfig = changeOnlyShowTopSuffixToInlineLabel(config)
+    expect(newConfig.yAxis.inlineLabel).toBe('test2')
+    expect(newConfig.dataFormat.onlyShowTopPrefixSuffix).toBe(undefined)
+    expect(newConfig.dataFormat.suffix).toBe('')
+  })
+})

--- a/packages/core/types/Axis.ts
+++ b/packages/core/types/Axis.ts
@@ -17,6 +17,7 @@ export type Axis = {
   hideAxis?: boolean
   hideLabel?: boolean
   hideTicks?: boolean
+  inlineLabel?: string
   label?: string
   labelOffset?: number
   labelPlacement?: string


### PR DESCRIPTION
## Summary
1. Allow resize of tooltip when necessary
2. Replaced left axis `suffix`+ `onlyShowTopPrefixSuffix` with inlineLabel
3. Added migration script for change 2.
4. Remove the now-called inlinedLabel from tooltip

## Testing Steps
Test for change 1.
1. Open chart with tooltip
2. Change to mobile view or shrink screen <350px
3. Confirm tooltip resizes instead of overflowing

Test for change 2.
1. Open chart in editor
2. Confirm inlineLabel is available and behaves like a suffix that only appears on top axis gridline and is allowed to overflow if label contains spaces
3. Confirm `onlyShowTopPrefixSuffix` is removed and `suffix` behaves normally

Test for change 3.
1. Open config with `suffix`+ `onlyShowTopPrefixSuffix`
2. Confirm that it behaves the same way and now show a populated `inlineLabel` in the editorf

Test for change 4.
1. Open chart with tooltip
2. Confirm inlineLabel does not show in tooltip


## Optional
### Storybook Links
http://localhost:6006/?path=/story/components-templates-chart-prefix-suffix--inline-label

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
