### PR TITLE
display dc on hex maps

### DIFF
--- a/packages/map/src/helpers/addUIDs.ts
+++ b/packages/map/src/helpers/addUIDs.ts
@@ -9,7 +9,6 @@ import {
 
 import { SUPPORTED_DC_NAMES, GEO_TYPES, GEOCODE_TYPES } from './constants'
 import { DataRow, MapConfig } from '../types/MapConfig'
-import { memoize } from 'lodash'
 
 // Data props
 const stateKeys = Object.keys(supportedStates)
@@ -65,8 +64,8 @@ const handleUSLocation = (row: DataRow, geoColumn: string, displayAsHex: boolean
     uid = memoizedFindUID(geoName, 'territory')
   }
 
-  if (!uid) uid = findCityUID(geoName)
   if (!uid) uid = handleDCDisplay(geoName, displayAsHex)
+  if (!uid) uid = findCityUID(geoName)
 
   return uid
 }


### PR DESCRIPTION
## Summary
DC color values weren't filling in on hex maps.

## Testing Steps
Verify DC works on hex maps.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
