### PR TITLE
[NEW-50505] Fix/focus indicators

### DIFF
--- a/packages/chart/src/scss/main.scss
+++ b/packages/chart/src/scss/main.scss
@@ -513,10 +513,6 @@
     }
   }
 
-  [tabindex]:focus-visible {
-    outline: 2px solid rgb(0, 95, 204) !important;
-  }
-
   // ANIMATIONS
   // Pie Chart Animations
   .animated-pie {
@@ -742,4 +738,17 @@
 
 .cdc-open-viz-module .debug {
   border: 2px solid red;
+}
+
+.modal.cdc-cove-editor *:focus-visible,
+.cdc-open-viz-module *:focus-visible {
+  outline: inherit !important;
+  outline-offset: 3px !important;
+}
+
+// Only frontend styles are applied in WCMS/TP
+// This helps match those styles when viewing in the editor
+.modal.cdc-cove-editor *:focus-visible {
+  outline: dashed 2px rgba(255, 102, 1, 0.9) !important;
+  outline-offset: 3px !important;
 }

--- a/packages/chart/src/scss/main.scss
+++ b/packages/chart/src/scss/main.scss
@@ -740,10 +740,14 @@
   border: 2px solid red;
 }
 
+// Only frontend styles are applied in WCMS/TP
+// This helps match those styles when viewing in the editor
 .modal.cdc-cove-editor *:focus-visible,
 .cdc-open-viz-module *:focus-visible {
-  outline: inherit !important;
-  outline-offset: 3px !important;
+  outline-width: inherit !important;
+  outline-style: inherit !important;
+  outline-color: inherit !important;
+  outline-offset: inherit !important;
 }
 
 // Only frontend styles are applied in WCMS/TP

--- a/packages/core/styles/_global.scss
+++ b/packages/core/styles/_global.scss
@@ -193,8 +193,4 @@ section.footnotes {
   -webkit-appearance: none;
   -moz-appearance: none;
   cursor: pointer;
-  &:focus-visible {
-    outline: 2px dashed var(--colors-blue-vivid-60, #005ea2) !important;
-    outline-offset: 2px;
-  }
 }

--- a/packages/core/styles/filters.scss
+++ b/packages/core/styles/filters.scss
@@ -93,10 +93,6 @@ div.single-filters {
     &:focus:not(:focus-visible) {
       outline: none !important;
     }
-    &:focus-visible {
-      outline: 2px dashed var(--colors-blue-vivid-60, #005ea2) !important;
-      outline-offset: 3px;
-    }
 
     &.tab--active {
       font-weight: 500;


### PR DESCRIPTION
## Summary
Focus indicators should inherit from their wrapping container.

## Testing Steps
- [ ] Review focus indicators on wcms/tp

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
