### PR TITLE
Fix [DEV-10990] Improve tick generation for y-axes with small ranges

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -288,7 +288,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     if (config.data && !config.data[index] && visualizationType === 'Forest Plot') return
     if (config.visualizationType === 'Forest Plot') return config.data[index][config.xAxis.dataKey]
     if (isDateScale(runtime.yAxis)) return formatDate(parseDate(tick))
-    if (orientation === 'vertical' && max - min < 3)
+    if (orientation === 'vertical' && max - min < 3 && !config.dataFormat?.roundTo)
       return formatNumber(tick, 'left', shouldAbbreviate, false, false, '1', { index, length: ticks.length })
     if (orientation === 'vertical') {
       // TODO suggestion: pass all options as object key/values to allow for more flexibility

--- a/packages/chart/src/helpers/countNumOfTicks.ts
+++ b/packages/chart/src/helpers/countNumOfTicks.ts
@@ -15,17 +15,8 @@ export const countNumOfTicks = ({ axis, max, runtime, currentViewport, isHorizon
         ? undefined
         : !isHorizontal && numTicks && numTicks
     // to fix edge case of small numbers with decimals
-    if (tickCount === undefined && !config.dataFormat.roundTo) {
-      // then it is set to Auto
-      if (Number(max) <= 3) {
-        tickCount = 2
-      } else {
-        tickCount = 4 // same default as standalone components
-      }
-    }
-    if (Number(tickCount) > Number(max) && !isHorizontal) {
-      // cap it and round it so its an integer
-      tickCount = Math.max(2, Number(min) < 0 ? Math.round(max) * 2 : Math.round(max))
+    if (tickCount === undefined) {
+      tickCount = 4 // same default as standalone components
     }
   }
 
@@ -38,14 +29,8 @@ export const countNumOfTicks = ({ axis, max, runtime, currentViewport, isHorizon
         : !isHorizontal && !numTicks
         ? undefined
         : !isHorizontal && numTicks && numTicks
-    if (isHorizontal && tickCount === undefined && !config.dataFormat.roundTo) {
-      // then it is set to Auto
-      // - check for small numbers situation
-      if (max <= 3) {
-        tickCount = 2
-      } else {
-        tickCount = 4 // same default as standalone components
-      }
+    if (isHorizontal && tickCount === undefined) {
+      tickCount = 4 // same default as standalone components
     }
 
     if (config.visualizationType === 'Forest Plot') {


### PR DESCRIPTION
## Summary

This improves tick generation for y-axes with small numbers by doing two things:

1. The number of ticks is no longer set to two
2. The number of decimal points visible in the y-axis respects the value in the "round to decimal point" option

## Testing Steps

Load [small-numbers.json](https://github.com/user-attachments/files/20909265/small-numbers.json) locally in the chart package.

On the `dev` branch, there will be two ticks on the y-axis, on this branch there will be more. If you change the [Left Value Axis => round to decimal point] option, the ticks will match the desired rounding on this branch, but will always show one decimal on the `dev` branch.
 
## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
