### PR TITLE
FIX : [DEV-10625] -Fix Up & Down data table sorting icons for responsive design

### DIFF
--- a/packages/core/components/DataTable/components/SortIcon/sort-icon.css
+++ b/packages/core/components/DataTable/components/SortIcon/sort-icon.css
@@ -1,36 +1,30 @@
-/* format the white triangle sort icon in data table headers */
 .sort-icon {
-  fill: white;
-  position: relative;
-  margin: 0 0.5rem !important;
-  :is(svg) {
-    position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+
+  svg {
+    width: 0.75rem;
+    height: 0.75rem;
     fill: rgba(255, 255, 255, 0.5);
+    margin: 0;
+    padding: 0;
+    line-height: 1;
+
     &.active {
       fill: white;
     }
-    width: 1rem;
-    height: 1rem;
   }
-  .up {
-    bottom: 0.5rem;
-  }
-  .down {
-    top: 0.5rem;
-  }
-}
 
-@media (max-width: 576px) {
-  .sort-icon {
-    :is(svg) {
-      width: 0.9rem;
-      height: 0.9rem;
-    }
-    .up {
-      bottom: 0.3rem;
-    }
-    .down {
-      top: 0.3rem;
-    }
+  svg.up,
+  svg.down {
+    margin: 0 !important;
   }
 }


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
Open data table in any charts/maps
Toogle sortings buttons Up And Down arrows.
Before : in small screens these buttons were overlap on top of each other
After : they dont overlap in any scree size.
<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
