### PR TITLE
feature: [DEV-10997] option to not filter non geo data rows

### DIFF
--- a/packages/core/components/DataTable/helpers/mapCellMatrix.tsx
+++ b/packages/core/components/DataTable/helpers/mapCellMatrix.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react'
 import { displayDataAsText } from '@cdc/core/helpers/displayDataAsText'
 import _ from 'lodash'
 import { applyLegendToRow } from '@cdc/map/src/helpers/applyLegendToRow'
+import { hashObj } from '@cdc/map/src/helpers'
 
 type MapRowsProps = DataTableProps & {
   rows: string[]
@@ -93,6 +94,7 @@ const mapCellArray = ({
           }
 
           const legendColor = applyLegendToRow(rowObj, config, runtimeLegend, legendMemo, legendSpecialClassLastMemo)
+          const noColor = !legendMemo.current.has(hashObj(rowObj))
 
           if (!legendColor) {
             console.error('No legend color found') // eslint-disable-line no-console
@@ -100,9 +102,15 @@ const mapCellArray = ({
           const labelValue = getGeoLabel(config, row, formatLegendLocation, displayGeoName)
           const mapZoomHandler =
             type === 'bubble' && allowMapZoom && geoType === 'world' ? () => setFilteredCountryCode(row) : undefined
+
+          const validColor = legendColor && legendColor.length > 0 && !noColor
           return (
             <div className='col-12'>
-              {legendColor && legendColor.length > 0 && <LegendShape fill={legendColor[0]} />}
+              {validColor ? (
+                <LegendShape fill={legendColor[0]} />
+              ) : (
+                <div className='d-inline-block me-2' style={{ width: '1rem', height: '1rem' }} />
+              )}
               <CellAnchor
                 markup={labelValue}
                 row={rowObj}

--- a/packages/core/types/Table.ts
+++ b/packages/core/types/Table.ts
@@ -8,7 +8,7 @@ export type Table = {
   cellMinWidth?: number
   collapsible?: boolean
   dateDisplayFormat?: string
-  dontFilterNonGeoRows?: boolean
+  showNonGeoData?: boolean
   download?: boolean
   downloadVisibleDataOnly?: boolean
   downloadImageButton?: boolean

--- a/packages/core/types/Table.ts
+++ b/packages/core/types/Table.ts
@@ -8,6 +8,7 @@ export type Table = {
   cellMinWidth?: number
   collapsible?: boolean
   dateDisplayFormat?: string
+  dontFilterNonGeoRows?: boolean
   download?: boolean
   downloadVisibleDataOnly?: boolean
   downloadImageButton?: boolean

--- a/packages/map/index.html
+++ b/packages/map/index.html
@@ -30,7 +30,7 @@
 
   <body>
     <!-- DEFAULT EXAMPLES -->
-    <div class="react-container" data-config="/examples/custom-map-layers.json"></div>
+    <div class="react-container" data-config="/examples/private/measles.json"></div>
 
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script type="module" src="./src/index.jsx"></script>

--- a/packages/map/src/CdcMapComponent.tsx
+++ b/packages/map/src/CdcMapComponent.tsx
@@ -294,7 +294,8 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
         { ...config, data: configObj.data },
         filters || runtimeFilters,
         hashData,
-        isCategoryLegend
+        isCategoryLegend,
+        config.table.dontFilterNonGeoRows
       )
       setRuntimeData(newRuntimeData)
     } else {

--- a/packages/map/src/CdcMapComponent.tsx
+++ b/packages/map/src/CdcMapComponent.tsx
@@ -295,7 +295,7 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
         filters || runtimeFilters,
         hashData,
         isCategoryLegend,
-        config.table.dontFilterNonGeoRows
+        config.table.showNonGeoData
       )
       setRuntimeData(newRuntimeData)
     } else {

--- a/packages/map/src/CdcMapComponent.tsx
+++ b/packages/map/src/CdcMapComponent.tsx
@@ -284,6 +284,7 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
       primary: config.columns.primary.name,
       mapPosition: config.mapPosition,
       map: config.map,
+      table: config.table,
       ...runtimeFilters
     })
 

--- a/packages/map/src/_stories/CdcMap.Table.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Table.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import CdcMapComponent from '../CdcMapComponent'
+import defaultPatterns from './_mock/default-patterns.json'
+import { editConfigKeys } from '@cdc/chart/src/helpers/configHelpers'
+
+const meta: Meta<typeof CdcMapComponent> = {
+  title: 'Components/Templates/Map/Table',
+  component: CdcMapComponent
+}
+
+type Story = StoryObj<typeof CdcMapComponent>
+
+export const Show_Non_Geo_Data: Story = {
+  args: {
+    config: editConfigKeys(defaultPatterns, [{ path: ['table', 'showNonGeoData'], value: true }])
+  }
+}
+
+export default meta

--- a/packages/map/src/_stories/_mock/default-patterns.json
+++ b/packages/map/src/_stories/_mock/default-patterns.json
@@ -146,10 +146,7 @@
     "additionalCityStyles": []
   },
   "mapPosition": {
-    "coordinates": [
-      0,
-      30
-    ],
+    "coordinates": [0, 30],
     "zoom": 1
   },
   "map": {
@@ -193,6 +190,12 @@
   },
   "usingWidgetLoader": true,
   "data": [
+    {
+      "STATE": "Non-Geo Data",
+      "Rate": 1000,
+      "Location": "Home",
+      "URL": "https://www.cdc.gov/"
+    },
     {
       "STATE": "AL",
       "Rate": 1000,

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -2625,6 +2625,35 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                     </Tooltip>
                   </span>
                 </label>
+                <label className='checkbox'>
+                  <input
+                    type='checkbox'
+                    checked={config.table.dontFilterNonGeoRows}
+                    onChange={event => {
+                      setConfig({
+                        ...config,
+                        table: {
+                          ...config.table,
+                          dontFilterNonGeoRows: event.target.checked
+                        }
+                      })
+                    }}
+                  />
+                  <span className='edit-label column-heading'>
+                    Don't Filter Non-Geo Rows
+                    <Tooltip style={{ textTransform: 'none' }}>
+                      <Tooltip.Target>
+                        <Icon
+                          display='question'
+                          style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
+                        />
+                      </Tooltip.Target>
+                      <Tooltip.Content>
+                        <p>Show any data not associated with a geographic location</p>
+                      </Tooltip.Content>
+                    </Tooltip>
+                  </span>
+                </label>
                 <TextField
                   value={table.indexLabel || ''}
                   updateField={updateField}

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -2628,19 +2628,19 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                 <label className='checkbox'>
                   <input
                     type='checkbox'
-                    checked={config.table.dontFilterNonGeoRows}
+                    checked={config.table.showNonGeoData}
                     onChange={event => {
                       setConfig({
                         ...config,
                         table: {
                           ...config.table,
-                          dontFilterNonGeoRows: event.target.checked
+                          showNonGeoData: event.target.checked
                         }
                       })
                     }}
                   />
                   <span className='edit-label column-heading'>
-                    Don't Filter Non-Geo Rows
+                    Show Non Geographic Data
                     <Tooltip style={{ textTransform: 'none' }}>
                       <Tooltip.Target>
                         <Icon

--- a/packages/map/src/helpers/generateRuntimeData.ts
+++ b/packages/map/src/helpers/generateRuntimeData.ts
@@ -26,7 +26,7 @@ const generateRuntimeData = (
     configObj.data.forEach((row: DataRow) => {
       if (!row.uid) {
         if (!keepNoUidRows) return false // No UID for this row, we can't use for mapping
-        row.uid = row.geography
+        row.uid = row[configObj.columns.geo.name]
       }
       const configPrimaryName = configObj.columns.primary.name
       const value = row[configPrimaryName]

--- a/packages/map/src/helpers/generateRuntimeData.ts
+++ b/packages/map/src/helpers/generateRuntimeData.ts
@@ -9,7 +9,7 @@ const generateRuntimeData = (
   filters: VizFilter[],
   hash: number,
   isCategoryLegend: boolean,
-  keepNoUidRows = true
+  keepNoUidRows = false
 ): {
   [uid: string]: DataRow
 } => {
@@ -24,7 +24,7 @@ const generateRuntimeData = (
     addUIDs(configObj, configObj.columns.geo.name)
 
     configObj.data.forEach((row: DataRow) => {
-      if (undefined === row.uid) {
+      if (!row.uid) {
         if (!keepNoUidRows) return false // No UID for this row, we can't use for mapping
         row.uid = row.geography
       }

--- a/packages/map/src/helpers/generateRuntimeData.ts
+++ b/packages/map/src/helpers/generateRuntimeData.ts
@@ -8,7 +8,8 @@ const generateRuntimeData = (
   configObj: MapConfig,
   filters: VizFilter[],
   hash: number,
-  isCategoryLegend: boolean
+  isCategoryLegend: boolean,
+  keepNoUidRows = true
 ): {
   [uid: string]: DataRow
 } => {
@@ -23,7 +24,10 @@ const generateRuntimeData = (
     addUIDs(configObj, configObj.columns.geo.name)
 
     configObj.data.forEach((row: DataRow) => {
-      if (undefined === row.uid) return false // No UID for this row, we can't use for mapping
+      if (undefined === row.uid) {
+        if (!keepNoUidRows) return false // No UID for this row, we can't use for mapping
+        row.uid = row.geography
+      }
       const configPrimaryName = configObj.columns.primary.name
       const value = row[configPrimaryName]
       const categoryLegend = typeof value === 'string' && isCategoryLegend

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -1,6 +1,7 @@
 import { useCallback, useContext } from 'react'
 import ConfigContext from '../context'
 import {
+  addUIDs,
   applyColorToLegend,
   getGeoFillColor,
   hashObj,
@@ -53,10 +54,14 @@ export const generateRuntimeLegend = (
     const newLegendMemo = new Map() // Reset memoization
     const newLegendSpecialClassLastMemo = new Map() // Reset bin memoization
     const countryKeys = Object.keys(supportedCountries)
-    const { data, legend, columns, general } = configObj
+    const { legend, columns, general } = configObj
     const primaryColName = columns.primary.name
     const isBubble = general.type === 'bubble'
     const categoricalCol = columns.categorical ? columns.categorical.name : undefined
+
+    // filter out rows without a geo column
+    addUIDs(configObj, configObj.columns.geo.name)
+    const data = configObj.data.filter(row => row.uid) // Filter out rows without UIDs
 
     const result = {
       fromHash: null,


### PR DESCRIPTION
## Summary
option to not filter non geo data rows

## Testing Steps
1. Open map with non-geographic data
2. Check "showNonGeoData" in the Data Table section
3. Confirm that data shows up

## Optional
### Storybook Links
http://localhost:6006/?path=/story/components-templates-map-table--show-non-geo-data

### Screenshots
<img width="348" alt="Screenshot 2025-06-16 at 6 39 14 PM" src="https://github.com/user-attachments/assets/3169e79e-3fff-4e10-90b1-75fd17725b1e" />

