### PR TITLE
Feature [DEV-11034] Add control to collapse long data tables from the bottom

### DIFF
--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -138,7 +138,8 @@ export default {
     showVertical: true,
     dateDisplayFormat: '',
     showMissingDataLabel: true,
-    showSuppressedSymbol: true
+    showSuppressedSymbol: true,
+    collapsible: true
   },
   orientation: 'vertical',
   color: 'pinkpurple',

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -26,8 +26,6 @@ import './data-table.css'
 import _ from 'lodash'
 import { getDataSeriesColumns } from './helpers/getDataSeriesColumns'
 
-const USE_BOTTOM_COLLAPSE_THRESHOLD = 20
-
 export type DataTableProps = {
   colorScale?: Function
   columns?: Record<string, Column>
@@ -281,8 +279,7 @@ const DataTable = (props: DataTableProps) => {
         ? mapCellMatrix({ ...props, rows, wrapColumns, runtimeData, viewport })
         : chartCellMatrix({ rows, ...props, runtimeData, isVertical, sortBy, hasRowType, viewport })
 
-    const useBottomExpandCollapse =
-      expanded && Array.isArray(childrenMatrix) && childrenMatrix.length >= USE_BOTTOM_COLLAPSE_THRESHOLD
+    const useBottomExpandCollapse = config.table.showBottomCollapse && expanded && Array.isArray(childrenMatrix)
 
     // If every value in a column is a number, record the column index so the header and cells can be right-aligned
     const rightAlignedCols = childrenMatrix.length
@@ -395,6 +392,7 @@ const DataTable = (props: DataTableProps) => {
             <button
               className='border-0 bg-transparent text-decoration-underline mt-2'
               style={{ color: 'var(--colors-link-blue)', fontSize: '0.772rem', textUnderlineOffset: '6px' }}
+              onClick={() => setExpanded(false)}
             >
               - Collapse table
             </button>

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -295,6 +295,7 @@ const DataTable = (props: DataTableProps) => {
       )
       : {}
 
+    const showCollapseButton = config.table.collapsible !== false && useBottomExpandCollapse
     const TableMediaControls = ({ belowTable }) => {
       const hasDownloadLink = config.table.download
       return (
@@ -353,8 +354,9 @@ const DataTable = (props: DataTableProps) => {
                 )
               }
               tableOptions={{
-                className: `table table-striped table-width-unset ${expanded ? 'data-table' : 'data-table cdcdataviz-sr-only'}${isVertical ? '' : ' horizontal'
-                  }`,
+                className: `table table-striped table-width-unset ${
+                  expanded ? 'data-table' : 'data-table cdcdataviz-sr-only'
+                }${isVertical ? '' : ' horizontal'}`,
                 'aria-live': 'assertive',
                 'aria-rowcount': config?.data?.length ? config.data.length : -1,
                 hidden: !expanded,
@@ -386,11 +388,18 @@ const DataTable = (props: DataTableProps) => {
                 />
               )}
           </div>
-          {config.table.collapsible !== false && useBottomExpandCollapse && (
-            <ExpandCollapse expanded={expanded} setExpanded={setExpanded} tableTitle={tableTitle} end />
-          )}
         </section>
-        {config.table.showDownloadLinkBelow && <TableMediaControls belowTable={true} />}
+        <div className={`w-100 d-flex ${showCollapseButton ? 'justify-content-between' : 'justify-content-end'}`}>
+          {config.table.showDownloadLinkBelow && <TableMediaControls belowTable={true} />}
+          {showCollapseButton && (
+            <button
+              className='border-0 bg-transparent text-decoration-underline mt-2'
+              style={{ color: 'var(--colors-link-blue)', fontSize: '0.772rem', textUnderlineOffset: '6px' }}
+            >
+              - Collapse table
+            </button>
+          )}
+        </div>
         <div id={skipId} className='cdcdataviz-sr-only'>
           Skipped data table.
         </div>

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -279,6 +279,8 @@ const DataTable = (props: DataTableProps) => {
         ? mapCellMatrix({ ...props, rows, wrapColumns, runtimeData, viewport })
         : chartCellMatrix({ rows, ...props, runtimeData, isVertical, sortBy, hasRowType, viewport })
 
+    const useBottomExpandCollapse = expanded && Array.isArray(childrenMatrix) && childrenMatrix.length >= 19
+
     // If every value in a column is a number, record the column index so the header and cells can be right-aligned
     const rightAlignedCols = childrenMatrix.length
       ? Object.fromEntries(
@@ -312,7 +314,7 @@ const DataTable = (props: DataTableProps) => {
         <section id={tabbingId.replace('#', '')} className={getClassNames()} aria-label={accessibilityLabel}>
           <SkipTo skipId={skipId} skipMessage='Skip Data Table' />
           {config.table.collapsible !== false && (
-            <ExpandCollapse expanded={expanded} setExpanded={setExpanded} tableTitle={tableTitle} viewport={viewport} />
+            <ExpandCollapse expanded={expanded} setExpanded={setExpanded} tableTitle={tableTitle} />
           )}
           <div className='table-container' style={limitHeight}>
             <Table
@@ -381,6 +383,9 @@ const DataTable = (props: DataTableProps) => {
                 />
               )}
           </div>
+          {config.table.collapsible !== false && useBottomExpandCollapse && (
+            <ExpandCollapse expanded={expanded} setExpanded={setExpanded} tableTitle={tableTitle} end />
+          )}
         </section>
         {config.table.showDownloadLinkBelow && <TableMediaControls belowTable={true} />}
         <div id={skipId} className='cdcdataviz-sr-only'>

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -26,6 +26,8 @@ import './data-table.css'
 import _ from 'lodash'
 import { getDataSeriesColumns } from './helpers/getDataSeriesColumns'
 
+const USE_BOTTOM_COLLAPSE_THRESHOLD = 20
+
 export type DataTableProps = {
   colorScale?: Function
   columns?: Record<string, Column>
@@ -279,7 +281,8 @@ const DataTable = (props: DataTableProps) => {
         ? mapCellMatrix({ ...props, rows, wrapColumns, runtimeData, viewport })
         : chartCellMatrix({ rows, ...props, runtimeData, isVertical, sortBy, hasRowType, viewport })
 
-    const useBottomExpandCollapse = expanded && Array.isArray(childrenMatrix) && childrenMatrix.length >= 19
+    const useBottomExpandCollapse =
+      expanded && Array.isArray(childrenMatrix) && childrenMatrix.length >= USE_BOTTOM_COLLAPSE_THRESHOLD
 
     // If every value in a column is a number, record the column index so the header and cells can be right-aligned
     const rightAlignedCols = childrenMatrix.length

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -311,7 +311,11 @@ const DataTable = (props: DataTableProps) => {
 
     return (
       <ErrorBoundary component='DataTable'>
-        {!config.table.showDownloadLinkBelow && <TableMediaControls />}
+        {!config.table.showDownloadLinkBelow && (
+          <div className='w-100 d-flex justify-content-end'>
+            <TableMediaControls />
+          </div>
+        )}
         <section id={tabbingId.replace('#', '')} className={getClassNames()} aria-label={accessibilityLabel}>
           <SkipTo skipId={skipId} skipMessage='Skip Data Table' />
           {config.table.collapsible !== false && (
@@ -386,8 +390,7 @@ const DataTable = (props: DataTableProps) => {
               )}
           </div>
         </section>
-        <div className={`w-100 d-flex ${showCollapseButton ? 'justify-content-between' : 'justify-content-end'}`}>
-          {config.table.showDownloadLinkBelow && <TableMediaControls belowTable={true} />}
+        <div className={`w-100 d-flex justify-content-between`}>
           {showCollapseButton && (
             <button
               className='border-0 bg-transparent text-decoration-underline mt-2'
@@ -397,6 +400,7 @@ const DataTable = (props: DataTableProps) => {
               - Collapse table
             </button>
           )}
+          {config.table.showDownloadLinkBelow && <TableMediaControls belowTable={true} />}
         </div>
         <div id={skipId} className='cdcdataviz-sr-only'>
           Skipped data table.

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -390,7 +390,7 @@ const DataTable = (props: DataTableProps) => {
               )}
           </div>
         </section>
-        <div className={`w-100 d-flex justify-content-between`}>
+        <div className={`w-100 d-flex ${showCollapseButton ? 'justify-content-between' : 'justify-content-end'}`}>
           {showCollapseButton && (
             <button
               className='border-0 bg-transparent text-decoration-underline mt-2'

--- a/packages/core/components/DataTable/components/ExpandCollapse.tsx
+++ b/packages/core/components/DataTable/components/ExpandCollapse.tsx
@@ -1,7 +1,13 @@
 import Icon from '../../ui/Icon'
 import parse from 'html-react-parser'
 
-const ExpandCollapse = ({ expanded, setExpanded, tableTitle, fontSize, viewport }) => {
+interface ExpandCollapseProps {
+  expanded: boolean
+  setExpanded: (expanded: boolean) => void
+  tableTitle: string
+}
+
+const ExpandCollapse = ({ expanded, setExpanded, tableTitle }: ExpandCollapseProps) => {
   return (
     <div
       role='button'

--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -216,7 +216,7 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
         section='table'
         updateField={updateField}
       />
-      {config.table.collapsible !== false && (
+      {config.table.collapsible && (
         <CheckBox
           value={config.table.expanded}
           fieldName='expanded'
@@ -225,7 +225,7 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
           updateField={updateField}
         />
       )}
-      {config.table.collapsible !== false && (
+      {config.table.collapsible && (
         <CheckBox
           value={config.table.showBottomCollapse}
           fieldName='showBottomCollapse'

--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -225,6 +225,15 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
           updateField={updateField}
         />
       )}
+      {config.table.collapsible !== false && (
+        <CheckBox
+          value={config.table.showBottomCollapse}
+          fieldName='showBottomCollapse'
+          label=' Show Collapse Button Under Table'
+          section='table'
+          updateField={updateField}
+        />
+      )}
       <CheckBox
         value={config.table.download}
         fieldName='download'

--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -229,7 +229,7 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
         <CheckBox
           value={config.table.showBottomCollapse}
           fieldName='showBottomCollapse'
-          label=' Show Collapse Button Under Table'
+          label='Show collapse below table'
           section='table'
           updateField={updateField}
         />
@@ -247,7 +247,7 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
             value={config.table.showDownloadLinkBelow}
             fieldName='showDownloadLinkBelow'
             className='ms-4'
-            label='Show collapse below table'
+            label='Show Link Below Table'
             section='table'
             updateField={updateField}
           />

--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -247,7 +247,7 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
             value={config.table.showDownloadLinkBelow}
             fieldName='showDownloadLinkBelow'
             className='ms-4'
-            label='Show Link Below Table'
+            label='Show collapse below table'
             section='table'
             updateField={updateField}
           />

--- a/packages/core/styles/_button-section.scss
+++ b/packages/core/styles/_button-section.scss
@@ -14,9 +14,7 @@
 
 // links that appear above data tables
 .download-links {
-  display: flex;
   justify-content: flex-end;
-  width: 100%;
   line-height: 1;
   &.brush-active {
     margin-top: 2em;

--- a/packages/core/types/Table.ts
+++ b/packages/core/types/Table.ts
@@ -23,6 +23,7 @@ export type Table = {
   pivot?: Pivot
   show?: boolean
   sharedFilterColumns?: string[] // added at runtime by Dashboard
+  showBottomCollapse?: boolean // if true, the table will have a button to collapse at bottom of the expanded table
   showDataTableLink?: boolean
   showDownloadImgButton?: boolean
   showDownloadLinkBelow?: boolean

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -91,7 +91,8 @@ export default {
     forceDisplay: true,
     download: false,
     indexLabel: '',
-    cellMinWidth: '0'
+    cellMinWidth: '0',
+    collapsible: true
   },
   tooltips: {
     appearanceType: 'hover',


### PR DESCRIPTION
## Summary
Add control to collapse long data tables from the bottom
*Only shows on charts with at least 20 rows

## Testing Steps
1. Open Viz with data table
2. Check `SHOW COLLAPSE BELOW TABLE`
3. Expand data table
4. Confirm collapse button shows at bottom of table

## Optional
### Storybook Links
http://localhost:6006/?path=/story/private-respiratory-virus--all-configs

### Screenshots
<img width="276" height="50" alt="Screenshot 2025-07-25 at 2 42 03 PM" src="https://github.com/user-attachments/assets/7693678e-5465-417a-b725-ed31b58e9d82" />
<img width="416" height="389" alt="Screenshot 2025-07-30 at 10 41 54 AM" src="https://github.com/user-attachments/assets/7903f642-c9fe-42f3-959b-16a368b365cc" />

