### PR TITLE
fix: inline label dashboard updater

### DIFF
--- a/packages/core/helpers/ver/4.25.6.ts
+++ b/packages/core/helpers/ver/4.25.6.ts
@@ -2,20 +2,26 @@ import _ from 'lodash'
 
 // *NOTE: This ends support for only showing the top prefix
 export const changeOnlyShowTopSuffixToInlineLabel = config => {
-  if (!config.dataFormat?.suffix) return config
-  if (!config.dataFormat.onlyShowTopPrefixSuffix) return config
+  if (config.type === 'chart') {
+    if (!config.dataFormat?.suffix) return config
+    if (!config.dataFormat.onlyShowTopPrefixSuffix) return config
 
-  delete config.dataFormat.onlyShowTopPrefixSuffix
+    delete config.dataFormat.onlyShowTopPrefixSuffix
 
-  if (!config.yAxis) config.yAxis = {}
+    if (!config.yAxis) config.yAxis = {}
 
-  if (!config.yAxis?.inlineLabel) {
-    config.yAxis.inlineLabel = config.dataFormat.suffix
+    if (!config.yAxis?.inlineLabel) {
+      config.yAxis.inlineLabel = config.dataFormat.suffix
+    }
+
+    config.dataFormat.suffix = ''
+
+    return config
+  } else if (config.type === 'dashboard') {
+    Object.values(config.visualizations).forEach(visualization => {
+      changeOnlyShowTopSuffixToInlineLabel(visualization)
+    })
   }
-
-  config.dataFormat.suffix = ''
-
-  return config
 }
 
 const update_4_25_6 = config => {

--- a/packages/core/helpers/ver/4.25.6.ts
+++ b/packages/core/helpers/ver/4.25.6.ts
@@ -21,6 +21,7 @@ export const changeOnlyShowTopSuffixToInlineLabel = config => {
     Object.values(config.visualizations).forEach(visualization => {
       changeOnlyShowTopSuffixToInlineLabel(visualization)
     })
+    return config
   }
 }
 

--- a/packages/core/helpers/ver/tests/4.25.6.test.ts
+++ b/packages/core/helpers/ver/tests/4.25.6.test.ts
@@ -4,6 +4,7 @@ import { changeOnlyShowTopSuffixToInlineLabel } from '../4.25.6'
 describe('changeOnlyShowTopSuffixToInlineLabel(config) ', () => {
   it("should'nt change config if no suffix", () => {
     const config = {
+      type: 'chart',
       dataFormat: {
         onlyShowTopPrefixSuffix: true,
         suffix: ''
@@ -14,6 +15,7 @@ describe('changeOnlyShowTopSuffixToInlineLabel(config) ', () => {
   })
   it("should't change suffix if onlyShowTopPrefixSuffix is false", () => {
     const config = {
+      type: 'chart',
       dataFormat: {
         onlyShowTopPrefixSuffix: false,
         suffix: 'test'
@@ -24,6 +26,7 @@ describe('changeOnlyShowTopSuffixToInlineLabel(config) ', () => {
   })
   it('should change suffix to inlineLabel if onlyShowTopPrefixSuffix is true', () => {
     const config = {
+      type: 'chart',
       dataFormat: {
         onlyShowTopPrefixSuffix: true,
         suffix: 'test'
@@ -36,6 +39,7 @@ describe('changeOnlyShowTopSuffixToInlineLabel(config) ', () => {
   })
   it("should't overwrite existing yAxis inlineLabel", () => {
     const config = {
+      type: 'chart',
       dataFormat: {
         onlyShowTopPrefixSuffix: true,
         suffix: 'test'
@@ -48,5 +52,33 @@ describe('changeOnlyShowTopSuffixToInlineLabel(config) ', () => {
     expect(newConfig.yAxis.inlineLabel).toBe('test2')
     expect(newConfig.dataFormat.onlyShowTopPrefixSuffix).toBe(undefined)
     expect(newConfig.dataFormat.suffix).toBe('')
+  })
+  it('should change suffix to inlineLabel for dashboard visualizations', () => {
+    const config = {
+      type: 'dashboard',
+      visualizations: [
+        {
+          type: 'chart',
+          dataFormat: {
+            onlyShowTopPrefixSuffix: true,
+            suffix: 'test'
+          }
+        },
+        {
+          type: 'chart',
+          dataFormat: {
+            onlyShowTopPrefixSuffix: true,
+            suffix: 'test2'
+          }
+        }
+      ]
+    }
+    const newConfig = changeOnlyShowTopSuffixToInlineLabel(config)
+    expect(newConfig.visualizations[0].yAxis.inlineLabel).toBe('test')
+    expect(newConfig.visualizations[0].dataFormat.onlyShowTopPrefixSuffix).toBe(undefined)
+    expect(newConfig.visualizations[0].dataFormat.suffix).toBe('')
+    expect(newConfig.visualizations[1].yAxis.inlineLabel).toBe('test2')
+    expect(newConfig.visualizations[1].dataFormat.onlyShowTopPrefixSuffix).toBe(undefined)
+    expect(newConfig.visualizations[1].dataFormat.suffix).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
Updater not working for dashboard

## Testing Steps
open [mhdc-flash.json](https://github.com/user-attachments/files/20778887/mhdc-flash.json) and confirm it has inline label

