### PR TITLE
feature [dev-10538] reset dashboard dropdowns

### DIFF
--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -18,6 +18,7 @@ type DashboardFilterProps = {
   showSubmit: boolean
   applyFilters: MouseEventHandler<HTMLButtonElement>
   applyFiltersButtonText?: string
+  resetFilters: Function
 }
 
 const DashboardFilters: React.FC<DashboardFilterProps> = ({
@@ -27,7 +28,8 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
   handleOnChange,
   showSubmit,
   applyFilters,
-  applyFiltersButtonText
+  applyFiltersButtonText,
+  resetFilters
 }) => {
   const nullVal = (filter: SharedFilter) => {
     const val = filter.queuedActive || filter.active
@@ -184,19 +186,31 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
         )
       })}
       {showSubmit && (
-        <button
-          className='btn btn-primary mb-1'
-          onClick={applyFilters}
-          disabled={show.some(filterIndex => {
-            const emptyFilterValues = [undefined, '', '- Select -']
-            return (
-              emptyFilterValues.includes(sharedFilters[filterIndex].queuedActive) &&
-              emptyFilterValues.includes(sharedFilters[filterIndex].active)
-            )
-          })}
-        >
-          {applyFiltersButtonText || 'GO!'}
-        </button>
+        <>
+          <button
+            className='btn btn-primary mb-1'
+            onClick={applyFilters}
+            disabled={show.some(filterIndex => {
+              const emptyFilterValues = [undefined, '', '- Select -']
+              return (
+                emptyFilterValues.includes(sharedFilters[filterIndex].queuedActive) &&
+                emptyFilterValues.includes(sharedFilters[filterIndex].active)
+              )
+            })}
+          >
+            {applyFiltersButtonText || 'GO!'}
+          </button>
+          <button
+            type='reset'
+            className='btn btn-link bg-body text-primary mb-1'
+            onClick={e => {
+              e.preventDefault()
+              resetFilters(sharedFilters)
+            }}
+          >
+            Clear Filters
+          </button>
+        </>
       )}
     </form>
   )

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
@@ -143,6 +143,20 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
       }
     }
   }
+
+  const resetFilters = sharedFilters => {
+    const newSharedFilters = _.cloneDeep(sharedFilters)
+    newSharedFilters.forEach(filter => {
+      filter.active = null
+      filter.queuedActive = null
+      if (filter.subGrouping) {
+        filter.subGrouping.active = null
+        filter.subGrouping.queuedActive = null
+      }
+    })
+    dispatch({ type: 'SET_DATA', payload: {} })
+    dispatch({ type: 'SET_SHARED_FILTERS', payload: newSharedFilters })
+  }
   const [displayPanel, setDisplayPanel] = useState(true)
   const onBackClick = () => {
     setDisplayPanel(!displayPanel)
@@ -187,6 +201,7 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
               showSubmit={visualizationConfig.filterBehavior === FilterBehavior.Apply && !visualizationConfig.autoLoad}
               applyFilters={applyFilters}
               applyFiltersButtonText={visualizationConfig.applyFiltersButtonText}
+              resetFilters={resetFilters}
             />
           </div>
         </Layout.Responsive>


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->
Added Reset button to the Dashboard Dropdowns

## Testing Steps
<!-- Provide testing steps -->
Scenario: Upload [dev-10538-config.json](https://github.com/user-attachments/files/20109327/dev-10538-config.json) and navigate to Preview
Expected: 3 Dashboard Filters on top with data loaded for the page

Select any options in the Topic, Measure, and Sub-Measure dropdowns

Click View Results
Expected: Data will load on the screen

Click Clear Filters
Expected: The filters will return to original setting, in this case Select, and the Data on the page will be removed.
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
