### PR TITLE
Feature [DEV-10991] Multiple series

### DIFF
--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -752,7 +752,7 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
   const updateField = updateFieldFactory(config, updateConfig)
   const updateFieldDeprecated = (section, subsection, fieldName, newValue) => {
     if (isDebug)
-      console.error(
+      console.log(
         '#COVE: CHART: EditorPanel: section, subsection, fieldName, newValue',
         section,
         subsection,
@@ -1198,7 +1198,7 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
   if (isDebug && config?.series?.length === 0) {
     let setdatacol = setDataColumn()
     if (setdatacol !== '') addNewSeries(setdatacol)
-    if (isDebug) console.error('### COVE DEBUG: Chart: Setting default datacol=', setdatacol) // eslint-disable-line
+    if (isDebug) console.log('### COVE DEBUG: Chart: Setting default datacol=', setdatacol) // eslint-disable-line
   }
 
   const chartsWithOptions = [

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -20,6 +20,7 @@ import DataTableEditor from '@cdc/core/components/EditorPanel/DataTableEditor'
 import VizFilterEditor from '@cdc/core/components/EditorPanel/VizFilterEditor'
 import Tooltip from '@cdc/core/components/ui/Tooltip'
 import { Select, TextField, CheckBox } from '@cdc/core/components/EditorPanel/Inputs'
+import MultiSelect from '@cdc/core/components/MultiSelect'
 import { viewports } from '@cdc/core/helpers/getViewport'
 import { approvedCurveTypes } from '@cdc/core/helpers/lineChartHelpers'
 
@@ -109,7 +110,7 @@ const PreliminaryData: React.FC<PreliminaryProps> = ({ config, updateConfig, dat
     let preliminaryData = config.preliminaryData ? [...config.preliminaryData] : []
     const defaultValues = {
       type: defaultType,
-      seriesKey: '',
+      seriesKeys: [],
       label: 'Suppressed',
       column: '',
       value: '',
@@ -159,7 +160,7 @@ const PreliminaryData: React.FC<PreliminaryProps> = ({ config, updateConfig, dat
               displayTable,
               displayTooltip,
               label,
-              seriesKey,
+              seriesKeys,
               style,
               symbol,
               type,
@@ -384,14 +385,18 @@ const PreliminaryData: React.FC<PreliminaryProps> = ({ config, updateConfig, dat
                   </>
                 ) : (
                   <>
-                    <Select
-                      value={seriesKey}
-                      initial='Select'
-                      fieldName='seriesKey'
-                      label='ASSOCIATE TO SERIES'
-                      updateField={(_, __, fieldName, value) => update(fieldName, value, i)}
-                      options={config.runtime.lineSeriesKeys ?? config.runtime?.seriesKeys}
-                    />
+                    <label>
+                      <span className='edit-label'>ASSOCIATE TO THESE SERIES</span>
+                      <MultiSelect
+                        fieldName='seriesKeys'
+                        updateField={(_, __, fieldName, value) => update(fieldName, value, i)}
+                        options={(config.runtime.lineSeriesKeys ?? config.runtime?.seriesKeys).map(c => ({
+                          label: c,
+                          value: c
+                        }))}
+                        selected={seriesKeys}
+                      />
+                    </label>
                     <Select
                       value={column}
                       initial='Select'

--- a/packages/chart/src/components/LineChart/helpers.ts
+++ b/packages/chart/src/components/LineChart/helpers.ts
@@ -17,19 +17,19 @@ export const createStyles = (props: StyleProps): Style[] => {
 
   const dynamicSeriesKey = dynamicCategory ? originalSeriesKey : seriesKey
   const validPreliminaryData: PreliminaryDataItem[] = preliminaryData.filter(
-    pd => pd.seriesKey && pd.column && pd.value && pd.type && pd.style && pd.type === 'effect'
+    pd => pd.seriesKeys?.length && pd.column && pd.value && pd.type && pd.style && pd.type === 'effect'
   )
   const isEffectLine = (pd, dataPoint) => {
     if (dynamicCategory) {
       return (
         pd.type === 'effect' &&
         pd.style !== 'Open Circles' &&
-        pd.seriesKey === seriesKey &&
+        pd.seriesKeys.includes(seriesKey) &&
         String(dataPoint[dynamicSeriesKey]) === String(pd.value)
       )
     } else {
       return (
-        pd.seriesKey === seriesKey &&
+        pd.seriesKeys.includes(seriesKey) &&
         dataPoint[pd.column] === pd.value &&
         pd.type === 'effect' &&
         pd.style !== 'Open Circles'
@@ -71,11 +71,11 @@ export const filterCircles = (
 ): DataItem[] => {
   // Filter and map preliminaryData to get circlesFiltered
   const circlesFiltered = preliminaryData
-    ?.filter(item => item.style.includes('Circles') && item.type === 'effect')
+    ?.filter(item => item.style.includes('Circles') && item.type === 'effect' && item.seriesKeys?.length)
     .map(item => ({
       column: item.column,
       value: item.value,
-      seriesKey: item.seriesKey,
+      seriesKeys: item.seriesKeys,
       circleSize: item.circleSize,
       style: item.style
     }))
@@ -85,7 +85,7 @@ export const filterCircles = (
     circlesFiltered.forEach(fc => {
       if (
         item[fc.column] === fc.value &&
-        fc.seriesKey === seriesKey &&
+        fc.seriesKeys.includes(seriesKey) &&
         item[seriesKey] &&
         fc.style === 'Open Circles'
       ) {
@@ -98,7 +98,7 @@ export const filterCircles = (
       }
       if (
         (!fc.value || item[fc.column] === fc.value) &&
-        fc.seriesKey === seriesKey &&
+        fc.seriesKeys.includes(seriesKey) &&
         item[seriesKey] &&
         fc.style === 'Filled Circles'
       ) {

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -44,7 +44,7 @@ export interface PreliminaryDataItem {
   iconCode: string
   label: string
   lineCode: string
-  seriesKey: string
+  seriesKeys: string[]
   style: string
   symbol: string
   type: 'effect' | 'suppression'

--- a/packages/core/helpers/coveUpdateWorker.ts
+++ b/packages/core/helpers/coveUpdateWorker.ts
@@ -15,6 +15,7 @@ import update_4_25_1 from './ver/4.25.1'
 import update_4_25_3 from './ver/4.25.3'
 import update_4_25_4 from './ver/4.25.4'
 import update_4_25_6 from './ver/4.25.6'
+import update_4_25_7 from './ver/4.25.7'
 
 export const coveUpdateWorker = (config, multiDashboardVersion?) => {
   let genConfig = config
@@ -32,7 +33,8 @@ export const coveUpdateWorker = (config, multiDashboardVersion?) => {
     ['4.25.1', update_4_25_1],
     ['4.25.3', update_4_25_3],
     ['4.25.4', update_4_25_4],
-    ['4.25.6', update_4_25_6]
+    ['4.25.6', update_4_25_6],
+    ['4.25.7', update_4_25_7]
   ]
 
   versions.forEach(([version, updateFunction, alwaysRun]: [string, UpdateFunction, boolean?]) => {

--- a/packages/core/helpers/ver/4.25.7.ts
+++ b/packages/core/helpers/ver/4.25.7.ts
@@ -3,8 +3,10 @@ import _ from 'lodash'
 export const updatePreliminaryDataSeriesKeys = config => {
   if (config.type === 'chart') {
     ;(config.preliminaryData || []).forEach(pd => {
-      pd.seriesKeys = pd.seriesKey ? [pd.seriesKey] : []
-      delete pd.seriesKey
+      if (!pd.seriesKeys) {
+        pd.seriesKeys = pd.seriesKey ? [pd.seriesKey] : []
+        delete pd.seriesKey
+      }
     })
   } else if (config.type === 'dashboard') {
     Object.values(config.visualizations).forEach(visualization => {

--- a/packages/core/helpers/ver/4.25.7.ts
+++ b/packages/core/helpers/ver/4.25.7.ts
@@ -1,0 +1,24 @@
+import _ from 'lodash'
+
+export const updatePreliminaryDataSeriesKeys = config => {
+  if (config.type === 'chart') {
+    ;(config.preliminaryData || []).forEach(pd => {
+      pd.seriesKeys = pd.seriesKey ? [pd.seriesKey] : []
+      delete pd.seriesKey
+    })
+  } else if (config.type === 'dashboard') {
+    Object.values(config.visualizations).forEach(visualization => {
+      updatePreliminaryDataSeriesKeys(visualization)
+    })
+  }
+}
+
+const update_4_25_7 = config => {
+  const ver = '4.25.7'
+  const newConfig = _.cloneDeep(config)
+  updatePreliminaryDataSeriesKeys(newConfig)
+  newConfig.version = ver
+  return newConfig
+}
+
+export default update_4_25_7


### PR DESCRIPTION
## Summary

This allows the user to associate line effects with multiple series instead of just one series. 

## Testing Steps

Load [multiple-dashed-lines.json](https://github.com/user-attachments/files/20909695/multiple-dashed-lines.json) locally in the chart package.

In the editor, go to [Data Series -> Effect Data] and associate the existing dashed line effect with multiple series. (Careful, you have to click on the down arrow on the dropdown, otherwise it thinks you're deleting the last selected value.)

In the grey area on the chart, you will see a dashed line for each series you've selected. You may have to show/hide some series to see it working. The dashed line item in the chart legend will appear only once.

If you go through the same process on the `dev` branch, you will only be able to associate the dashed line effect with one series at a time. This means you have to create five effects, and the legend ends up looking like this:

![Screenshot 2025-06-25 at 3 57 04 PM](https://github.com/user-attachments/assets/a82a0bf8-a771-4ef3-ba6e-0fb589dc313c)


## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
