### PR TITLE
fix chart csv download

### DIFF
--- a/packages/core/helpers/ver/4.25.3.ts
+++ b/packages/core/helpers/ver/4.25.3.ts
@@ -2,7 +2,10 @@ import _ from 'lodash'
 
 const remapTableDownloadCSV = config => {
   if (config.general?.showDownloadButton !== undefined) {
-    const download = config.general.showDownloadButton
+    let download = config.general.showDownloadButton
+    if (config.type === 'chart') {
+      download = config.table.download || config.general.showDownloadButton
+    }
     delete config.general.showDownloadButton
     config.table.download = download
   }


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

For legacy configurations the CSV download links disappeared in some cases after the 2.25.5 release. This was due to a migration error.



## Testing Steps
<!-- Provide testing steps -->

https://www.cdc.gov/maternal-mortality/php/pregnancy-mortality-surveillance-data/index.html?cove-tab=1 this page should have download links under all the tables.

<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
