### PR TITLE
fix [dev-10982] N/A barcharts should not show tooltip

### DIFF
--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -193,6 +193,8 @@ export const useTooltip = props => {
           }
         })
       } else {
+        const dynamicSeries = config.series.find(s => s.dynamicCategory)
+
         // Show Only the Hovered Series in Tooltip
         const dataColumn = resolvedScaleValues[0]
         const [seriesKey, value] = findDataKeyByThreshold(y, dataColumn)
@@ -203,7 +205,7 @@ export const useTooltip = props => {
           tooltipItems.push([config.xAxis.dataKey, closestXScaleValue || xVal])
           const formattedValue = getFormattedValue(seriesKey, value, config, getAxisPosition)
           tooltipItems.push([seriesKey, formattedValue])
-        } else {
+        } else if (dynamicSeries) {
           Object.keys(dataColumn).forEach(key => {
             tooltipItems.push([key, dataColumn[key]])
           })


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

An update in new-50398 caused the N/A bar charts to show tooltips.

## Testing Steps
<!-- Provide testing steps -->

Test 1) Regression test this ticket: https://github.com/CDCgov/cdc-open-viz/pull/2090

Test 2) 
[bad-bar-tooltip.json](https://github.com/user-attachments/files/20801982/bad-bar-tooltip.json) navigate to preview.
Expected: hovering over N/A should not show a tooltip

<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
