### PR TITLE
FIX: [DEV-10704] - Adjust Area Chart Scales for date & categorial axis

### DIFF
--- a/packages/chart/src/components/AreaChart/components/AreaChart.Stacked.jsx
+++ b/packages/chart/src/components/AreaChart/components/AreaChart.Stacked.jsx
@@ -11,7 +11,7 @@ import { Bar, AreaStack } from '@visx/shape'
 import { Group } from '@visx/group'
 import { approvedCurveTypes } from '@cdc/core/helpers/lineChartHelpers'
 
-const AreaChartStacked = ({ xScale, yScale, yMax, xMax, handleTooltipMouseOver, handleTooltipMouseOff, isDebug }) => {
+const AreaChartStacked = ({ xScale, yScale, yMax, xMax, handleTooltipMouseOver, handleTooltipMouseOff }) => {
   // import data from context
   let { transformedData, config, seriesHighlight, colorScale, rawData } = useContext(ConfigContext)
   const data = config.brush?.active && config.brush.data?.length ? config.brush.data : transformedData

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -30,12 +30,14 @@ import CategoricalYAxis from './Axis/Categorical.Axis'
 import { isLegendWrapViewport, isMobileHeightViewport } from '@cdc/core/helpers/viewports'
 import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
 import { calcInitialHeight, handleAutoPaddingRight } from '../helpers/sizeHelpers'
+import { filterAndShiftLinearDateTicks } from '../helpers/filterAndShiftLinearDateTicks'
 
 // Hooks
 import useMinMax from '../hooks/useMinMax'
 import useReduceData from '../hooks/useReduceData'
 import useRightAxis from '../hooks/useRightAxis'
-import useScales, { getTickValues, filterAndShiftLinearDateTicks } from '../hooks/useScales'
+import useScales, { getTickValues } from '../hooks/useScales'
+
 import getTopAxis from '../helpers/getTopAxis'
 import { useTooltip as useCoveTooltip } from '../hooks/useTooltip'
 import { useEditorPermissions } from './EditorPanel/useEditorPermissions'
@@ -663,8 +665,9 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           onMouseMove={onMouseMove}
           width={parentWidth + config.yAxis.rightAxisSize}
           height={isNoDataAvailable ? 1 : parentHeight}
-          className={`linear ${config.animate ? 'animated' : ''} ${animatedChart && config.animate ? 'animate' : ''} ${debugSvg && 'debug'
-            } ${isDraggingAnnotation && 'dragging-annotation'}`}
+          className={`linear ${config.animate ? 'animated' : ''} ${animatedChart && config.animate ? 'animate' : ''} ${
+            debugSvg && 'debug'
+          } ${isDraggingAnnotation && 'dragging-annotation'}`}
           role='img'
           aria-label={handleChartAriaLabels(config)}
           style={{ overflow: 'visible' }}
@@ -757,20 +760,20 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           )}
           {((visualizationType === 'Area Chart' && config.visualizationSubType === 'stacked') ||
             visualizationType === 'Combo') && (
-              <AreaChartStacked
-                xScale={xScale}
-                yScale={yScale}
-                yMax={yMax}
-                xMax={xMax}
-                chartRef={svgRef}
-                width={xMax}
-                height={yMax}
-                handleTooltipMouseOver={handleTooltipMouseOver}
-                handleTooltipMouseOff={handleTooltipMouseOff}
-                tooltipData={tooltipData}
-                showTooltip={showTooltip}
-              />
-            )}
+            <AreaChartStacked
+              xScale={xScale}
+              yScale={yScale}
+              yMax={yMax}
+              xMax={xMax}
+              chartRef={svgRef}
+              width={xMax}
+              height={yMax}
+              handleTooltipMouseOver={handleTooltipMouseOver}
+              handleTooltipMouseOff={handleTooltipMouseOff}
+              tooltipData={tooltipData}
+              showTooltip={showTooltip}
+            />
+          )}
           {(visualizationType === 'Bar' || visualizationType === 'Combo' || convertLineToBarGraph) && (
             <BarChart
               xScale={xScale}
@@ -1018,10 +1021,10 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                         to={
                           runtime.horizontal
                             ? {
-                              x: 0,
-                              y:
-                                config.visualizationType === 'Forest Plot' ? parentHeight : Number(heights.horizontal)
-                            }
+                                x: 0,
+                                y:
+                                  config.visualizationType === 'Forest Plot' ? parentHeight : Number(heights.horizontal)
+                              }
                             : props.axisToPoint
                         }
                         stroke='#000'
@@ -1082,12 +1085,13 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             config.yAxis.labelPlacement === 'On Date/Category Axis' &&
                             !config.yAxis.hideLabel && (
                               <Text
-                                transform={`translate(${tick.to.x - 5}, ${config.isLollipopChart
+                                transform={`translate(${tick.to.x - 5}, ${
+                                  config.isLollipopChart
                                     ? tick.to.y - minY
                                     : tick.to.y -
-                                    minY +
-                                    (Number(config.barHeight * config.runtime.series.length) - barMinHeight) / 2
-                                  }) rotate(-${config.runtime.horizontal ? config.runtime.yAxis.tickRotation || 0 : 0})`}
+                                      minY +
+                                      (Number(config.barHeight * config.runtime.series.length) - barMinHeight) / 2
+                                }) rotate(-${config.runtime.horizontal ? config.runtime.yAxis.tickRotation || 0 : 0})`}
                                 verticalAnchor={'start'}
                                 textAnchor={'end'}
                                 fontSize={tickLabelFontSize}
@@ -1101,8 +1105,9 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             config.yAxis.labelPlacement === 'On Date/Category Axis' &&
                             !config.yAxis.hideLabel && (
                               <Text
-                                transform={`translate(${tick.to.x - 5}, ${tick.to.y - minY + (Number(config.barHeight) - barMinHeight) / 2
-                                  }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
+                                transform={`translate(${tick.to.x - 5}, ${
+                                  tick.to.y - minY + (Number(config.barHeight) - barMinHeight) / 2
+                                }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
                                 verticalAnchor={'start'}
                                 textAnchor={'end'}
                                 fontSize={tickLabelFontSize}
@@ -1115,8 +1120,9 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             visualizationType === 'Paired Bar' &&
                             !config.yAxis.hideLabel && (
                               <Text
-                                transform={`translate(${tick.to.x - 5}, ${tick.to.y - minY + Number(config.barHeight) / 2
-                                  }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
+                                transform={`translate(${tick.to.x - 5}, ${
+                                  tick.to.y - minY + Number(config.barHeight) / 2
+                                }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
                                 textAnchor={'end'}
                                 verticalAnchor='middle'
                                 fontSize={tickLabelFontSize}
@@ -1128,10 +1134,11 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                             visualizationType === 'Deviation Bar' &&
                             !config.yAxis.hideLabel && (
                               <Text
-                                transform={`translate(${tick.to.x - 5}, ${config.isLollipopChart
+                                transform={`translate(${tick.to.x - 5}, ${
+                                  config.isLollipopChart
                                     ? tick.to.y - minY + 2
                                     : tick.to.y - minY + Number(config.barHeight) / 2
-                                  }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
+                                }) rotate(-${runtime.horizontal ? runtime.yAxis.tickRotation : 0})`}
                                 textAnchor={'end'}
                                 verticalAnchor='middle'
                                 fontSize={tickLabelFontSize}
@@ -1162,14 +1169,14 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                                   seriesHighlight.includes(
                                     config.runtime.seriesLabelsAll[tick.formattedValue - 1]
                                   )) && (
-                                    <rect
-                                      x={0 - Number(config.yAxis.size)}
-                                      y={tick.to.y - 8 + (config.runtime.horizontal ? horizontalTickOffset : 7)}
-                                      width={Number(config.yAxis.size) + xScale(xScale.domain()[0])}
-                                      height='2'
-                                      fill={colorScale(config.runtime.seriesLabelsAll[tick.formattedValue - 1])}
-                                    />
-                                  )}
+                                  <rect
+                                    x={0 - Number(config.yAxis.size)}
+                                    y={tick.to.y - 8 + (config.runtime.horizontal ? horizontalTickOffset : 7)}
+                                    width={Number(config.yAxis.size) + xScale(xScale.domain()[0])}
+                                    height='2'
+                                    fill={colorScale(config.runtime.seriesLabelsAll[tick.formattedValue - 1])}
+                                  />
+                                )}
                               </>
                             )}
                           {orientation === 'vertical' &&
@@ -1312,8 +1319,9 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                       className='y-label'
                       textAnchor='middle'
                       verticalAnchor='start'
-                      transform={`translate(${config.yAxis.rightLabelOffsetSize ? config.yAxis.rightLabelOffsetSize : 0
-                        }, ${axisCenter}) rotate(-90)`}
+                      transform={`translate(${
+                        config.yAxis.rightLabelOffsetSize ? config.yAxis.rightLabelOffsetSize : 0
+                      }, ${axisCenter}) rotate(-90)`}
                       fontWeight='bold'
                       fill={config.yAxis.rightAxisLabelColor}
                       fontSize={axisLabelFontSize}
@@ -1345,8 +1353,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                 runtime.horizontal && config.visualizationType !== 'Forest Plot'
                   ? Number(heights.horizontal) + Number(config.xAxis.axisPadding)
                   : config.visualizationType === 'Forest Plot'
-                    ? yMax + Number(config.xAxis.axisPadding)
-                    : yMax
+                  ? yMax + Number(config.xAxis.axisPadding)
+                  : yMax
               }
               left={config.visualizationType !== 'Forest Plot' ? Number(runtime.yAxis.size) : 0}
               label={config[section].label}
@@ -1359,8 +1367,8 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                 config.runtime.xAxis.manual
                   ? getTickValues(xAxisDataMapped, xScale, isDateTime ? xTickCount : getManualStep(), config)
                   : config.runtime.xAxis.type === 'date'
-                    ? xAxisDataMapped
-                    : undefined
+                  ? xAxisDataMapped
+                  : undefined
               }
             >
               {props => {
@@ -1386,14 +1394,14 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
                 // filter out every [distanceBetweenTicks] tick starting from the end, so the last tick is always labeled
                 const filteredTicks = useDateSpanMonths
                   ? [...props.ticks]
-                    .reverse()
-                    .filter((_, i) => i % distanceBetweenTicks === 0)
-                    .reverse()
-                    .map((tick, i, arr) => ({
-                      ...tick,
-                      // reformat in case showYearsOnce, since first month of year may have changed
-                      formattedValue: handleBottomTickFormatting(tick.value, i, arr)
-                    }))
+                      .reverse()
+                      .filter((_, i) => i % distanceBetweenTicks === 0)
+                      .reverse()
+                      .map((tick, i, arr) => ({
+                        ...tick,
+                        // reformat in case showYearsOnce, since first month of year may have changed
+                        formattedValue: handleBottomTickFormatting(tick.value, i, arr)
+                      }))
                   : props.ticks
 
                 const axisMaxHeight = bottomLabelStart + BOTTOM_LABEL_PADDING
@@ -1526,8 +1534,9 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           tooltipData.dataXPosition &&
           !config.tooltips.singleSeries && (
             <>
-              <style>{`.tooltip {background-color: rgba(255,255,255, ${config.tooltips.opacity / 100
-                }) !important;`}</style>
+              <style>{`.tooltip {background-color: rgba(255,255,255, ${
+                config.tooltips.opacity / 100
+              }) !important;`}</style>
               <style>{`.tooltip {max-width:300px} !important; word-wrap: break-word; `}</style>
               <TooltipWithBounds
                 ref={tooltipRef}

--- a/packages/chart/src/helpers/filterAndShiftLinearDateTicks.ts
+++ b/packages/chart/src/helpers/filterAndShiftLinearDateTicks.ts
@@ -1,0 +1,58 @@
+// Ensure that the last tick is shown for charts with a "Date (Linear Scale)" scale
+import { ChartConfig } from '../types/ChartConfig'
+import { getTicks } from '@visx/scale'
+export const filterAndShiftLinearDateTicks = (
+  config: ChartConfig,
+  axisProps: { scale: any; numTicks: number; ticks: { value: any; formattedValue?: string }[] },
+  xAxisDataMapped: any[],
+  formatDate: (value: any, index: number, all: any[]) => string
+) => {
+  // Guard #1: must have a scale & ticks array
+  if (!axisProps?.scale || !Array.isArray(axisProps.ticks)) {
+    return []
+  }
+
+  // Guard #2: if no domain data, just format what we have
+  if (!Array.isArray(xAxisDataMapped) || xAxisDataMapped.length === 0) {
+    axisProps.ticks.forEach((t, i) => {
+      t.formattedValue = formatDate(t.value, i, axisProps.ticks)
+    })
+    return axisProps.ticks
+  }
+
+  // get our filtered tick *values*
+  const filteredTickValues = getTicks(axisProps.scale, axisProps.numTicks) || []
+
+  let ticks = axisProps.ticks
+
+  if (filteredTickValues.length > 0 && filteredTickValues.length < xAxisDataMapped.length) {
+    const lastFiltered = filteredTickValues[filteredTickValues.length - 1]
+    const lastIdx = xAxisDataMapped.indexOf(lastFiltered)
+
+    let shift = 0
+    if (lastIdx >= 0 && lastIdx < xAxisDataMapped.length - 1) {
+      shift = config.xAxis.sortByRecentDate
+        ? -xAxisDataMapped.indexOf(filteredTickValues[0])
+        : xAxisDataMapped.length - 1 - lastIdx
+    }
+
+    ticks = filteredTickValues.map(value => {
+      const baseIndex = axisProps.ticks.findIndex(t => t.value === value)
+      const targetIndex = baseIndex + shift
+
+      // Guard #3: if shifting would go out of bounds, clamp
+      const safeIndex = Math.max(0, Math.min(axisProps.ticks.length - 1, targetIndex))
+      return axisProps.ticks[safeIndex]
+    })
+  }
+
+  // Finally, format all ticks
+  ticks.forEach((tick, i) => {
+    // Guard #4: only format if we actually have a value
+    if (tick && tick.value != null) {
+      tick.formattedValue = formatDate(tick.value, i, ticks)
+    }
+  })
+
+  return ticks
+}


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
Adjusted scales for Area chart to remove padding from both sides of the chart when axis type is 'date' or 'categorical'
To test : open area chart and switch to categorical axis or date and there should not be any paddings
here is example image : 
![Screenshot 2025-06-30 at 19 13 10](https://github.com/user-attachments/assets/59d39630-c82e-4ef3-86c3-fd6218e797e2)

<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
