### PR TITLE
[NEW-50455] Forecasting > appear in front of lines

### DIFF
--- a/packages/chart/examples/feature/forecasting/combo-forecasting.json
+++ b/packages/chart/examples/feature/forecasting/combo-forecasting.json
@@ -1,42 +1,46 @@
 {
   "type": "chart",
-  "title": "Forecasting Chart Example",
+  "title": "",
   "showTitle": true,
   "showDownloadMediaButton": false,
   "theme": "theme-blue",
-  "animate": true,
+  "animate": false,
   "fontSize": "medium",
   "lineDatapointStyle": "hover",
   "barHasBorder": "false",
   "isLollipopChart": false,
   "lollipopShape": "circle",
   "lollipopColorStyle": "two-tone",
-  "visualizationSubType": "regular",
+  "visualizationSubType": "regular ",
   "barStyle": "",
   "roundingStyle": "standard",
   "tipRounding": "top",
   "isResponsiveTicks": false,
   "general": {
-    "showDownloadButton": false
+    "annotationDropdownText": "Annotations",
+    "showMissingDataLabel": true,
+    "showSuppressedSymbol": true,
+    "showZeroValueData": true,
+    "hideNullValue": true
   },
   "padding": {
-    "left": 0,
-    "right": 0
+    "left": 5,
+    "right": 5
   },
   "yAxis": {
     "hideAxis": false,
     "displayNumbersOnBar": false,
     "hideLabel": false,
     "hideTicks": false,
-    "size": "75",
+    "size": 50,
     "gridLines": false,
     "enablePadding": false,
-    "min": "0",
-    "max": "900",
+    "min": "",
+    "max": "",
     "labelColor": "#333",
     "tickLabelColor": "#333",
     "tickColor": "#333",
-    "rightHideAxis": false,
+    "rightHideAxis": true,
     "rightAxisSize": 50,
     "rightLabel": "",
     "rightLabelOffsetSize": 0,
@@ -45,26 +49,18 @@
     "rightAxisTickColor": "#333",
     "numTicks": "",
     "axisPadding": 0,
+    "scalePadding": 10,
     "tickRotation": 0,
-    "anchors": [
-      {
-        "value": "10/15/2022"
-      }
-    ],
-    "label": "Cases by Date of Report"
+    "anchors": [],
+    "shoMissingDataLabel": true,
+    "showMissingDataLine": true,
+    "categories": []
   },
   "boxplot": {
     "plots": [],
     "borders": "true",
-    "firstQuartilePercentage": 25,
-    "thirdQuartilePercentage": 75,
-    "boxWidthPercentage": 40,
     "plotOutlierValues": false,
     "plotNonOutlierValues": true,
-    "legend": {
-      "showHowToReadText": false,
-      "howToReadText": ""
-    },
     "labels": {
       "q1": "Lower Quartile",
       "q2": "q2",
@@ -76,13 +72,23 @@
       "median": "Median",
       "sd": "Standard Deviation",
       "iqr": "Interquartile Range",
-      "count": "Count",
+      "total": "Total",
       "outliers": "Outliers",
-      "values": "Values"
+      "values": "Values",
+      "lowerBounds": "Lower Bounds",
+      "upperBounds": "Upper Bounds",
+      "count": "Count"
+    },
+    "firstQuartilePercentage": 25,
+    "thirdQuartilePercentage": 75,
+    "boxWidthPercentage": 40,
+    "legend": {
+      "showHowToReadText": false,
+      "howToReadText": ""
     }
   },
   "topAxis": {
-    "hasLine": true
+    "hasLine": false
   },
   "isLegendValue": false,
   "barThickness": 0.35,
@@ -93,12 +99,8 @@
     "horizontal": 750
   },
   "xAxis": {
-    "anchors": [
-      {
-        "value": "500",
-        "lineStyle": "dashed-md"
-      }
-    ],
+    "sortDates": false,
+    "anchors": [],
     "type": "date",
     "showTargetLabel": true,
     "targetLabel": "Target",
@@ -106,40 +108,50 @@
     "hideLabel": false,
     "hideTicks": false,
     "size": 75,
-    "tickRotation": 30,
+    "tickRotation": 0,
     "min": "",
     "max": "",
     "labelColor": "#333",
     "tickLabelColor": "#333",
     "tickColor": "#333",
     "numTicks": "",
-    "labelOffset": 65,
+    "labelOffset": 0,
     "axisPadding": 0,
     "target": 0,
     "maxTickRotation": 0,
-    "label": "",
+    "padding": 5,
+    "showYearsOnce": false,
+    "sortByRecentDate": false,
     "dataKey": "date",
     "dateParseFormat": "%m/%d/%Y",
-    "dateDisplayFormat": "%m/%d/%Y"
+    "dateDisplayFormat": "%m/%d/%Y",
+    "axisBBox": 29.360000610351562,
+    "tickWidthMax": 86
   },
   "table": {
     "label": "Data Table",
-    "expanded": false,
+    "expanded": true,
     "limitHeight": false,
     "height": "",
     "caption": "",
     "showDownloadUrl": false,
     "showDataTableLink": true,
+    "showDownloadLinkBelow": true,
     "indexLabel": "",
-    "download": false,
-    "showVertical": false,
+    "download": true,
+    "showVertical": true,
+    "dateDisplayFormat": "",
+    "showMissingDataLabel": true,
+    "showSuppressedSymbol": true,
     "show": true
   },
   "orientation": "vertical",
   "color": "pinkpurple",
   "columns": {},
   "legend": {
+    "hide": false,
     "behavior": "isolate",
+    "axisAlign": true,
     "singleRow": false,
     "colorCode": "",
     "reverseLabelOrder": false,
@@ -149,15 +161,33 @@
     "dynamicLegendItemLimit": 5,
     "dynamicLegendItemLimitMessage": "Dynamic Legend Item Limit Hit.",
     "dynamicLegendChartMessage": "Select Options from the Legend",
+    "label": "",
+    "lineMode": false,
+    "verticalSorted": false,
+    "highlightOnHover": false,
+    "hideSuppressedLabels": false,
+    "hideSuppressionLink": false,
+    "seriesHighlight": [],
+    "style": "circles",
+    "subStyle": "linear blocks",
+    "groupBy": "",
+    "shape": "circle",
+    "tickRotation": "",
+    "order": "dataColumn",
+    "hideBorder": {
+      "side": false,
+      "topBottom": true
+    },
     "position": "right",
-    "hide": false
+    "orderedValues": [],
+    "unified": true
   },
   "exclusions": {
     "active": false,
     "keys": []
   },
-  "palette": "sequential-bluereverse",
-  "isPaletteReversed": true,
+  "palette": "qualitative-bold",
+  "isPaletteReversed": false,
   "twoColor": {
     "palette": "monochrome-1",
     "isPaletteReversed": false
@@ -171,7 +201,7 @@
     "bottomSuffix": "",
     "bottomPrefix": "",
     "bottomAbbreviated": false,
-    "roundTo": "0"
+    "useCommas": false
   },
   "confidenceKeys": {},
   "visual": {
@@ -179,93 +209,5285 @@
     "accent": true,
     "background": true,
     "verticalHoverLine": false,
-    "horizontalHoverLine": false
+    "horizontalHoverLine": false,
+    "lineDatapointSymbol": "none",
+    "maximumShapeAmount": 7
   },
   "useLogScale": false,
   "filterBehavior": "Filter Change",
   "highlightedBarValues": [],
   "series": [
     {
-      "dataKey": "confirm",
-      "type": "Bar",
-      "axis": "Left",
-      "tooltip": true
-    },
-    {
-      "dataKey": "type",
+      "dataKey": "quarter",
       "type": "Forecasting",
-      "axis": "Left",
+      "stages": [
+        {
+          "key": "quarter one",
+          "color": ""
+        },
+        {
+          "key": "quarter two",
+          "color": "qualitative-softreverse"
+        },
+        {
+          "key": "quarter three",
+          "color": "qualitative-softreverse"
+        },
+        {
+          "key": "quarter four",
+          "color": "qualitative4reverse"
+        }
+      ],
+      "stageColumn": "quarter",
       "confidenceIntervals": [
         {
           "high": "upper_90",
           "low": "lower_90"
-        },
-        {
-          "high": "upper_50",
-          "low": "lower_50"
-        },
-        {
-          "high": "upper_20",
-          "low": "lower_20"
         }
       ],
-      "stageColumn": "type",
-      "stageItem": "estimate",
-      "stages": [
-        {
-          "key": "estimate",
-          "color": "sequential-green"
-        },
-        {
-          "key": "estimate based on partial data",
-          "color": "sequential-orange-(MPX)"
-        },
-        {
-          "key": "forecast",
-          "color": "sequential-blue"
-        }
-      ],
+      "tooltip": true,
+      "axis": "Left"
+    },
+    {
+      "dataKey": "random_col",
+      "type": "Line",
+      "axis": "Left",
       "tooltip": true
     }
   ],
   "tooltips": {
-    "opacity": 90
+    "opacity": 90,
+    "singleSeries": false,
+    "dateDisplayFormat": ""
   },
-  "forecastingChart": {
-    "showBars": false,
-    "barColumn": "confirm",
-    "barColor": "#918e90",
-    "confidenceIntervals": [
-      {
-        "low": "lower_20",
-        "high": "upper_20"
-      },
-      {
-        "low": "lower_50",
-        "high": "upper_50"
-      },
-      {
-        "low": "lower_90",
-        "high": "upper_90"
-      },
-      {}
-    ],
-    "stages": "type",
-    "colors": [
-      "sequential-greenreverse",
-      "sequential-orange-(MPX)reverse",
-      "sequential-blue-2-(MPX)reverse"
-    ],
-    "groups": [
-      "estimate",
-      "estimate based on partial data",
-      "forecast"
-    ],
-    "showBarColumn": true
-  },
-  "dataUrl": "./examples/feature/forecasting/case_date_example.csv",
-  "animateReplay": true,
+  "datasets": {},
   "visualizationType": "Combo",
+  "data": [
+    {
+      "date": "1/1/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "67"
+    },
+    {
+      "date": "1/2/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "11"
+    },
+    {
+      "date": "1/3/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "94"
+    },
+    {
+      "date": "1/4/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "95"
+    },
+    {
+      "date": "1/5/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "79"
+    },
+    {
+      "date": "1/6/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "2"
+    },
+    {
+      "date": "1/7/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "36"
+    },
+    {
+      "date": "1/8/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "9"
+    },
+    {
+      "date": "1/9/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "3"
+    },
+    {
+      "date": "1/10/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "64"
+    },
+    {
+      "date": "1/11/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "48"
+    },
+    {
+      "date": "1/12/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "94"
+    },
+    {
+      "date": "1/13/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "38"
+    },
+    {
+      "date": "1/14/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "33"
+    },
+    {
+      "date": "1/15/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "23"
+    },
+    {
+      "date": "1/16/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "13"
+    },
+    {
+      "date": "1/17/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "89"
+    },
+    {
+      "date": "1/18/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "12"
+    },
+    {
+      "date": "1/19/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "24"
+    },
+    {
+      "date": "1/20/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "86"
+    },
+    {
+      "date": "1/21/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "17"
+    },
+    {
+      "date": "1/22/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "37"
+    },
+    {
+      "date": "1/23/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "9"
+    },
+    {
+      "date": "1/24/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "15"
+    },
+    {
+      "date": "1/25/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "7"
+    },
+    {
+      "date": "1/26/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "40"
+    },
+    {
+      "date": "1/27/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "18"
+    },
+    {
+      "date": "1/28/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "67"
+    },
+    {
+      "date": "1/29/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "40"
+    },
+    {
+      "date": "1/30/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "84"
+    },
+    {
+      "date": "1/31/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "81"
+    },
+    {
+      "date": "2/1/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "16"
+    },
+    {
+      "date": "2/2/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "85"
+    },
+    {
+      "date": "2/3/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "48"
+    },
+    {
+      "date": "2/4/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "45"
+    },
+    {
+      "date": "2/5/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "93"
+    },
+    {
+      "date": "2/6/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "77"
+    },
+    {
+      "date": "2/7/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "35"
+    },
+    {
+      "date": "2/8/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "44"
+    },
+    {
+      "date": "2/9/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "57"
+    },
+    {
+      "date": "2/10/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "92"
+    },
+    {
+      "date": "2/11/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "50"
+    },
+    {
+      "date": "2/12/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "81"
+    },
+    {
+      "date": "2/13/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "13"
+    },
+    {
+      "date": "2/14/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "31"
+    },
+    {
+      "date": "2/15/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "52"
+    },
+    {
+      "date": "2/16/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "91"
+    },
+    {
+      "date": "2/17/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "57"
+    },
+    {
+      "date": "2/18/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "79"
+    },
+    {
+      "date": "2/19/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "75"
+    },
+    {
+      "date": "2/20/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "8"
+    },
+    {
+      "date": "2/21/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "11"
+    },
+    {
+      "date": "2/22/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "41"
+    },
+    {
+      "date": "2/23/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "20"
+    },
+    {
+      "date": "2/24/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "80"
+    },
+    {
+      "date": "2/25/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "65"
+    },
+    {
+      "date": "2/26/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "76"
+    },
+    {
+      "date": "2/27/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "11"
+    },
+    {
+      "date": "2/28/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "88"
+    },
+    {
+      "date": "3/1/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "92"
+    },
+    {
+      "date": "3/2/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "53"
+    },
+    {
+      "date": "3/3/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "89"
+    },
+    {
+      "date": "3/4/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "40"
+    },
+    {
+      "date": "3/5/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "26"
+    },
+    {
+      "date": "3/6/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "67"
+    },
+    {
+      "date": "3/7/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "79"
+    },
+    {
+      "date": "3/8/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "13"
+    },
+    {
+      "date": "3/9/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "71"
+    },
+    {
+      "date": "3/10/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "52"
+    },
+    {
+      "date": "3/11/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "69"
+    },
+    {
+      "date": "3/12/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "89"
+    },
+    {
+      "date": "3/13/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "55"
+    },
+    {
+      "date": "3/14/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "77"
+    },
+    {
+      "date": "3/15/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "19"
+    },
+    {
+      "date": "3/16/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "16"
+    },
+    {
+      "date": "3/17/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "33"
+    },
+    {
+      "date": "3/18/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "54"
+    },
+    {
+      "date": "3/19/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "49"
+    },
+    {
+      "date": "3/20/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "29"
+    },
+    {
+      "date": "3/21/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "85"
+    },
+    {
+      "date": "3/22/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "53"
+    },
+    {
+      "date": "3/23/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "25"
+    },
+    {
+      "date": "3/24/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "36"
+    },
+    {
+      "date": "3/25/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "79"
+    },
+    {
+      "date": "3/26/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "100"
+    },
+    {
+      "date": "3/27/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "12"
+    },
+    {
+      "date": "3/28/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "71"
+    },
+    {
+      "date": "3/29/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "46"
+    },
+    {
+      "date": "3/30/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "32"
+    },
+    {
+      "date": "3/31/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "81"
+    },
+    {
+      "date": "4/1/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "4/2/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "84"
+    },
+    {
+      "date": "4/3/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "97"
+    },
+    {
+      "date": "4/4/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "69"
+    },
+    {
+      "date": "4/5/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "76"
+    },
+    {
+      "date": "4/6/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "69"
+    },
+    {
+      "date": "4/7/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "9"
+    },
+    {
+      "date": "4/8/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "53"
+    },
+    {
+      "date": "4/9/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "63"
+    },
+    {
+      "date": "4/10/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "26"
+    },
+    {
+      "date": "4/11/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "9"
+    },
+    {
+      "date": "4/12/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "48"
+    },
+    {
+      "date": "4/13/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "36"
+    },
+    {
+      "date": "4/14/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "29"
+    },
+    {
+      "date": "4/15/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "66"
+    },
+    {
+      "date": "4/16/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "53"
+    },
+    {
+      "date": "4/17/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "10"
+    },
+    {
+      "date": "4/18/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "62"
+    },
+    {
+      "date": "4/19/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "84"
+    },
+    {
+      "date": "4/20/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "88"
+    },
+    {
+      "date": "4/21/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "27"
+    },
+    {
+      "date": "4/22/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "81"
+    },
+    {
+      "date": "4/23/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "16"
+    },
+    {
+      "date": "4/24/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "95"
+    },
+    {
+      "date": "4/25/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "80"
+    },
+    {
+      "date": "4/26/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "53"
+    },
+    {
+      "date": "4/27/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "65"
+    },
+    {
+      "date": "4/28/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "39"
+    },
+    {
+      "date": "4/29/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "1"
+    },
+    {
+      "date": "4/30/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "37"
+    },
+    {
+      "date": "5/1/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "5/2/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "88"
+    },
+    {
+      "date": "5/3/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "75"
+    },
+    {
+      "date": "5/4/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "80"
+    },
+    {
+      "date": "5/5/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "45"
+    },
+    {
+      "date": "5/6/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "5/7/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "8"
+    },
+    {
+      "date": "5/8/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "2"
+    },
+    {
+      "date": "5/9/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "41"
+    },
+    {
+      "date": "5/10/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "42"
+    },
+    {
+      "date": "5/11/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "88"
+    },
+    {
+      "date": "5/12/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "94"
+    },
+    {
+      "date": "5/13/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "31"
+    },
+    {
+      "date": "5/14/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "19"
+    },
+    {
+      "date": "5/15/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "62"
+    },
+    {
+      "date": "5/16/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "62"
+    },
+    {
+      "date": "5/17/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "33"
+    },
+    {
+      "date": "5/18/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "86"
+    },
+    {
+      "date": "5/19/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "36"
+    },
+    {
+      "date": "5/20/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "82"
+    },
+    {
+      "date": "5/21/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "52"
+    },
+    {
+      "date": "5/22/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "64"
+    },
+    {
+      "date": "5/23/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "82"
+    },
+    {
+      "date": "5/24/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "85"
+    },
+    {
+      "date": "5/25/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "87"
+    },
+    {
+      "date": "5/26/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "23"
+    },
+    {
+      "date": "5/27/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "61"
+    },
+    {
+      "date": "5/28/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "64"
+    },
+    {
+      "date": "5/29/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "14"
+    },
+    {
+      "date": "5/30/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "73"
+    },
+    {
+      "date": "5/31/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "92"
+    },
+    {
+      "date": "6/1/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "85"
+    },
+    {
+      "date": "6/2/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "75"
+    },
+    {
+      "date": "6/3/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "67"
+    },
+    {
+      "date": "6/4/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "39"
+    },
+    {
+      "date": "6/5/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "39"
+    },
+    {
+      "date": "6/6/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "92"
+    },
+    {
+      "date": "6/7/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "6/8/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "48"
+    },
+    {
+      "date": "6/9/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "69"
+    },
+    {
+      "date": "6/10/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "74"
+    },
+    {
+      "date": "6/11/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "40"
+    },
+    {
+      "date": "6/12/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "34"
+    },
+    {
+      "date": "6/13/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "38"
+    },
+    {
+      "date": "6/14/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "14"
+    },
+    {
+      "date": "6/15/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "42"
+    },
+    {
+      "date": "6/16/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "16"
+    },
+    {
+      "date": "6/17/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "47"
+    },
+    {
+      "date": "6/18/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "43"
+    },
+    {
+      "date": "6/19/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "28"
+    },
+    {
+      "date": "6/20/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "88"
+    },
+    {
+      "date": "6/21/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "6/22/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "63"
+    },
+    {
+      "date": "6/23/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "43"
+    },
+    {
+      "date": "6/24/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "47"
+    },
+    {
+      "date": "6/25/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "80"
+    },
+    {
+      "date": "6/26/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "6"
+    },
+    {
+      "date": "6/27/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "13"
+    },
+    {
+      "date": "6/28/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "39"
+    },
+    {
+      "date": "6/29/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "62"
+    },
+    {
+      "date": "6/30/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "26"
+    },
+    {
+      "date": "7/1/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "96"
+    },
+    {
+      "date": "7/2/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "0"
+    },
+    {
+      "date": "7/3/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "24"
+    },
+    {
+      "date": "7/4/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "4"
+    },
+    {
+      "date": "7/5/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "39"
+    },
+    {
+      "date": "7/6/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "1"
+    },
+    {
+      "date": "7/7/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "18"
+    },
+    {
+      "date": "7/8/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "38"
+    },
+    {
+      "date": "7/9/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "92"
+    },
+    {
+      "date": "7/10/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "11"
+    },
+    {
+      "date": "7/11/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "48"
+    },
+    {
+      "date": "7/12/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "62"
+    },
+    {
+      "date": "7/13/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "82"
+    },
+    {
+      "date": "7/14/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "55"
+    },
+    {
+      "date": "7/15/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "63"
+    },
+    {
+      "date": "7/16/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "26"
+    },
+    {
+      "date": "7/17/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "26"
+    },
+    {
+      "date": "7/18/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "22"
+    },
+    {
+      "date": "7/19/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "65"
+    },
+    {
+      "date": "7/20/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "1"
+    },
+    {
+      "date": "7/21/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "16"
+    },
+    {
+      "date": "7/22/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "20"
+    },
+    {
+      "date": "7/23/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "44"
+    },
+    {
+      "date": "7/24/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "38"
+    },
+    {
+      "date": "7/25/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "33"
+    },
+    {
+      "date": "7/26/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "9"
+    },
+    {
+      "date": "7/27/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "8"
+    },
+    {
+      "date": "7/28/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "70"
+    },
+    {
+      "date": "7/29/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "16"
+    },
+    {
+      "date": "7/30/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "26"
+    },
+    {
+      "date": "7/31/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "93"
+    },
+    {
+      "date": "8/1/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "5"
+    },
+    {
+      "date": "8/2/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "9"
+    },
+    {
+      "date": "8/3/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "66"
+    },
+    {
+      "date": "8/4/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "15"
+    },
+    {
+      "date": "8/5/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "3"
+    },
+    {
+      "date": "8/6/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "28"
+    },
+    {
+      "date": "8/7/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "93"
+    },
+    {
+      "date": "8/8/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "88"
+    },
+    {
+      "date": "8/9/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "87"
+    },
+    {
+      "date": "8/10/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "27"
+    },
+    {
+      "date": "8/11/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "51"
+    },
+    {
+      "date": "8/12/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "25"
+    },
+    {
+      "date": "8/13/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "6"
+    },
+    {
+      "date": "8/14/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "87"
+    },
+    {
+      "date": "8/15/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "83"
+    },
+    {
+      "date": "8/16/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "61"
+    },
+    {
+      "date": "8/17/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "93"
+    },
+    {
+      "date": "8/18/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "91"
+    },
+    {
+      "date": "8/19/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "87"
+    },
+    {
+      "date": "8/20/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "99"
+    },
+    {
+      "date": "8/21/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "27"
+    },
+    {
+      "date": "8/22/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "91"
+    },
+    {
+      "date": "8/23/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "100"
+    },
+    {
+      "date": "8/24/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "36"
+    },
+    {
+      "date": "8/25/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "73"
+    },
+    {
+      "date": "8/26/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "73"
+    },
+    {
+      "date": "8/27/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "80"
+    },
+    {
+      "date": "8/28/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "100"
+    },
+    {
+      "date": "8/29/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "84"
+    },
+    {
+      "date": "8/30/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "40"
+    },
+    {
+      "date": "8/31/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "30"
+    },
+    {
+      "date": "9/1/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "6"
+    },
+    {
+      "date": "9/2/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "26"
+    },
+    {
+      "date": "9/3/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "45"
+    },
+    {
+      "date": "9/4/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "1"
+    },
+    {
+      "date": "9/5/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "14"
+    },
+    {
+      "date": "9/6/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "44"
+    },
+    {
+      "date": "9/7/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "93"
+    },
+    {
+      "date": "9/8/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "63"
+    },
+    {
+      "date": "9/9/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "65"
+    },
+    {
+      "date": "9/10/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "79"
+    },
+    {
+      "date": "9/11/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "90"
+    },
+    {
+      "date": "9/12/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "23"
+    },
+    {
+      "date": "9/13/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "95"
+    },
+    {
+      "date": "9/14/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "64"
+    },
+    {
+      "date": "9/15/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "32"
+    },
+    {
+      "date": "9/16/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "39"
+    },
+    {
+      "date": "9/17/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "67"
+    },
+    {
+      "date": "9/18/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "9"
+    },
+    {
+      "date": "9/19/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "48"
+    },
+    {
+      "date": "9/20/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "49"
+    },
+    {
+      "date": "9/21/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "56"
+    },
+    {
+      "date": "9/22/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "59"
+    },
+    {
+      "date": "9/23/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "0"
+    },
+    {
+      "date": "9/24/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "94"
+    },
+    {
+      "date": "9/25/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "86"
+    },
+    {
+      "date": "9/26/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "37"
+    },
+    {
+      "date": "9/27/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "50"
+    },
+    {
+      "date": "9/28/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "31"
+    },
+    {
+      "date": "9/29/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "44"
+    },
+    {
+      "date": "9/30/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "48"
+    },
+    {
+      "date": "10/1/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "76"
+    },
+    {
+      "date": "10/2/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "14"
+    },
+    {
+      "date": "10/3/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "76"
+    },
+    {
+      "date": "10/4/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "12"
+    },
+    {
+      "date": "10/5/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "25"
+    },
+    {
+      "date": "10/6/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "86"
+    },
+    {
+      "date": "10/7/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "69"
+    },
+    {
+      "date": "10/8/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "86"
+    },
+    {
+      "date": "10/9/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "99"
+    },
+    {
+      "date": "10/10/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "24"
+    },
+    {
+      "date": "10/11/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "69"
+    },
+    {
+      "date": "10/12/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "42"
+    },
+    {
+      "date": "10/13/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "1"
+    },
+    {
+      "date": "10/14/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "72"
+    },
+    {
+      "date": "10/15/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "85"
+    },
+    {
+      "date": "10/16/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "2"
+    },
+    {
+      "date": "10/17/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "42"
+    },
+    {
+      "date": "10/18/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "55"
+    },
+    {
+      "date": "10/19/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "59"
+    },
+    {
+      "date": "10/20/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "71"
+    },
+    {
+      "date": "10/21/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "19"
+    },
+    {
+      "date": "10/22/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "43"
+    },
+    {
+      "date": "10/23/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "29"
+    },
+    {
+      "date": "10/24/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "78"
+    },
+    {
+      "date": "10/25/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "21"
+    },
+    {
+      "date": "10/26/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "76"
+    },
+    {
+      "date": "10/27/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "65"
+    },
+    {
+      "date": "10/28/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "88"
+    },
+    {
+      "date": "10/29/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "41"
+    },
+    {
+      "date": "10/30/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "31"
+    },
+    {
+      "date": "10/31/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "71"
+    },
+    {
+      "date": "11/1/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "59"
+    },
+    {
+      "date": "11/2/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "65"
+    },
+    {
+      "date": "11/3/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "91"
+    },
+    {
+      "date": "11/4/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "60"
+    },
+    {
+      "date": "11/5/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "22"
+    },
+    {
+      "date": "11/6/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "26"
+    },
+    {
+      "date": "11/7/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "10"
+    },
+    {
+      "date": "11/8/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "39"
+    },
+    {
+      "date": "11/9/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "67"
+    },
+    {
+      "date": "11/10/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "0"
+    },
+    {
+      "date": "11/11/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "19"
+    },
+    {
+      "date": "11/12/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "9"
+    },
+    {
+      "date": "11/13/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "70"
+    },
+    {
+      "date": "11/14/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "86"
+    },
+    {
+      "date": "11/15/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "40"
+    },
+    {
+      "date": "11/16/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "7"
+    },
+    {
+      "date": "11/17/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "57"
+    },
+    {
+      "date": "11/18/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "16"
+    },
+    {
+      "date": "11/19/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "24"
+    },
+    {
+      "date": "11/20/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "68"
+    },
+    {
+      "date": "11/21/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "36"
+    },
+    {
+      "date": "11/22/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "62"
+    },
+    {
+      "date": "11/23/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "96"
+    },
+    {
+      "date": "11/24/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "75"
+    },
+    {
+      "date": "11/25/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "55"
+    },
+    {
+      "date": "11/26/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "14"
+    },
+    {
+      "date": "11/27/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "60"
+    },
+    {
+      "date": "11/28/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "23"
+    },
+    {
+      "date": "11/29/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "8"
+    },
+    {
+      "date": "11/30/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "82"
+    },
+    {
+      "date": "12/1/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "27"
+    },
+    {
+      "date": "12/2/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "67"
+    },
+    {
+      "date": "12/3/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "47"
+    },
+    {
+      "date": "12/4/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "73"
+    },
+    {
+      "date": "12/5/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "33"
+    },
+    {
+      "date": "12/6/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "73"
+    },
+    {
+      "date": "12/7/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "85"
+    },
+    {
+      "date": "12/8/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "83"
+    },
+    {
+      "date": "12/9/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "14"
+    },
+    {
+      "date": "12/10/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "32"
+    },
+    {
+      "date": "12/11/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "13"
+    },
+    {
+      "date": "12/12/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "58"
+    },
+    {
+      "date": "12/13/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "21"
+    },
+    {
+      "date": "12/14/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "92"
+    },
+    {
+      "date": "12/15/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "28"
+    },
+    {
+      "date": "12/16/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "12"
+    },
+    {
+      "date": "12/17/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "3"
+    },
+    {
+      "date": "12/18/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "30"
+    },
+    {
+      "date": "12/19/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "39"
+    },
+    {
+      "date": "12/20/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "64"
+    },
+    {
+      "date": "12/21/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "84"
+    },
+    {
+      "date": "12/22/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "19"
+    },
+    {
+      "date": "12/23/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "11"
+    },
+    {
+      "date": "12/24/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "41"
+    },
+    {
+      "date": "12/25/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "39"
+    },
+    {
+      "date": "12/26/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "22"
+    },
+    {
+      "date": "12/27/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "32"
+    },
+    {
+      "date": "12/28/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "99"
+    },
+    {
+      "date": "12/29/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "56"
+    },
+    {
+      "date": "12/30/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "56"
+    },
+    {
+      "date": "12/31/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "76"
+    }
+  ],
+  "dataFileName": "valid-forecast-data.csv",
+  "dataFileSourceType": "file",
+  "formattedData": [
+    {
+      "date": "1/1/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "67"
+    },
+    {
+      "date": "1/2/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "11"
+    },
+    {
+      "date": "1/3/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "94"
+    },
+    {
+      "date": "1/4/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "95"
+    },
+    {
+      "date": "1/5/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "79"
+    },
+    {
+      "date": "1/6/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "2"
+    },
+    {
+      "date": "1/7/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "36"
+    },
+    {
+      "date": "1/8/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "9"
+    },
+    {
+      "date": "1/9/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "3"
+    },
+    {
+      "date": "1/10/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "64"
+    },
+    {
+      "date": "1/11/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "48"
+    },
+    {
+      "date": "1/12/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "94"
+    },
+    {
+      "date": "1/13/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "38"
+    },
+    {
+      "date": "1/14/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "33"
+    },
+    {
+      "date": "1/15/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "23"
+    },
+    {
+      "date": "1/16/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "13"
+    },
+    {
+      "date": "1/17/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "89"
+    },
+    {
+      "date": "1/18/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "12"
+    },
+    {
+      "date": "1/19/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "24"
+    },
+    {
+      "date": "1/20/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "86"
+    },
+    {
+      "date": "1/21/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "17"
+    },
+    {
+      "date": "1/22/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "37"
+    },
+    {
+      "date": "1/23/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "9"
+    },
+    {
+      "date": "1/24/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "15"
+    },
+    {
+      "date": "1/25/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "7"
+    },
+    {
+      "date": "1/26/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "40"
+    },
+    {
+      "date": "1/27/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "18"
+    },
+    {
+      "date": "1/28/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "67"
+    },
+    {
+      "date": "1/29/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "40"
+    },
+    {
+      "date": "1/30/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "84"
+    },
+    {
+      "date": "1/31/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "81"
+    },
+    {
+      "date": "2/1/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "16"
+    },
+    {
+      "date": "2/2/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "85"
+    },
+    {
+      "date": "2/3/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "48"
+    },
+    {
+      "date": "2/4/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "45"
+    },
+    {
+      "date": "2/5/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "93"
+    },
+    {
+      "date": "2/6/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "77"
+    },
+    {
+      "date": "2/7/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "35"
+    },
+    {
+      "date": "2/8/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "44"
+    },
+    {
+      "date": "2/9/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "57"
+    },
+    {
+      "date": "2/10/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "92"
+    },
+    {
+      "date": "2/11/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "50"
+    },
+    {
+      "date": "2/12/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "81"
+    },
+    {
+      "date": "2/13/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "13"
+    },
+    {
+      "date": "2/14/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "31"
+    },
+    {
+      "date": "2/15/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "52"
+    },
+    {
+      "date": "2/16/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "91"
+    },
+    {
+      "date": "2/17/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "57"
+    },
+    {
+      "date": "2/18/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "79"
+    },
+    {
+      "date": "2/19/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "75"
+    },
+    {
+      "date": "2/20/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "8"
+    },
+    {
+      "date": "2/21/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "11"
+    },
+    {
+      "date": "2/22/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "41"
+    },
+    {
+      "date": "2/23/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "20"
+    },
+    {
+      "date": "2/24/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "80"
+    },
+    {
+      "date": "2/25/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "65"
+    },
+    {
+      "date": "2/26/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "76"
+    },
+    {
+      "date": "2/27/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "11"
+    },
+    {
+      "date": "2/28/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "88"
+    },
+    {
+      "date": "3/1/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "92"
+    },
+    {
+      "date": "3/2/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "53"
+    },
+    {
+      "date": "3/3/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "89"
+    },
+    {
+      "date": "3/4/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "40"
+    },
+    {
+      "date": "3/5/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "26"
+    },
+    {
+      "date": "3/6/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "67"
+    },
+    {
+      "date": "3/7/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "79"
+    },
+    {
+      "date": "3/8/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "13"
+    },
+    {
+      "date": "3/9/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "71"
+    },
+    {
+      "date": "3/10/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "52"
+    },
+    {
+      "date": "3/11/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "69"
+    },
+    {
+      "date": "3/12/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "89"
+    },
+    {
+      "date": "3/13/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "55"
+    },
+    {
+      "date": "3/14/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "77"
+    },
+    {
+      "date": "3/15/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "19"
+    },
+    {
+      "date": "3/16/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "16"
+    },
+    {
+      "date": "3/17/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "33"
+    },
+    {
+      "date": "3/18/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "54"
+    },
+    {
+      "date": "3/19/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "49"
+    },
+    {
+      "date": "3/20/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "29"
+    },
+    {
+      "date": "3/21/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "85"
+    },
+    {
+      "date": "3/22/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "53"
+    },
+    {
+      "date": "3/23/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "25"
+    },
+    {
+      "date": "3/24/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "36"
+    },
+    {
+      "date": "3/25/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "79"
+    },
+    {
+      "date": "3/26/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "100"
+    },
+    {
+      "date": "3/27/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "12"
+    },
+    {
+      "date": "3/28/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "71"
+    },
+    {
+      "date": "3/29/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "46"
+    },
+    {
+      "date": "3/30/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "32"
+    },
+    {
+      "date": "3/31/2023",
+      "quarter": "quarter one",
+      "upper_90": "90",
+      "lower_90": "10",
+      "random_col": "81"
+    },
+    {
+      "date": "4/1/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "4/2/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "84"
+    },
+    {
+      "date": "4/3/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "97"
+    },
+    {
+      "date": "4/4/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "69"
+    },
+    {
+      "date": "4/5/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "76"
+    },
+    {
+      "date": "4/6/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "69"
+    },
+    {
+      "date": "4/7/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "9"
+    },
+    {
+      "date": "4/8/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "53"
+    },
+    {
+      "date": "4/9/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "63"
+    },
+    {
+      "date": "4/10/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "26"
+    },
+    {
+      "date": "4/11/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "9"
+    },
+    {
+      "date": "4/12/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "48"
+    },
+    {
+      "date": "4/13/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "36"
+    },
+    {
+      "date": "4/14/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "29"
+    },
+    {
+      "date": "4/15/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "66"
+    },
+    {
+      "date": "4/16/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "53"
+    },
+    {
+      "date": "4/17/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "10"
+    },
+    {
+      "date": "4/18/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "62"
+    },
+    {
+      "date": "4/19/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "84"
+    },
+    {
+      "date": "4/20/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "88"
+    },
+    {
+      "date": "4/21/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "27"
+    },
+    {
+      "date": "4/22/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "81"
+    },
+    {
+      "date": "4/23/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "16"
+    },
+    {
+      "date": "4/24/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "95"
+    },
+    {
+      "date": "4/25/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "80"
+    },
+    {
+      "date": "4/26/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "53"
+    },
+    {
+      "date": "4/27/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "65"
+    },
+    {
+      "date": "4/28/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "39"
+    },
+    {
+      "date": "4/29/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "1"
+    },
+    {
+      "date": "4/30/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "37"
+    },
+    {
+      "date": "5/1/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "5/2/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "88"
+    },
+    {
+      "date": "5/3/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "75"
+    },
+    {
+      "date": "5/4/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "80"
+    },
+    {
+      "date": "5/5/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "45"
+    },
+    {
+      "date": "5/6/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "5/7/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "8"
+    },
+    {
+      "date": "5/8/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "2"
+    },
+    {
+      "date": "5/9/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "41"
+    },
+    {
+      "date": "5/10/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "42"
+    },
+    {
+      "date": "5/11/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "88"
+    },
+    {
+      "date": "5/12/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "94"
+    },
+    {
+      "date": "5/13/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "31"
+    },
+    {
+      "date": "5/14/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "19"
+    },
+    {
+      "date": "5/15/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "62"
+    },
+    {
+      "date": "5/16/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "62"
+    },
+    {
+      "date": "5/17/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "33"
+    },
+    {
+      "date": "5/18/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "86"
+    },
+    {
+      "date": "5/19/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "36"
+    },
+    {
+      "date": "5/20/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "82"
+    },
+    {
+      "date": "5/21/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "52"
+    },
+    {
+      "date": "5/22/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "64"
+    },
+    {
+      "date": "5/23/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "82"
+    },
+    {
+      "date": "5/24/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "85"
+    },
+    {
+      "date": "5/25/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "87"
+    },
+    {
+      "date": "5/26/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "23"
+    },
+    {
+      "date": "5/27/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "61"
+    },
+    {
+      "date": "5/28/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "64"
+    },
+    {
+      "date": "5/29/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "14"
+    },
+    {
+      "date": "5/30/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "73"
+    },
+    {
+      "date": "5/31/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "92"
+    },
+    {
+      "date": "6/1/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "85"
+    },
+    {
+      "date": "6/2/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "75"
+    },
+    {
+      "date": "6/3/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "67"
+    },
+    {
+      "date": "6/4/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "39"
+    },
+    {
+      "date": "6/5/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "39"
+    },
+    {
+      "date": "6/6/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "92"
+    },
+    {
+      "date": "6/7/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "6/8/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "48"
+    },
+    {
+      "date": "6/9/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "69"
+    },
+    {
+      "date": "6/10/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "74"
+    },
+    {
+      "date": "6/11/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "40"
+    },
+    {
+      "date": "6/12/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "34"
+    },
+    {
+      "date": "6/13/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "38"
+    },
+    {
+      "date": "6/14/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "14"
+    },
+    {
+      "date": "6/15/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "42"
+    },
+    {
+      "date": "6/16/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "16"
+    },
+    {
+      "date": "6/17/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "47"
+    },
+    {
+      "date": "6/18/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "43"
+    },
+    {
+      "date": "6/19/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "28"
+    },
+    {
+      "date": "6/20/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "88"
+    },
+    {
+      "date": "6/21/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "70"
+    },
+    {
+      "date": "6/22/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "63"
+    },
+    {
+      "date": "6/23/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "43"
+    },
+    {
+      "date": "6/24/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "47"
+    },
+    {
+      "date": "6/25/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "80"
+    },
+    {
+      "date": "6/26/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "6"
+    },
+    {
+      "date": "6/27/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "13"
+    },
+    {
+      "date": "6/28/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "39"
+    },
+    {
+      "date": "6/29/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "62"
+    },
+    {
+      "date": "6/30/2023",
+      "quarter": "quarter two",
+      "upper_90": "80",
+      "lower_90": "20",
+      "random_col": "26"
+    },
+    {
+      "date": "7/1/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "96"
+    },
+    {
+      "date": "7/2/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "0"
+    },
+    {
+      "date": "7/3/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "24"
+    },
+    {
+      "date": "7/4/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "4"
+    },
+    {
+      "date": "7/5/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "39"
+    },
+    {
+      "date": "7/6/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "1"
+    },
+    {
+      "date": "7/7/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "18"
+    },
+    {
+      "date": "7/8/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "38"
+    },
+    {
+      "date": "7/9/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "92"
+    },
+    {
+      "date": "7/10/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "11"
+    },
+    {
+      "date": "7/11/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "48"
+    },
+    {
+      "date": "7/12/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "62"
+    },
+    {
+      "date": "7/13/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "82"
+    },
+    {
+      "date": "7/14/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "55"
+    },
+    {
+      "date": "7/15/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "63"
+    },
+    {
+      "date": "7/16/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "26"
+    },
+    {
+      "date": "7/17/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "26"
+    },
+    {
+      "date": "7/18/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "22"
+    },
+    {
+      "date": "7/19/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "65"
+    },
+    {
+      "date": "7/20/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "1"
+    },
+    {
+      "date": "7/21/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "16"
+    },
+    {
+      "date": "7/22/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "20"
+    },
+    {
+      "date": "7/23/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "44"
+    },
+    {
+      "date": "7/24/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "38"
+    },
+    {
+      "date": "7/25/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "33"
+    },
+    {
+      "date": "7/26/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "9"
+    },
+    {
+      "date": "7/27/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "8"
+    },
+    {
+      "date": "7/28/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "70"
+    },
+    {
+      "date": "7/29/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "16"
+    },
+    {
+      "date": "7/30/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "26"
+    },
+    {
+      "date": "7/31/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "93"
+    },
+    {
+      "date": "8/1/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "5"
+    },
+    {
+      "date": "8/2/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "9"
+    },
+    {
+      "date": "8/3/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "66"
+    },
+    {
+      "date": "8/4/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "15"
+    },
+    {
+      "date": "8/5/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "3"
+    },
+    {
+      "date": "8/6/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "28"
+    },
+    {
+      "date": "8/7/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "93"
+    },
+    {
+      "date": "8/8/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "88"
+    },
+    {
+      "date": "8/9/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "87"
+    },
+    {
+      "date": "8/10/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "27"
+    },
+    {
+      "date": "8/11/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "51"
+    },
+    {
+      "date": "8/12/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "25"
+    },
+    {
+      "date": "8/13/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "6"
+    },
+    {
+      "date": "8/14/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "87"
+    },
+    {
+      "date": "8/15/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "83"
+    },
+    {
+      "date": "8/16/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "61"
+    },
+    {
+      "date": "8/17/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "93"
+    },
+    {
+      "date": "8/18/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "91"
+    },
+    {
+      "date": "8/19/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "87"
+    },
+    {
+      "date": "8/20/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "99"
+    },
+    {
+      "date": "8/21/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "27"
+    },
+    {
+      "date": "8/22/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "91"
+    },
+    {
+      "date": "8/23/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "100"
+    },
+    {
+      "date": "8/24/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "36"
+    },
+    {
+      "date": "8/25/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "73"
+    },
+    {
+      "date": "8/26/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "73"
+    },
+    {
+      "date": "8/27/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "80"
+    },
+    {
+      "date": "8/28/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "100"
+    },
+    {
+      "date": "8/29/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "84"
+    },
+    {
+      "date": "8/30/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "40"
+    },
+    {
+      "date": "8/31/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "30"
+    },
+    {
+      "date": "9/1/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "6"
+    },
+    {
+      "date": "9/2/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "26"
+    },
+    {
+      "date": "9/3/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "45"
+    },
+    {
+      "date": "9/4/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "1"
+    },
+    {
+      "date": "9/5/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "14"
+    },
+    {
+      "date": "9/6/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "44"
+    },
+    {
+      "date": "9/7/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "93"
+    },
+    {
+      "date": "9/8/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "63"
+    },
+    {
+      "date": "9/9/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "65"
+    },
+    {
+      "date": "9/10/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "79"
+    },
+    {
+      "date": "9/11/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "90"
+    },
+    {
+      "date": "9/12/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "23"
+    },
+    {
+      "date": "9/13/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "95"
+    },
+    {
+      "date": "9/14/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "64"
+    },
+    {
+      "date": "9/15/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "32"
+    },
+    {
+      "date": "9/16/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "39"
+    },
+    {
+      "date": "9/17/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "67"
+    },
+    {
+      "date": "9/18/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "9"
+    },
+    {
+      "date": "9/19/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "48"
+    },
+    {
+      "date": "9/20/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "49"
+    },
+    {
+      "date": "9/21/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "56"
+    },
+    {
+      "date": "9/22/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "59"
+    },
+    {
+      "date": "9/23/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "0"
+    },
+    {
+      "date": "9/24/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "94"
+    },
+    {
+      "date": "9/25/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "86"
+    },
+    {
+      "date": "9/26/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "37"
+    },
+    {
+      "date": "9/27/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "50"
+    },
+    {
+      "date": "9/28/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "31"
+    },
+    {
+      "date": "9/29/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "44"
+    },
+    {
+      "date": "9/30/2023",
+      "quarter": "quarter three",
+      "upper_90": "70",
+      "lower_90": "30",
+      "random_col": "48"
+    },
+    {
+      "date": "10/1/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "76"
+    },
+    {
+      "date": "10/2/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "14"
+    },
+    {
+      "date": "10/3/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "76"
+    },
+    {
+      "date": "10/4/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "12"
+    },
+    {
+      "date": "10/5/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "25"
+    },
+    {
+      "date": "10/6/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "86"
+    },
+    {
+      "date": "10/7/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "69"
+    },
+    {
+      "date": "10/8/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "86"
+    },
+    {
+      "date": "10/9/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "99"
+    },
+    {
+      "date": "10/10/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "24"
+    },
+    {
+      "date": "10/11/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "69"
+    },
+    {
+      "date": "10/12/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "42"
+    },
+    {
+      "date": "10/13/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "1"
+    },
+    {
+      "date": "10/14/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "72"
+    },
+    {
+      "date": "10/15/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "85"
+    },
+    {
+      "date": "10/16/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "2"
+    },
+    {
+      "date": "10/17/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "42"
+    },
+    {
+      "date": "10/18/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "55"
+    },
+    {
+      "date": "10/19/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "59"
+    },
+    {
+      "date": "10/20/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "71"
+    },
+    {
+      "date": "10/21/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "19"
+    },
+    {
+      "date": "10/22/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "43"
+    },
+    {
+      "date": "10/23/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "29"
+    },
+    {
+      "date": "10/24/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "78"
+    },
+    {
+      "date": "10/25/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "21"
+    },
+    {
+      "date": "10/26/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "76"
+    },
+    {
+      "date": "10/27/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "65"
+    },
+    {
+      "date": "10/28/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "88"
+    },
+    {
+      "date": "10/29/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "41"
+    },
+    {
+      "date": "10/30/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "31"
+    },
+    {
+      "date": "10/31/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "71"
+    },
+    {
+      "date": "11/1/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "59"
+    },
+    {
+      "date": "11/2/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "65"
+    },
+    {
+      "date": "11/3/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "91"
+    },
+    {
+      "date": "11/4/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "60"
+    },
+    {
+      "date": "11/5/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "22"
+    },
+    {
+      "date": "11/6/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "26"
+    },
+    {
+      "date": "11/7/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "10"
+    },
+    {
+      "date": "11/8/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "39"
+    },
+    {
+      "date": "11/9/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "67"
+    },
+    {
+      "date": "11/10/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "0"
+    },
+    {
+      "date": "11/11/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "19"
+    },
+    {
+      "date": "11/12/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "9"
+    },
+    {
+      "date": "11/13/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "70"
+    },
+    {
+      "date": "11/14/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "86"
+    },
+    {
+      "date": "11/15/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "40"
+    },
+    {
+      "date": "11/16/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "7"
+    },
+    {
+      "date": "11/17/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "57"
+    },
+    {
+      "date": "11/18/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "16"
+    },
+    {
+      "date": "11/19/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "24"
+    },
+    {
+      "date": "11/20/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "68"
+    },
+    {
+      "date": "11/21/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "36"
+    },
+    {
+      "date": "11/22/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "62"
+    },
+    {
+      "date": "11/23/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "96"
+    },
+    {
+      "date": "11/24/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "75"
+    },
+    {
+      "date": "11/25/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "55"
+    },
+    {
+      "date": "11/26/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "14"
+    },
+    {
+      "date": "11/27/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "60"
+    },
+    {
+      "date": "11/28/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "23"
+    },
+    {
+      "date": "11/29/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "8"
+    },
+    {
+      "date": "11/30/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "82"
+    },
+    {
+      "date": "12/1/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "27"
+    },
+    {
+      "date": "12/2/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "67"
+    },
+    {
+      "date": "12/3/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "47"
+    },
+    {
+      "date": "12/4/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "73"
+    },
+    {
+      "date": "12/5/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "33"
+    },
+    {
+      "date": "12/6/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "73"
+    },
+    {
+      "date": "12/7/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "85"
+    },
+    {
+      "date": "12/8/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "83"
+    },
+    {
+      "date": "12/9/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "14"
+    },
+    {
+      "date": "12/10/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "32"
+    },
+    {
+      "date": "12/11/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "13"
+    },
+    {
+      "date": "12/12/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "58"
+    },
+    {
+      "date": "12/13/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "21"
+    },
+    {
+      "date": "12/14/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "92"
+    },
+    {
+      "date": "12/15/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "28"
+    },
+    {
+      "date": "12/16/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "12"
+    },
+    {
+      "date": "12/17/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "3"
+    },
+    {
+      "date": "12/18/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "30"
+    },
+    {
+      "date": "12/19/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "39"
+    },
+    {
+      "date": "12/20/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "64"
+    },
+    {
+      "date": "12/21/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "84"
+    },
+    {
+      "date": "12/22/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "19"
+    },
+    {
+      "date": "12/23/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "11"
+    },
+    {
+      "date": "12/24/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "41"
+    },
+    {
+      "date": "12/25/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "39"
+    },
+    {
+      "date": "12/26/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "22"
+    },
+    {
+      "date": "12/27/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "32"
+    },
+    {
+      "date": "12/28/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "99"
+    },
+    {
+      "date": "12/29/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "56"
+    },
+    {
+      "date": "12/30/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "56"
+    },
+    {
+      "date": "12/31/2023",
+      "quarter": "quarter four",
+      "upper_90": "60",
+      "lower_90": "40",
+      "random_col": "76"
+    }
+  ],
+  "dataDescription": {
+    "horizontal": false,
+    "series": false
+  },
   "validated": 4.23,
-  "dynamicMarginTop": 0
+  "dynamicMarginTop": 0,
+  "annotations": [],
+  "allowLineToBarGraph": "__​undefined__",
+  "debugSvg": false,
+  "chartMessage": {
+    "noData": "No Data Available"
+  },
+  "lineDatapointColor": "Same as Line",
+  "preliminaryData": [],
+  "brush": {
+    "height": 45,
+    "active": false
+  },
+  "filters": [],
+  "forestPlot": {
+    "startAt": 0,
+    "colors": {
+      "line": "",
+      "shape": ""
+    },
+    "lineOfNoEffect": {
+      "show": true
+    },
+    "type": "",
+    "pooledResult": {
+      "diamondHeight": 5,
+      "column": ""
+    },
+    "estimateField": "",
+    "estimateRadius": "",
+    "shape": "square",
+    "rowHeight": 20,
+    "description": {
+      "show": true,
+      "text": "description",
+      "location": 0
+    },
+    "result": {
+      "show": true,
+      "text": "result",
+      "location": 100
+    },
+    "radius": {
+      "min": 2,
+      "max": 10,
+      "scalingColumn": ""
+    },
+    "regression": {
+      "lower": 0,
+      "upper": 0,
+      "estimateField": 0
+    },
+    "leftWidthOffset": 0,
+    "rightWidthOffset": 0,
+    "showZeroLine": false,
+    "leftLabel": "",
+    "rightLabel": ""
+  },
+  "area": {
+    "isStacked": false
+  },
+  "sankey": {
+    "title": {
+      "defaultColor": "black"
+    },
+    "iterations": 1,
+    "rxValue": 0.9,
+    "overallSize": {
+      "width": 900,
+      "height": 700
+    },
+    "margin": {
+      "margin_y": 25,
+      "margin_x": 0
+    },
+    "nodeSize": {
+      "nodeWidth": 26,
+      "nodeHeight": 40
+    },
+    "nodePadding": 55,
+    "nodeFontColor": "black",
+    "nodeColor": {
+      "default": "#ff8500",
+      "inactive": "#808080"
+    },
+    "linkColor": {
+      "default": "#ffc900",
+      "inactive": "#D3D3D3"
+    },
+    "opacity": {
+      "nodeOpacityDefault": 1,
+      "nodeOpacityInactive": 0.1,
+      "LinkOpacityDefault": 1,
+      "LinkOpacityInactive": 0.1
+    },
+    "storyNodeFontColor": "#006778",
+    "storyNodeText": [],
+    "nodeValueStyle": {
+      "textBefore": "(",
+      "textAfter": ")"
+    },
+    "data": []
+  },
+  "version": "4.25.6",
+  "migrations": {
+    "addColorMigration": true
+  }
 }

--- a/packages/chart/index.html
+++ b/packages/chart/index.html
@@ -1,38 +1,39 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <style>
-      body {
-        margin: 0;
-        border-top: none !important;
-      }
 
-      .cdc-map-outer-container {
-        min-height: 100vh;
-      }
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <style>
+    body {
+      margin: 0;
+      border-top: none !important;
+    }
 
-      /* .react-container + .react-container {
+    .cdc-map-outer-container {
+      min-height: 100vh;
+    }
+
+    /* .react-container + .react-container {
         margin-top: 3rem;
       } */
-    </style>
-    <link rel="stylesheet prefetch" href="https://www.cdc.gov/TemplatePackage/5.0/css/app.min.css?_=71669" />
-  </head>
+  </style>
+  <link rel="stylesheet prefetch" href="https://www.cdc.gov/TemplatePackage/5.0/css/app.min.css?_=71669" />
+</head>
 
-  <body>
-    <!-- SANKEY EXAMPLE -->
-    <!-- <div class="container d-flex flex-wrap body-wrapper bg-white" style="width:  750px">
+<body>
+  <!-- SANKEY EXAMPLE -->
+  <!-- <div class="container d-flex flex-wrap body-wrapper bg-white" style="width:  750px">
       <main class="col-lg-9 order-lg-2" role="main" aria-label="Main Content Area">
         <div class="row">
           <div class="col-md-12"> -->
-    <!-- <div class="react-container" data-config="/examples/feature/sankey/sankey-example-data.json"></div> -->
-    <!-- </div>
+  <!-- <div class="react-container" data-config="/examples/feature/sankey/sankey-example-data.json"></div> -->
+  <!-- </div>
         </div>
       </main>
     </div> -->
 
-    <!--
+  <!--
       EXAMPLES:
         chart/examples/features: different chart types and tests
         chart/examples/private: an ignored git folder used for addl. troubleshooting.
@@ -44,124 +45,123 @@
 
   -->
 
-    <!-- GENERIC CHART TYPES -->
-    <!-- <div class="react-container" data-config="/examples/private/ari-other-conditions-1.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/private/Viral-Respiratory-Deaths-Age.json"></div> -->
-    <!--    <div class="react-container" data-config="/examples/cases-year.json"></div>-->
-    <!-- <div class="react-container" data-config="/examples/test.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/line/line-chart.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/dev-8332.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/annotations/index.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/filters/url-filter.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/bar/additional-column-tooltip.json"></div> -->
-    <!-- <div class="react-container" data-config="https://cdc.gov/poxvirus/mpox/modules/data-viz/mpx-trends_1.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-date-apple.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/forest-plot/linear.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/forest-plot/logarithmic.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/forest-plot/forest-plot.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/pie/planet-pie-example-config.json"></div> -->
-    <!-- <div class="react-container" data-config=https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Line_Chart_Viz.json></div> -->
-    <!-- <div class="react-container" data-config=/examples/feature/regions/index.json></div> -->
-    <!-- <div class="react-container" data-config=https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Line_Chart_Regions_Viz.json></div> -->
-    <!-- <div class="react-container" data-config=https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Line_Chart_Regions_Viz.json></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/forecasting/forecasting.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/forecasting/combo-forecasting.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/forecasting/effective_reproduction.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-date.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-category.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/scatterplot-image-download.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/deviation/planet-deviation-config.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/private/test.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/combo/planet-combo-example-config.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/combo/right-issues.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/dev-9822.json"></div> -->
+  <!-- GENERIC CHART TYPES -->
+  <!-- <div class="react-container" data-config="/examples/private/ari-other-conditions-1.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/private/Viral-Respiratory-Deaths-Age.json"></div> -->
+  <!--    <div class="react-container" data-config="/examples/cases-year.json"></div>-->
+  <!-- <div class="react-container" data-config="/examples/test.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/line/line-chart.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/dev-8332.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/annotations/index.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/filters/url-filter.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/bar/additional-column-tooltip.json"></div> -->
+  <!-- <div class="react-container" data-config="https://cdc.gov/poxvirus/mpox/modules/data-viz/mpx-trends_1.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-date-apple.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/forest-plot/linear.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/forest-plot/logarithmic.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/forest-plot/forest-plot.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/pie/planet-pie-example-config.json"></div> -->
+  <!-- <div class="react-container" data-config=https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Line_Chart_Viz.json></div> -->
+  <!-- <div class="react-container" data-config=/examples/feature/regions/index.json></div> -->
+  <!-- <div class="react-container" data-config=https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Line_Chart_Regions_Viz.json></div> -->
+  <!-- <div class="react-container" data-config=https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Line_Chart_Regions_Viz.json></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/forecasting/forecasting.json"></div> -->
+  <div class="react-container" data-config="/examples/feature/forecasting/combo-forecasting.json"></div>
+  <!-- <div class="react-container" data-config="/examples/feature/forecasting/effective_reproduction.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-date.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/area/area-chart-category.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/scatterplot-image-download.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/deviation/planet-deviation-config.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/private/test.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/combo/planet-combo-example-config.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/combo/right-issues.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/dev-9822.json"></div> -->
 
-    <!-- BAR -->
-    <!-- <div class="react-container" data-config="/examples/feature/bar/planet-example-config.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/bar/planet-chart-horizontal-example-config.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/bar/example-bar-chart.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/bar/horizontal-chart-max-increase.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/bar/horizontal-chart.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/bar/horizontal-stacked-bar-chart.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/bar/planet-chart-horizontal-example-config.json"></div> -->
+  <!-- BAR -->
+  <!-- <div class="react-container" data-config="/examples/feature/bar/planet-example-config.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/bar/planet-chart-horizontal-example-config.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/bar/example-bar-chart.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/bar/horizontal-chart-max-increase.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/bar/horizontal-chart.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/bar/horizontal-stacked-bar-chart.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/bar/planet-chart-horizontal-example-config.json"></div> -->
 
-    <!-- TESTS DATA TABLE SORTING  -->
-    <!-- Bar Chart with Confidence Intervals (bottom of page)  -->
-    <!-- <div class="react-container" data-config="https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Example_Bar_CI.json"></div> -->
-    <!-- TPOXX Patient Data -->
-    <!-- <div class="react-container" data-config="https://www.cdc.gov/poxvirus/mpox/modules/data-viz/tpoxx_weekly_race_eth.json"></div> -->
-    <!-- <div class="react-container" data-config="https://www.cdc.gov/poxvirus/mpox/modules/data-viz/mpx-tpoxx-age-gender.json"></div> -->
-    <!-- Non-Variola Orthopoxvirus (NVO) Laboratory Testing by Demographics -->
-    <!-- <div class="react-container" data-config="https://wwwdev-cdc.msappproxy.net/poxvirus/mpox/modules/data-viz/lab-data.json"></div> -->
-    <!-- <div class="react-container" data-config="https://wwwdev-cdc.msappproxy.net/poxvirus/mpox/modules/data-viz/lab-data-age.json"></div> -->
-    <!-- PROBLEM WITH THEIR PAGE CONFIG or CONFLICT with -->
-    <!-- CORS ERROR pulling data on Covid Flu RSV page at https://wwwdev-cdc.msappproxy.net/respiratory-viruses/index.html-->
-    <!-- <div class="react-container" data-config="https://wwwdev-cdc.msappproxy.net/respiratory-viruses/modules/emergency-dept-visits_live.json"></div> -->
-    <!-- MPOX -->
-    <!-- <div class="react-container" data-config="https://www.cdc.gov/poxvirus/mpox/modules/data-viz/mpox-demographics-monthly.json"></div> -->
-    <!-- <div class="react-container" data-config="/https://www.cdc.gov/poxvirus/mpox/modules/data-viz/mpx-age-sex1.json"></div> -->
+  <!-- TESTS DATA TABLE SORTING  -->
+  <!-- Bar Chart with Confidence Intervals (bottom of page)  -->
+  <!-- <div class="react-container" data-config="https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Example_Bar_CI.json"></div> -->
+  <!-- TPOXX Patient Data -->
+  <!-- <div class="react-container" data-config="https://www.cdc.gov/poxvirus/mpox/modules/data-viz/tpoxx_weekly_race_eth.json"></div> -->
+  <!-- <div class="react-container" data-config="https://www.cdc.gov/poxvirus/mpox/modules/data-viz/mpx-tpoxx-age-gender.json"></div> -->
+  <!-- Non-Variola Orthopoxvirus (NVO) Laboratory Testing by Demographics -->
+  <!-- <div class="react-container" data-config="https://wwwdev-cdc.msappproxy.net/poxvirus/mpox/modules/data-viz/lab-data.json"></div> -->
+  <!-- <div class="react-container" data-config="https://wwwdev-cdc.msappproxy.net/poxvirus/mpox/modules/data-viz/lab-data-age.json"></div> -->
+  <!-- PROBLEM WITH THEIR PAGE CONFIG or CONFLICT with -->
+  <!-- CORS ERROR pulling data on Covid Flu RSV page at https://wwwdev-cdc.msappproxy.net/respiratory-viruses/index.html-->
+  <!-- <div class="react-container" data-config="https://wwwdev-cdc.msappproxy.net/respiratory-viruses/modules/emergency-dept-visits_live.json"></div> -->
+  <!-- MPOX -->
+  <!-- <div class="react-container" data-config="https://www.cdc.gov/poxvirus/mpox/modules/data-viz/mpox-demographics-monthly.json"></div> -->
+  <!-- <div class="react-container" data-config="/https://www.cdc.gov/poxvirus/mpox/modules/data-viz/mpx-age-sex1.json"></div> -->
 
-    <!-- TESTS DATE EXCLUSIONS -->
-    <!-- <div class="react-container" data-config="/examples/feature/boxplot/boxplot.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/tests-case-rate/case-rate-example-config.json"></div> -->
+  <!-- TESTS DATE EXCLUSIONS -->
+  <!-- <div class="react-container" data-config="/examples/feature/boxplot/boxplot.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-case-rate/case-rate-example-config.json"></div> -->
 
-    <!-- TESTS BIG SMALL-->
-    <!-- <div class="react-container" data-config="/examples/feature/tests-big-small/big-small-test-line.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/tests-big-small/big-small-test-bar.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/tests-big-small/big-small-test-negative.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/tests-big-small/line-chart-max-increase.json"></div> -->
+  <!-- TESTS BIG SMALL-->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-big-small/big-small-test-line.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-big-small/big-small-test-bar.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-big-small/big-small-test-negative.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-big-small/line-chart-max-increase.json"></div> -->
 
-    <!-- TESTS NONNUMERICS -->
-    <!-- <div
+  <!-- TESTS NONNUMERICS -->
+  <!-- <div
       class="react-container"
       data-config="/examples/feature/tests-non-numerics/planet-pie-example-config-nonnumeric.json"
     ></div> -->
-    <div
-      class="react-container"
-      data-config="/examples/feature/tests-non-numerics/example-combo-bar-nonnumeric.json"
-    ></div>
-    <!-- <div class="react-container" data-config="/examples/feature/tests-non-numerics/example-bar-chart-nonnumeric.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/sparkline.json"></div> -->
-    <!-- <div
+  <div class="react-container" data-config="/examples/feature/tests-non-numerics/example-combo-bar-nonnumeric.json">
+  </div>
+  <!-- <div class="react-container" data-config="/examples/feature/tests-non-numerics/example-bar-chart-nonnumeric.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/sparkline.json"></div> -->
+  <!-- <div
       class="react-container"
       data-config="/examples/feature/tests-non-numerics/sparkline-chart-nonnumeric.json"
     ></div> -->
-    <!-- <div class="react-container" data-config="/examples/region-issue.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/tests-non-numerics/stacked-vertical-bar-example-nonnumerics.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/region-issue.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-non-numerics/stacked-vertical-bar-example-nonnumerics.json"></div> -->
 
-    <!-- TESTS CUTOFF -->
-    <!-- <div class="react-container" data-config="/examples/feature/tests-cutoff/cutoff-example-config.json"></div> -->
+  <!-- TESTS CUTOFF -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-cutoff/cutoff-example-config.json"></div> -->
 
-    <!-- TESTS COVID -->
-    <!-- <div class="react-container" data-config="/examples/feature/tests-covid/covid-confidence-example-config.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/tests-covid/covid-example-config.json"></div> -->
+  <!-- TESTS COVID -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-covid/covid-confidence-example-config.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-covid/covid-example-config.json"></div> -->
 
-    <!--
+  <!--
       GALLERY EXAMPLES BELOW THIS LINE...
         https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/example-data-map-cities-states.html
 
     -->
 
-    <!-- GENERIC CHART TYPES  -->
-    <!-- <div class="react-container" data-config="/examples/gallery/paired-bar/paired-bar-chart.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/line/line-chart.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/feature/annotations/index.json"></div> -->
+  <!-- GENERIC CHART TYPES  -->
+  <!-- <div class="react-container" data-config="/examples/gallery/paired-bar/paired-bar-chart.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/line/line-chart.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/annotations/index.json"></div> -->
 
-    <!-- HORIZONTAL BAR CHARTS -->
-    <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-horizontal/horizontal-bar-chart-with-numbers-on-bar.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-horizontal/horizontal-bar-chart.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-horizontal/horizontal-stacked.json"></div> -->
+  <!-- HORIZONTAL BAR CHARTS -->
+  <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-horizontal/horizontal-bar-chart-with-numbers-on-bar.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-horizontal/horizontal-bar-chart.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-horizontal/horizontal-stacked.json"></div> -->
 
-    <!-- VERTICAL BAR CHARTS -->
-    <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/combo-line-chart.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-categorical.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-stacked.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-confidence.json"></div> -->
-    <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart.json"></div> -->
-    <!-- <div class="react-container" data-config="https://www.cdc.gov/respiratory-viruses/modules/respiratory-virus-activity/emergency-dept-visits_live.json"></div> -->
+  <!-- VERTICAL BAR CHARTS -->
+  <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/combo-line-chart.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-categorical.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-stacked.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart-confidence.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/gallery/bar-chart-vertical/vertical-bar-chart.json"></div> -->
+  <!-- <div class="react-container" data-config="https://www.cdc.gov/respiratory-viruses/modules/respiratory-virus-activity/emergency-dept-visits_live.json"></div> -->
 
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
 
-    <script type="module" src="./src/index.jsx"></script>
-  </body>
+  <script type="module" src="./src/index.jsx"></script>
+</body>
+
 </html>

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -246,11 +246,11 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     handleTooltipMouseOff,
     TooltipListItem,
   } = useCoveTooltip({
-      xScale,
-      yScale,
-      seriesScale,
-      showTooltip,
-      hideTooltip
+    xScale,
+    yScale,
+    seriesScale,
+    showTooltip,
+    hideTooltip
   })
   // get the number of months between the first and last date
   const { dataKey } = runtime.xAxis
@@ -645,9 +645,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           onMouseMove={onMouseMove}
           width={parentWidth + config.yAxis.rightAxisSize}
           height={isNoDataAvailable ? 1 : parentHeight}
-          className={`linear ${config.animate ? 'animated' : ''} ${animatedChart && config.animate ? 'animate' : ''} ${
-            debugSvg && 'debug'
-          } ${isDraggingAnnotation && 'dragging-annotation'}`}
+          className={`linear ${config.animate ? 'animated' : ''} ${animatedChart && config.animate ? 'animate' : ''} ${debugSvg && 'debug'
+            } ${isDraggingAnnotation && 'dragging-annotation'}`}
           role='img'
           aria-label={handleChartAriaLabels(config)}
           style={{ overflow: 'visible' }}
@@ -738,20 +737,20 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           )}
           {((visualizationType === 'Area Chart' && config.visualizationSubType === 'stacked') ||
             visualizationType === 'Combo') && (
-            <AreaChartStacked
-              xScale={xScale}
-              yScale={yScale}
-              yMax={yMax}
-              xMax={xMax}
-              chartRef={svgRef}
-              width={xMax}
-              height={yMax}
-              handleTooltipMouseOver={handleTooltipMouseOver}
-              handleTooltipMouseOff={handleTooltipMouseOff}
-              tooltipData={tooltipData}
-              showTooltip={showTooltip}
-            />
-          )}
+              <AreaChartStacked
+                xScale={xScale}
+                yScale={yScale}
+                yMax={yMax}
+                xMax={xMax}
+                chartRef={svgRef}
+                width={xMax}
+                height={yMax}
+                handleTooltipMouseOver={handleTooltipMouseOver}
+                handleTooltipMouseOff={handleTooltipMouseOff}
+                tooltipData={tooltipData}
+                showTooltip={showTooltip}
+              />
+            )}
           {(visualizationType === 'Bar' || visualizationType === 'Combo' || convertLineToBarGraph) && (
             <BarChart
               xScale={xScale}
@@ -787,6 +786,29 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               showTooltip={showTooltip}
             />
           )}
+
+          {/* Line chart */}
+          {/* TODO: Make this just line or combo? */}
+          {!['Paired Bar', 'Box Plot', 'Area Chart', 'Scatter Plot', 'Deviation Bar', 'Forecasting', 'Bar'].includes(
+            visualizationType
+          ) &&
+            !convertLineToBarGraph && (
+              <>
+                <LineChart
+                  xScale={xScale}
+                  yScale={yScale}
+                  getXAxisData={getXAxisData}
+                  getYAxisData={getYAxisData}
+                  xMax={xMax}
+                  yMax={yMax}
+                  seriesStyle={config.runtime.series}
+                  tooltipData={tooltipData}
+                  handleTooltipMouseOver={handleTooltipMouseOver}
+                  handleTooltipMouseOff={handleTooltipMouseOff}
+                />
+              </>
+            )}
+
           {(visualizationType === 'Forecasting' || visualizationType === 'Combo') && (
             <Forecasting
               showTooltip={showTooltip}
@@ -826,27 +848,6 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           )}
           {/*Brush chart */}
           {config.brush.active && config.xAxis.type !== 'categorical' && <BrushChart xMax={xMax} yMax={yMax} />}
-          {/* Line chart */}
-          {/* TODO: Make this just line or combo? */}
-          {!['Paired Bar', 'Box Plot', 'Area Chart', 'Scatter Plot', 'Deviation Bar', 'Forecasting', 'Bar'].includes(
-            visualizationType
-          ) &&
-            !convertLineToBarGraph && (
-              <>
-                <LineChart
-                  xScale={xScale}
-                  yScale={yScale}
-                  getXAxisData={getXAxisData}
-                  getYAxisData={getYAxisData}
-                  xMax={xMax}
-                  yMax={yMax}
-                  seriesStyle={config.runtime.series}
-                  tooltipData={tooltipData}
-                  handleTooltipMouseOver={handleTooltipMouseOver}
-                  handleTooltipMouseOff={handleTooltipMouseOff}
-                />
-              </>
-            )}
           {/* y anchors */}
           {config.yAxis.anchors &&
             config.yAxis.anchors.map((anchor, index) => {
@@ -871,7 +872,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                   strokeDasharray={handleLineType(anchor.lineStyle)}
                   stroke={anchor.color ? anchor.color : 'rgba(0,0,0,1)'}
                   className='anchor-y'
-                  from={{ x: 0 + padding, y: position - middleOffset}}
+                  from={{ x: 0 + padding, y: position - middleOffset }}
                   to={{ x: width - config.yAxis.rightAxisSize, y: position - middleOffset }}
                 />
               )
@@ -903,14 +904,14 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               return (
                 // prettier-ignore
                 <Line
-                key={`xAxis-${anchor.value}--${index}`}
-                strokeDasharray={handleLineType(anchor.lineStyle)}
-                stroke={anchor.color ? anchor.color : 'rgba(0,0,0,1)'}
-                fill={anchor.color ? anchor.color : 'rgba(0,0,0,1)'}
-                className='anchor-x'
-                from={{ x: Number(anchorPosition) + Number(padding), y: 0 }}
-                to={{ x: Number(anchorPosition) + Number(padding), y: yMax }}
-              />
+                  key={`xAxis-${anchor.value}--${index}`}
+                  strokeDasharray={handleLineType(anchor.lineStyle)}
+                  stroke={anchor.color ? anchor.color : 'rgba(0,0,0,1)'}
+                  fill={anchor.color ? anchor.color : 'rgba(0,0,0,1)'}
+                  className='anchor-x'
+                  from={{ x: Number(anchorPosition) + Number(padding), y: 0 }}
+                  to={{ x: Number(anchorPosition) + Number(padding), y: yMax }}
+                />
               )
             })}
           {/* we are handling regions in bar charts differently, so that we can calculate the bar group into the region space. */}
@@ -1004,10 +1005,10 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                         to={
                           runtime.horizontal
                             ? {
-                                x: 0,
-                                y:
-                                  config.visualizationType === 'Forest Plot' ? parentHeight : Number(heights.horizontal)
-                              }
+                              x: 0,
+                              y:
+                                config.visualizationType === 'Forest Plot' ? parentHeight : Number(heights.horizontal)
+                            }
                             : props.axisToPoint
                         }
                         stroke='#000'
@@ -1068,13 +1069,12 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             config.yAxis.labelPlacement === 'On Date/Category Axis' &&
                             !config.yAxis.hideLabel && (
                               <Text
-                                transform={`translate(${tick.to.x - 5}, ${
-                                  config.isLollipopChart
+                                transform={`translate(${tick.to.x - 5}, ${config.isLollipopChart
                                     ? tick.to.y - minY
                                     : tick.to.y -
-                                      minY +
-                                      (Number(config.barHeight * config.runtime.series.length) - barMinHeight) / 2
-                                }) rotate(-${config.runtime.horizontal ? config.runtime.yAxis.tickRotation || 0 : 0})`}
+                                    minY +
+                                    (Number(config.barHeight * config.runtime.series.length) - barMinHeight) / 2
+                                  }) rotate(-${config.runtime.horizontal ? config.runtime.yAxis.tickRotation || 0 : 0})`}
                                 verticalAnchor={'start'}
                                 textAnchor={'end'}
                                 fontSize={tickLabelFontSize}
@@ -1088,9 +1088,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             config.yAxis.labelPlacement === 'On Date/Category Axis' &&
                             !config.yAxis.hideLabel && (
                               <Text
-                                transform={`translate(${tick.to.x - 5}, ${
-                                  tick.to.y - minY + (Number(config.barHeight) - barMinHeight) / 2
-                                }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
+                                transform={`translate(${tick.to.x - 5}, ${tick.to.y - minY + (Number(config.barHeight) - barMinHeight) / 2
+                                  }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
                                 verticalAnchor={'start'}
                                 textAnchor={'end'}
                                 fontSize={tickLabelFontSize}
@@ -1103,9 +1102,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             visualizationType === 'Paired Bar' &&
                             !config.yAxis.hideLabel && (
                               <Text
-                                transform={`translate(${tick.to.x - 5}, ${
-                                  tick.to.y - minY + Number(config.barHeight) / 2
-                                }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
+                                transform={`translate(${tick.to.x - 5}, ${tick.to.y - minY + Number(config.barHeight) / 2
+                                  }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
                                 textAnchor={'end'}
                                 verticalAnchor='middle'
                                 fontSize={tickLabelFontSize}
@@ -1117,11 +1115,10 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             visualizationType === 'Deviation Bar' &&
                             !config.yAxis.hideLabel && (
                               <Text
-                                transform={`translate(${tick.to.x - 5}, ${
-                                  config.isLollipopChart
+                                transform={`translate(${tick.to.x - 5}, ${config.isLollipopChart
                                     ? tick.to.y - minY + 2
                                     : tick.to.y - minY + Number(config.barHeight) / 2
-                                }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
+                                  }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
                                 textAnchor={'end'}
                                 verticalAnchor='middle'
                                 fontSize={tickLabelFontSize}
@@ -1152,14 +1149,14 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                   seriesHighlight.includes(
                                     config.runtime.seriesLabelsAll[tick.formattedValue - 1]
                                   )) && (
-                                  <rect
-                                    x={0 - Number(config.yAxis.size)}
-                                    y={tick.to.y - 8 + (config.runtime.horizontal ? horizontalTickOffset : 7)}
-                                    width={Number(config.yAxis.size) + xScale(xScale.domain()[0])}
-                                    height='2'
-                                    fill={colorScale(config.runtime.seriesLabelsAll[tick.formattedValue - 1])}
-                                  />
-                                )}
+                                    <rect
+                                      x={0 - Number(config.yAxis.size)}
+                                      y={tick.to.y - 8 + (config.runtime.horizontal ? horizontalTickOffset : 7)}
+                                      width={Number(config.yAxis.size) + xScale(xScale.domain()[0])}
+                                      height='2'
+                                      fill={colorScale(config.runtime.seriesLabelsAll[tick.formattedValue - 1])}
+                                    />
+                                  )}
                               </>
                             )}
                           {orientation === 'vertical' &&
@@ -1302,9 +1299,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       className='y-label'
                       textAnchor='middle'
                       verticalAnchor='start'
-                      transform={`translate(${
-                        config.yAxis.rightLabelOffsetSize ? config.yAxis.rightLabelOffsetSize : 0
-                      }, ${axisCenter}) rotate(-90)`}
+                      transform={`translate(${config.yAxis.rightLabelOffsetSize ? config.yAxis.rightLabelOffsetSize : 0
+                        }, ${axisCenter}) rotate(-90)`}
                       fontWeight='bold'
                       fill={config.yAxis.rightAxisLabelColor}
                       fontSize={axisLabelFontSize}
@@ -1336,8 +1332,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                 runtime.horizontal && config.visualizationType !== 'Forest Plot'
                   ? Number(heights.horizontal) + Number(config.xAxis.axisPadding)
                   : config.visualizationType === 'Forest Plot'
-                  ? yMax + Number(config.xAxis.axisPadding)
-                  : yMax
+                    ? yMax + Number(config.xAxis.axisPadding)
+                    : yMax
               }
               left={config.visualizationType !== 'Forest Plot' ? Number(runtime.yAxis.size) : 0}
               label={config[section].label}
@@ -1350,8 +1346,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                 config.runtime.xAxis.manual
                   ? getTickValues(xAxisDataMapped, xScale, isDateTime ? xTickCount : getManualStep(), config)
                   : config.runtime.xAxis.type === 'date'
-                  ? xAxisDataMapped
-                  : undefined
+                    ? xAxisDataMapped
+                    : undefined
               }
             >
               {props => {
@@ -1377,14 +1373,14 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                 // filter out every [distanceBetweenTicks] tick starting from the end, so the last tick is always labeled
                 const filteredTicks = useDateSpanMonths
                   ? [...props.ticks]
-                      .reverse()
-                      .filter((_, i) => i % distanceBetweenTicks === 0)
-                      .reverse()
-                      .map((tick, i, arr) => ({
-                        ...tick,
-                        // reformat in case showYearsOnce, since first month of year may have changed
-                        formattedValue: handleBottomTickFormatting(tick.value, i, arr)
-                      }))
+                    .reverse()
+                    .filter((_, i) => i % distanceBetweenTicks === 0)
+                    .reverse()
+                    .map((tick, i, arr) => ({
+                      ...tick,
+                      // reformat in case showYearsOnce, since first month of year may have changed
+                      formattedValue: handleBottomTickFormatting(tick.value, i, arr)
+                    }))
                   : props.ticks
 
                 const axisMaxHeight = bottomLabelStart + BOTTOM_LABEL_PADDING
@@ -1516,9 +1512,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           tooltipData.dataYPosition &&
           tooltipData.dataXPosition && (
             <>
-              <style>{`.tooltip {background-color: rgba(255,255,255, ${
-                config.tooltips.opacity / 100
-              }) !important;`}</style>
+              <style>{`.tooltip {background-color: rgba(255,255,255, ${config.tooltips.opacity / 100
+                }) !important;`}</style>
               <style>{`.tooltip {max-width:300px} !important; word-wrap: break-word; `}</style>
               <TooltipWithBounds
                 ref={tooltipRef}


### PR DESCRIPTION
## Summary
Place forecast charts in front of lines on combo charts. In the future, we should consider using the order in `config.series` but it looks like the current order is based off of the visualizationType being displayed.

## Testing Steps
Open the combo-forecasting.json example and verify forecasting charts appear on top.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
