### PR TITLE
Fix : [DEV-10945] Fix Pie Chart Tooltips and Data Table

### DIFF
--- a/packages/chart/src/components/Legend/Legend.Suppression.tsx
+++ b/packages/chart/src/components/Legend/Legend.Suppression.tsx
@@ -8,7 +8,7 @@ interface LegendProps {
 
 const LegendSuppression: React.FC<LegendProps> = ({ config, isLegendBottom }) => {
   const { preliminaryData, visualizationType, visualizationSubType, legend, data } = config
-  const showPiePercent = config.dataFormat.showPiePercent
+  const showPiePercent = config.dataFormat.showPiePercent && config.visualizationType === 'Pie'
   const hasOpenCircleEffects = () =>
     preliminaryData?.some(pd => pd.label && pd.type === 'effect' && pd.style !== 'Filled Circles') &&
     ['Line', 'Combo'].includes(visualizationType)

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -124,15 +124,19 @@ export const useTooltip = props => {
 
       const degrees = ((endAngle - startAngle) * 180) / Math.PI
       const pctOf360 = (degrees / 360) * 100
-      const pctString = pctOf360.toFixed(roundTo) + '%'
+      const pctString = value => value.toFixed(roundTo) + '%'
+      const showPiePercent = config.dataFormat.showPiePercent || false
 
-      if (config.dataFormat.showPiePercent && pieData[config.xAxis.dataKey] === 'Calculated Area') {
+      if (showPiePercent && pieData[config.xAxis.dataKey] === 'Calculated Area') {
         tooltipItems.push(['', 'Calculated Area'])
       } else {
         tooltipItems.push(
           [config.xAxis.dataKey, pieData[config.xAxis.dataKey]],
-          [config.runtime.yAxis.dataKey, formatNumber(pieData[config.runtime.yAxis.dataKey])],
-          ['Percent', pctString]
+          [
+            config.runtime.yAxis.dataKey,
+            showPiePercent ? pctString(pctOf360) : formatNumber(pieData[config.runtime.yAxis.dataKey])
+          ],
+          showPiePercent ? [] : ['Percent', pctString(pctOf360)]
         )
       }
     }

--- a/packages/core/components/DataTable/helpers/getChartCellValue.ts
+++ b/packages/core/components/DataTable/helpers/getChartCellValue.ts
@@ -1,6 +1,7 @@
 import { parseDate, formatDate } from '@cdc/core/helpers/cove/date'
 import { formatNumber } from '../../../helpers/cove/number'
 import { TableConfig } from '../types/TableConfig'
+import _ from 'lodash'
 
 const isPivotColumn = (columnName, config) => {
   const tableHasPivotColumnConfigured = config.table.pivot?.valueColumns?.length
@@ -61,13 +62,19 @@ export const getChartCellValue = (row: string, column: string, config: TableConf
     })
 
     let addColParams = isAdditionalColumn(column, config, rowObj)
-    if (addColParams) {
+    const piePercent =
+      (_.toNumber(runtimeData[row][column]) / _.sumBy(runtimeData, d => _.toNumber(d[column]))) * 100 || 0
+
+    const valueToFormat =
+      config.visualizationType === 'Pie' && !config.dataFormat.showPiePercent ? piePercent : runtimeData[row][column]
+
+    if (Object.keys(addColParams).length > 0) {
       cellValue = config.dataFormat
-        ? formatNumber(runtimeData[row][column], resolvedAxis, false, config, addColParams)
+        ? formatNumber(valueToFormat, resolvedAxis, false, config, addColParams)
         : runtimeData[row][column]
     } else {
       cellValue = config.dataFormat
-        ? formatNumber(runtimeData[row][column], resolvedAxis, false, config)
+        ? formatNumber(valueToFormat, resolvedAxis, false, config)
         : runtimeData[row][column]
     }
   }

--- a/packages/core/helpers/cove/number.ts
+++ b/packages/core/helpers/cove/number.ts
@@ -177,7 +177,7 @@ const formatNumber = (num, axis, shouldAbbreviate = false, config = null, addCol
   result += num
 
   if (!inlineLabel || addColSuffix) {
-    if (config.visualizationType === 'Pie' && config.dataFormat.showPiePercent) {
+    if (config.visualizationType === 'Pie') {
       result = `${result}%`
     }
     if (addColSuffix !== undefined && axis === 'left') {


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
Fixed Tooltips to show only percentage values if user selects "show data value " checkbox
else shows two values : original data value and calculated percentage
Added data table default % sign all times.
![Screenshot 2025-06-22 at 19 59 41](https://github.com/user-attachments/assets/b7833d11-6fd6-424e-aa42-ba9188e1e787)

<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
