### PR TITLE
FIX : [NEW-50441] :increase hover point for missing bars

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
@@ -267,6 +267,19 @@ export const BarChartHorizontal = () => {
                             display: displayBar ? 'block' : 'none'
                           }
                         })}
+                        {/* Invisible hit-area for N/A bars */}
+                        {(isSuppressed || absentDataLabel) && (
+                          <rect
+                            x={barX}
+                            y={barY - barHeight * 20}
+                            width={numbericBarHeight * 20}
+                            height={barWidth * 20}
+                            fill='transparent'
+                            tooltipHtml={tooltip}
+                            tooltipId={`cdc-open-viz-tooltip-${config.runtime.uniqueId}`}
+                            onMouseOver={e => onMouseOverBar(xAxisValue, bar.key, e, data)}
+                          />
+                        )}
                         {config.preliminaryData?.map((pd, index) => {
                           // check if user selected column
                           const selectedSuppressionColumn = !pd.column || pd.column === bar.key

--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -276,8 +276,7 @@ export const BarChartVertical = () => {
                           y: barY,
                           onMouseOver: e => onMouseOverBar(xAxisValue, bar.key, e, data),
                           onMouseLeave: onMouseLeaveBar,
-                          tooltipHtml: tooltip,
-                          tooltipId: `cdc-open-viz-tooltip-${config.runtime.uniqueId}`,
+
                           onClick: e => {
                             e.preventDefault()
                             if (setSharedFilter) {
@@ -292,6 +291,19 @@ export const BarChartVertical = () => {
                             cursor: dashboardConfig ? 'pointer' : 'default'
                           }
                         })}
+                        {/* Invisible hit-area for N/A bars */}
+                        {(isSuppressed || absentDataLabel) && (
+                          <rect
+                            x={barX}
+                            y={barY - barHeight * 20}
+                            width={barWidth}
+                            height={barHeight * 20}
+                            fill='transparent'
+                            tooltipHtml={tooltip}
+                            tooltipId={`cdc-open-viz-tooltip-${config.runtime.uniqueId}`}
+                            onMouseOver={e => onMouseOverBar(xAxisValue, bar.key, e, data)}
+                          />
+                        )}
                         {config.preliminaryData.map((pd, index) => {
                           // check if user selected column
                           const selectedSuppressionColumn = !pd.column || pd.column === bar.key
@@ -335,7 +347,6 @@ export const BarChartVertical = () => {
                             </Text>
                           )
                         })}
-
                         <Text // prettier-ignore
                           display={displayBar ? 'block' : 'none'}
                           opacity={transparentBar ? 0.5 : 1}
@@ -357,7 +368,6 @@ export const BarChartVertical = () => {
                         >
                           {absentDataLabel}
                         </Text>
-
                         {config.isLollipopChart && config.lollipopShape === 'circle' && (
                           <circle
                             display={displaylollipopShape}


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
Open Bar chart vetical/horizontal non stacked
Make sure data has missing points or value like "Data 1" : 'ABC'
Click "Show single series hover" on visual panel
Hover on the bars that has N/A. 
Before: to see tooltip we needed to hover on a small bar 
After : we can hover on a higher point on the bar and still see the values.
<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
