### PR TITLE
fix: inline-style not taking

### DIFF
--- a/packages/core/components/Filters/components/Dropdown.tsx
+++ b/packages/core/components/Filters/components/Dropdown.tsx
@@ -18,7 +18,7 @@ const Dropdown: React.FC<DropdownProps> = ({ index: outerIndex, label, filter, c
       name={label}
       aria-label={`Filter by ${label}`}
       className={`cove-form-select ${DROPDOWN_STYLES}`}
-      style={{ backgroundColor: 'white !important' }}
+      style={{ backgroundColor: 'white' }}
       data-index='0'
       value={queuedActive || active}
       onChange={e => {


### PR DESCRIPTION
## Summary
!important doesn't take in react inline styles

## Testing Steps
Open dropdown with iphone emulator and confirm it is white
