### PR TITLE
[DEV-11002] Multiple Map Legend Color Fixes

### DIFF
--- a/packages/map/src/_stories/CdcMap.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.stories.tsx
@@ -5,6 +5,7 @@ import SingleStateWithFilters from './_mock/DEV-8942.json'
 import exampleCityState from './_mock/example-city-state.json'
 import { editConfigKeys } from '@cdc/chart/src/helpers/configHelpers'
 import exampleLegendBins from './_mock/legend-bins.json'
+import floatingPoint from './_mock/floating-point.json'
 
 const meta: Meta<typeof CdcMap> = {
   title: 'Components/Templates/Map',
@@ -35,6 +36,7 @@ export const Equal_Number_Map: Story = {
 
 export const Scale_Based: Story = {
   args: {
+    isEditor: true,
     configUrl:
       'https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Scale-Based-Categorical-Map-With-Special-Classes.json'
   }
@@ -161,6 +163,13 @@ export const Custom_Color_Distributions_With_Update_Needed: Story = {
 export const Legend_Bins: Story = {
   args: {
     config: exampleLegendBins,
+    isEditor: true
+  }
+}
+
+export const Legend_Bins_Starting_Point_Fix: Story = {
+  args: {
+    config: floatingPoint,
     isEditor: true
   }
 }

--- a/packages/map/src/_stories/CdcMap.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.stories.tsx
@@ -83,7 +83,8 @@ export const Bubble_Map: Story = {
 
 export const HHS_Region_Map: Story = {
   args: {
-    configUrl: 'https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/example-hhs-regions-data.json'
+    configUrl: 'https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/example-hhs-regions-data.json',
+    isEditor: true
   }
 }
 

--- a/packages/map/src/_stories/_mock/floating-point.json
+++ b/packages/map/src/_stories/_mock/floating-point.json
@@ -1,0 +1,427 @@
+{
+    "general": {
+        "geoType": "us",
+        "geoBorderColor": "darkGray",
+        "showTitle": false,
+        "showSidebar": true,
+        "showDownloadButton": false,
+        "showDownloadMediaButton": false,
+        "displayAsHex": true,
+        "displayStateLabels": false,
+        "territoriesLabel": "Territories",
+        "language": "en",
+        "hasRegions": false,
+        "expandDataTable": false,
+        "fullBorder": false,
+        "type": "data",
+        "palette": {
+            "isReversed": true
+        },
+        "geoLabelOverride": "",
+        "convertFipsCodes": true,
+        "allowMapZoom": true,
+        "hideGeoColumnInTooltip": false,
+        "hidePrimaryColumnInTooltip": false,
+        "superTitle": "",
+        "equalNumberOptIn": true,
+        "navigationTarget": "_self",
+        "noStateFoundMessage": "Map Unavailable",
+        "annotationDropdownText": "Annotations",
+        "headerColor": "theme-blue",
+        "title": "",
+        "territoriesAlwaysShow": false,
+        "statePicked": {
+            "fipsCode": "01",
+            "stateName": "Alabama"
+        }
+    },
+    "type": "map",
+    "customColors": [
+        "gray",
+        "#edf8fb",
+        "gray",
+        "#b3cde3",
+        "gray",
+        "#8c96c6",
+        "#8856a7",
+        "#810f7c"
+    ],
+    "columns": {
+        "geo": {
+            "name": "state",
+            "label": "Location",
+            "tooltip": false,
+            "dataTable": true
+        },
+        "primary": {
+            "dataTable": true,
+            "tooltip": true,
+            "prefix": "",
+            "suffix": "%",
+            "name": "value",
+            "label": "",
+            "roundToPlace": 1
+        },
+        "navigate": {
+            "name": ""
+        },
+        "latitude": {
+            "name": ""
+        },
+        "longitude": {
+            "name": ""
+        }
+    },
+    "legend": {
+        "descriptions": {},
+        "specialClasses": [
+            {
+                "key": "value",
+                "value": "",
+                "label": "No data"
+            }
+        ],
+        "unified": false,
+        "singleColumn": false,
+        "dynamicDescription": false,
+        "type": "equalnumber",
+        "numberOfItems": 5,
+        "position": "side",
+        "title": "Legend",
+        "singleRow": false,
+        "verticalSorted": false,
+        "showSpecialClassesLast": true,
+        "categoryValuesOrder": [
+            "No",
+            "Yes"
+        ]
+    },
+    "filters": [],
+    "table": {
+        "wrapColumns": false,
+        "label": "Data Table",
+        "expanded": false,
+        "limitHeight": false,
+        "height": "",
+        "caption": "",
+        "showDownloadUrl": false,
+        "showDataTableLink": false,
+        "showFullGeoNameInCSV": false,
+        "forceDisplay": false,
+        "download": true,
+        "indexLabel": "",
+        "showDownloadLinkBelow": true,
+        "cellMinWidth": "0"
+    },
+    "tooltips": {
+        "appearanceType": "hover",
+        "linkLabel": "Learn More",
+        "capitalizeLabels": true,
+        "opacity": 90
+    },
+    "visual": {
+        "minBubbleSize": 1,
+        "maxBubbleSize": 20,
+        "extraBubbleBorder": false,
+        "cityStyle": "circle",
+        "cityStyleLabel": "",
+        "showBubbleZeros": false,
+        "additionalCityStyles": [],
+        "geoCodeCircleSize": 8
+    },
+    "mapPosition": {
+        "coordinates": [
+            0,
+            30
+        ],
+        "zoom": 1
+    },
+    "map": {
+        "layers": [],
+        "patterns": []
+    },
+    "filterBehavior": "Filter Change",
+    "dataTable": {
+        "title": "Data Table",
+        "forceDisplay": true,
+        "caption": "Lorem Ipsum - Text added to Data Table Caption",
+        "limitHeight": true,
+        "height": "100"
+    },
+    "orientation": null,
+    "visualizationSubType": null,
+    "validated": "4.24.3",
+    "version": "4.24.12",
+    "data": [
+        {
+            "state": "Alaska",
+            "stratification": "Total",
+            "value": "33.3"
+        },
+        {
+            "state": "Alabama",
+            "stratification": "Total",
+            "value": "32.7"
+        },
+        {
+            "state": "Arkansas",
+            "stratification": "Total",
+            "value": "31.8"
+        },
+        {
+            "state": "Arizona",
+            "stratification": "Total",
+            "value": "34.5"
+        },
+        {
+            "state": "California",
+            "stratification": "Total",
+            "value": "36.4"
+        },
+        {
+            "state": "Colorado",
+            "stratification": "Total",
+            "value": "35.0"
+        },
+        {
+            "state": "Connecticut",
+            "stratification": "Total",
+            "value": "36.5"
+        },
+        {
+            "state": "District of Columbia",
+            "stratification": "Total",
+            "value": "33.5"
+        },
+        {
+            "state": "Delaware",
+            "stratification": "Total",
+            "value": "35.6"
+        },
+        {
+            "state": "Florida",
+            "stratification": "Total",
+            "value": "35.6"
+        },
+        {
+            "state": "Georgia",
+            "stratification": "Total",
+            "value": "33.7"
+        },
+        {
+            "state": "Guam",
+            "stratification": "Total",
+            "value": "34.9"
+        },
+        {
+            "state": "Hawaii",
+            "stratification": "Total",
+            "value": "34.4"
+        },
+        {
+            "state": "Iowa",
+            "stratification": "Total",
+            "value": "34.3"
+        },
+        {
+            "state": "Idaho",
+            "stratification": "Total",
+            "value": "35.7"
+        },
+        {
+            "state": "Illinois",
+            "stratification": "Total",
+            "value": "35.0"
+        },
+        {
+            "state": "Indiana",
+            "stratification": "Total",
+            "value": "33.3"
+        },
+        {
+            "state": "Kansas",
+            "stratification": "Total",
+            "value": "33.3"
+        },
+        {
+            "state": "Kentucky",
+            "stratification": "Total",
+            "value": ""
+        },
+        {
+            "state": "Louisiana",
+            "stratification": "Total",
+            "value": "32.1"
+        },
+        {
+            "state": "Massachusetts",
+            "stratification": "Total",
+            "value": "35.2"
+        },
+        {
+            "state": "Maryland",
+            "stratification": "Total",
+            "value": "34.7"
+        },
+        {
+            "state": "Maine",
+            "stratification": "Total",
+            "value": "35.3"
+        },
+        {
+            "state": "Michigan",
+            "stratification": "Total",
+            "value": "33.4"
+        },
+        {
+            "state": "Minnesota",
+            "stratification": "Total",
+            "value": "34.2"
+        },
+        {
+            "state": "Missouri",
+            "stratification": "Total",
+            "value": "34.3"
+        },
+        {
+            "state": "Mississippi",
+            "stratification": "Total",
+            "value": "31.6"
+        },
+        {
+            "state": "Montana",
+            "stratification": "Total",
+            "value": "35.2"
+        },
+        {
+            "state": "North Carolina",
+            "stratification": "Total",
+            "value": "35.0"
+        },
+        {
+            "state": "North Dakota",
+            "stratification": "Total",
+            "value": "35.8"
+        },
+        {
+            "state": "Nebraska",
+            "stratification": "Total",
+            "value": "34.8"
+        },
+        {
+            "state": "New Hampshire",
+            "stratification": "Total",
+            "value": "35.6"
+        },
+        {
+            "state": "New Jersey",
+            "stratification": "Total",
+            "value": "35.9"
+        },
+        {
+            "state": "New Mexico",
+            "stratification": "Total",
+            "value": "33.9"
+        },
+        {
+            "state": "Nevada",
+            "stratification": "Total",
+            "value": "35.6"
+        },
+        {
+            "state": "New York",
+            "stratification": "Total",
+            "value": "36.1"
+        },
+        {
+            "state": "Ohio",
+            "stratification": "Total",
+            "value": "33.2"
+        },
+        {
+            "state": "Oklahoma",
+            "stratification": "Total",
+            "value": "31.9"
+        },
+        {
+            "state": "Oregon",
+            "stratification": "Total",
+            "value": "33.4"
+        },
+        {
+            "state": "Pennsylvania",
+            "stratification": "Total",
+            "value": ""
+        },
+        {
+            "state": "Puerto Rico",
+            "stratification": "Total",
+            "value": "35.1"
+        },
+        {
+            "state": "Rhode Island",
+            "stratification": "Total",
+            "value": "34.8"
+        },
+        {
+            "state": "South Carolina",
+            "stratification": "Total",
+            "value": "33.9"
+        },
+        {
+            "state": "South Dakota",
+            "stratification": "Total",
+            "value": "34.3"
+        },
+        {
+            "state": "Tennessee",
+            "stratification": "Total",
+            "value": "33.1"
+        },
+        {
+            "state": "Texas",
+            "stratification": "Total",
+            "value": "35.0"
+        },
+        {
+            "state": "Utah",
+            "stratification": "Total",
+            "value": "34.3"
+        },
+        {
+            "state": "Virginia",
+            "stratification": "Total",
+            "value": "34.3"
+        },
+        {
+            "state": "Virgin Islands",
+            "stratification": "Total",
+            "value": "38.2"
+        },
+        {
+            "state": "Vermont",
+            "stratification": "Total",
+            "value": "34.8"
+        },
+        {
+            "state": "Washington",
+            "stratification": "Total",
+            "value": "35.2"
+        },
+        {
+            "state": "Wisconsin",
+            "stratification": "Total",
+            "value": "34.1"
+        },
+        {
+            "state": "West Virginia",
+            "stratification": "Total",
+            "value": "32.0"
+        },
+        {
+            "state": "Wyoming",
+            "stratification": "Total",
+            "value": "35.7"
+        }
+    ]
+}

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -130,9 +130,11 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
 
         return runtimeLegend.items.findIndex(runtimeItem => {
           if (item.special && runtimeItem.special) {
-            // For special classes, match by value or label
-            return runtimeItem.value === (runtimeItem.label || runtimeItem.value) ||
-              runtimeItem.label === (item.label?.props?.children || item.label)
+            // For special classes, match by label (since formatted item label comes from runtime item)
+            const runtimeLabel = runtimeItem.label || runtimeItem.value
+            const itemLabel = typeof item.label === 'string' ? item.label :
+              (item.label?.props?.children || item.label)
+            return runtimeLabel === itemLabel
           } else if (!item.special && !runtimeItem.special) {
             // For categorical/qualitative items, match by single value
             if (config.legend.type === 'category' && item.categoryValue !== undefined) {

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -141,7 +141,7 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
               return runtimeItem.value === item.categoryValue
             }
             // For numeric items, match by min/max values
-            return runtimeItem.min === item.value[0] && runtimeItem.max === item.value[1]
+            return runtimeItem.min === item.value?.[0] && runtimeItem.max === item.value?.[1]
           }
           return false
         })

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -94,7 +94,8 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
           label: parse(legendLabel),
           disabled: entry.disabled,
           special: entry.hasOwnProperty('special'),
-          value: [entry.min, entry.max]
+          value: legend.type === 'category' ? entry.value : [entry.min, entry.max],
+          categoryValue: legend.type === 'category' ? entry.value : undefined
         }
       })
     } catch (e) {
@@ -133,7 +134,11 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
             return runtimeItem.value === (runtimeItem.label || runtimeItem.value) ||
               runtimeItem.label === (item.label?.props?.children || item.label)
           } else if (!item.special && !runtimeItem.special) {
-            // For regular items, match by min/max values
+            // For categorical/qualitative items, match by single value
+            if (config.legend.type === 'category' && item.categoryValue !== undefined) {
+              return runtimeItem.value === item.categoryValue
+            }
+            // For numeric items, match by min/max values
             return runtimeItem.min === item.value[0] && runtimeItem.max === item.value[1]
           }
           return false

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -122,16 +122,37 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
         dispatch({ type: 'SET_ACCESSIBLE_STATUS', payload: message })
       }
 
+      // Find the correct runtime index for toggling
+      // This is needed because special classes may have been moved to the end
+      const findRuntimeIndex = () => {
+        if (!runtimeLegend.items) return idx
+
+        return runtimeLegend.items.findIndex(runtimeItem => {
+          if (item.special && runtimeItem.special) {
+            // For special classes, match by value or label
+            return runtimeItem.value === (runtimeItem.label || runtimeItem.value) ||
+              runtimeItem.label === (item.label?.props?.children || item.label)
+          } else if (!item.special && !runtimeItem.special) {
+            // For regular items, match by min/max values
+            return runtimeItem.min === item.value[0] && runtimeItem.max === item.value[1]
+          }
+          return false
+        })
+      }
+
+      const runtimeIndex = findRuntimeIndex()
+      const safeRuntimeIndex = runtimeIndex >= 0 ? runtimeIndex : idx
+
       return (
         <li
           className={handleListItemClass()}
           key={idx}
           title={`Legend item ${item.label} - Click to disable`}
-          onClick={() => toggleLegendActive(idx, item.label, runtimeLegend, setRuntimeLegend, setAccessibleStatus)}
+          onClick={() => toggleLegendActive(safeRuntimeIndex, item.label, runtimeLegend, setRuntimeLegend, setAccessibleStatus)}
           onKeyDown={e => {
             if (e.key === 'Enter') {
               e.preventDefault()
-              toggleLegendActive(idx, item.label, runtimeLegend, setRuntimeLegend, setAccessibleStatus)
+              toggleLegendActive(safeRuntimeIndex, item.label, runtimeLegend, setRuntimeLegend, setAccessibleStatus)
             }
           }}
           tabIndex={0}
@@ -313,41 +334,41 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
 
             {((config.visual.additionalCityStyles && config.visual.additionalCityStyles.some(c => c.label)) ||
               config.visual.cityStyleLabel) && (
-              <>
-                <hr />
-                <div className={legendClasses.div.join(' ') || ''}>
-                  {config.visual.cityStyleLabel && (
-                    <div>
-                      <svg>
-                        <Group
-                          top={
-                            config.visual.cityStyle === 'pin' ? 19 : config.visual.cityStyle === 'triangle' ? 13 : 11
-                          }
-                          left={10}
-                        >
-                          {cityStyleShapes[config.visual.cityStyle.toLowerCase()]}
-                        </Group>
-                      </svg>
-                      <p>{config.visual.cityStyleLabel}</p>
-                    </div>
-                  )}
+                <>
+                  <hr />
+                  <div className={legendClasses.div.join(' ') || ''}>
+                    {config.visual.cityStyleLabel && (
+                      <div>
+                        <svg>
+                          <Group
+                            top={
+                              config.visual.cityStyle === 'pin' ? 19 : config.visual.cityStyle === 'triangle' ? 13 : 11
+                            }
+                            left={10}
+                          >
+                            {cityStyleShapes[config.visual.cityStyle.toLowerCase()]}
+                          </Group>
+                        </svg>
+                        <p>{config.visual.cityStyleLabel}</p>
+                      </div>
+                    )}
 
-                  {config.visual.additionalCityStyles.map(
-                    ({ shape, label }) =>
-                      label && (
-                        <div>
-                          <svg>
-                            <Group top={shape === 'Pin' ? 19 : shape === 'Triangle' ? 13 : 11} left={10}>
-                              {cityStyleShapes[shape.toLowerCase()]}
-                            </Group>
-                          </svg>
-                          <p>{label}</p>
-                        </div>
-                      )
-                  )}
-                </div>
-              </>
-            )}
+                    {config.visual.additionalCityStyles.map(
+                      ({ shape, label }) =>
+                        label && (
+                          <div>
+                            <svg>
+                              <Group top={shape === 'Pin' ? 19 : shape === 'Triangle' ? 13 : 11} left={10}>
+                                {cityStyleShapes[shape.toLowerCase()]}
+                              </Group>
+                            </svg>
+                            <p>{label}</p>
+                          </div>
+                        )
+                    )}
+                  </div>
+                </>
+              )}
             {runtimeLegend.disabledAmt > 0 && (
               <Button className={legendClasses.showAllButton.join(' ')} onClick={handleReset}>
                 Show All

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -7,55 +7,123 @@ type LegendItem = {
   special: boolean
 }
 
-//  Applies color to a legend item based on its index and special classes.
-export const applyColorToLegend = (legendItemIndex: number, config: MapConfig, result: LegendItem[] = []): string => {
-  if (!config) throw new Error('Config is required')
+const SPECIAL_CLASS_COLORS = ['#D4D4D4', '#939393']
+const DEFAULT_COLOR_PALETTE = 'bluegreen'
+const MAX_LEGEND_ITEMS = 10
+const REGION_MAP_COLOR_DARKEN_FACTOR = 0.75
+
+/**
+ * Extends a color palette for US region maps by adding a darkened color
+ */
+const handleColorPaletteForRegionMap = (
+  colorPalette: string[],
+  palette: { isReversed: boolean }
+): void => {
+  const sourceIndex = palette.isReversed ? 0 : 8
+  const darkenedColor = chroma(colorPalette[sourceIndex])
+    .darken(REGION_MAP_COLOR_DARKEN_FACTOR)
+    .hex()
+
+  if (palette.isReversed) {
+    colorPalette.unshift(darkenedColor)
+  } else {
+    colorPalette.push(darkenedColor)
+  }
+}
+
+/**
+ * Generates colors for special classes using a grayscale gradient
+ */
+const getSpecialClassColor = (index: number, specialClassCount: number): string => {
+  const specialClassColors = chroma.scale(SPECIAL_CLASS_COLORS).colors(specialClassCount)
+  return specialClassColors[index]
+}
+
+/**
+ * Gets color for qualitative palettes with safe index bounds
+ */
+const getQualitativeColor = (colorIndex: number, colorPalette: string[]): string => {
+  const safeIndex = Math.max(0, Math.min(colorIndex, colorPalette.length - 1))
+  return colorPalette[safeIndex]
+}
+
+/**
+ * Calculates the effective legend item count for color distribution
+ */
+const calculateLegendItemCount = (totalItems: number, specialClassCount: number): number => {
+  const regularItemCount = Math.max(totalItems - specialClassCount, 1)
+  return regularItemCount < MAX_LEGEND_ITEMS
+    ? regularItemCount
+    : Object.keys(colorDistributions).length
+}
+
+/**
+ * Gets color using distribution-based indexing
+ */
+const getDistributionBasedColor = (
+  legendItemIndex: number,
+  specialClassCount: number,
+  legendItemCount: number,
+  colorPalette: string[]
+): string | undefined => {
+  const colorDistributionArray = colorDistributions[legendItemCount] ?? []
+  const distributionIndex = colorDistributionArray[legendItemIndex - specialClassCount]
+  const regularItemColorIndex = legendItemIndex - specialClassCount
+
+  // If regularItemColorIndex is negative, return undefined (like original behavior)
+  if (regularItemColorIndex < 0) {
+    return undefined
+  }
+
+  // Use distribution index if available, otherwise use regular index
+  const colorIndex = distributionIndex ?? regularItemColorIndex
+
+  return colorPalette[colorIndex] ?? colorPalette[colorPalette.length - 1]
+}
+
+/**
+ * Applies color to a legend item based on its index and special classes.
+ */
+export const applyColorToLegend = (
+  legendItemIndex: number,
+  config: MapConfig,
+  result: LegendItem[] = []
+): string | undefined => {
+  if (!config) {
+    throw new Error('Config is required')
+  }
 
   const { legend, customColors, general, color } = config
   const { geoType, palette } = general
   const specialClasses = legend?.specialClasses ?? []
-  const colorPalette = customColors ?? colorPalettes[color] ?? colorPalettes['bluegreen']
+  const colorPalette = customColors ?? colorPalettes[color] ?? colorPalettes[DEFAULT_COLOR_PALETTE]
 
   // Handle Region Maps need for a 10th color
-  if (geoType === 'us-region' && colorPalette.length < 10 && colorPalette.length > 8) {
-    const darkenedColor = chroma(colorPalette[palette.isReversed ? 0 : 8])
-      .darken(0.75)
-      .hex()
-    palette.isReversed ? colorPalette.unshift(darkenedColor) : colorPalette.push(darkenedColor)
+  if (geoType === 'us-region' &&
+    colorPalette.length < MAX_LEGEND_ITEMS &&
+    colorPalette.length > 8) {
+    handleColorPaletteForRegionMap(colorPalette, palette)
   }
 
   const regularItemColorIndex = legendItemIndex - specialClasses.length
 
   // Handle special classes coloring
   if (result[legendItemIndex]?.special) {
-    const specialClassColors = chroma.scale(['#D4D4D4', '#939393']).colors(specialClasses.length)
-    return specialClassColors[legendItemIndex]
+    return getSpecialClassColor(legendItemIndex, specialClasses.length)
   }
 
   // Use qualitative color palettes directly
   if (color.includes('qualitative')) {
-    const safeIndex = Math.max(0, Math.min(regularItemColorIndex, colorPalette.length - 1))
-    return colorPalette[safeIndex]
+    return getQualitativeColor(regularItemColorIndex, colorPalette)
   }
 
-  // Determine color distribution
-  const legendItemCount =
-    Math.max(result.length - specialClasses.length, 1) < 10
-      ? Math.max(result.length - specialClasses.length, 1)
-      : Object.keys(colorDistributions).length
+  // Handle distribution-based coloring
+  const legendItemCount = calculateLegendItemCount(result.length, specialClasses.length)
 
-  const colorDistributionArray = colorDistributions[legendItemCount] ?? []
-
-  const rowDistributionIndex = colorDistributionArray[legendItemIndex - specialClasses.length]
-
-  const colorValue =
-    rowDistributionIndex ?? colorPalette[regularItemColorIndex] ?? colorPalette.at(-1)
-
-  // Check if specificColor is a string (e.g., a valid color code)
-  // if (typeof colorValue === 'string') {
-  //   return colorValue
-  // }
-
-  // Otherwise, use specificColor as an index for mapColorPalette
-  return colorPalette[colorValue]
+  return getDistributionBasedColor(
+    legendItemIndex,
+    specialClasses.length,
+    legendItemCount,
+    colorPalette
+  )
 }

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -41,10 +41,10 @@ export const applyColorToLegend = (legendItemIndex: number, config: MapConfig, r
     const distributionArray = colorDistributions[amt] ?? []
 
     const specificColor =
-      distributionArray[legendItemIndex - specialClasses.length] ?? colorPalette[regularItemColorIndex] ?? colorPalette.at(-1)
+      distributionArray[legendItemIndex - specialClasses.length] ?? colorPalette.at(-1)
 
     // If specificColor is a number, use it as an index; otherwise return the color directly
-    return typeof specificColor === 'string' ? specificColor : colorPalette[specificColor]
+    return colorPalette[specificColor] ?? '#fff'
   }
 
   // Use qualitative color palettes directly

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -61,8 +61,11 @@ export const applyColorToLegend = (legendIdx: number, config: MapConfig, result:
       : Object.keys(colorDistributions).length
   const distributionArray = colorDistributions[amt] ?? []
 
-  const specificColor =
-    distributionArray[legendIdx - actualSpecialClassCount] ?? mapColorPalette[colorIdx] ?? mapColorPalette.at(-1)
+  const distributionIndex = distributionArray[legendIdx - actualSpecialClassCount]
 
-  return mapColorPalette[specificColor]
+  if (distributionIndex !== undefined) {
+    return mapColorPalette[distributionIndex]
+  }
+
+  return mapColorPalette[colorIdx] ?? mapColorPalette.at(-1)
 }

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -35,6 +35,18 @@ export const applyColorToLegend = (legendItemIndex: number, config: MapConfig, r
     return specialClassColors[legendItemIndex]
   }
 
+  // For categorical maps with custom colors, use color distribution logic
+  if (config.legend?.type === 'category' && customColors) {
+    const amt = config.legend.additionalCategories?.length ?? 10
+    const distributionArray = colorDistributions[amt] ?? []
+
+    const specificColor =
+      distributionArray[legendItemIndex - specialClasses.length] ?? colorPalette[regularItemColorIndex] ?? colorPalette.at(-1)
+
+    // If specificColor is a number, use it as an index; otherwise return the color directly
+    return typeof specificColor === 'string' ? specificColor : colorPalette[specificColor]
+  }
+
   // Use qualitative color palettes directly
   if (color.includes('qualitative')) {
     const safeIndex = Math.max(0, Math.min(regularItemColorIndex, colorPalette.length - 1))
@@ -54,10 +66,10 @@ export const applyColorToLegend = (legendItemIndex: number, config: MapConfig, r
   const colorValue =
     rowDistributionIndex ?? colorPalette[regularItemColorIndex] ?? colorPalette.at(-1)
 
-  // Check if specificColor is a string (e.g., a valid color code)
-  // if (typeof colorValue === 'string') {
-  //   return colorValue
-  // }
+  // Check if specificColor is a string(e.g., a valid color code)
+  if (typeof colorValue === 'string' && config.legend?.type === 'category' && customColors) {
+    return colorValue
+  }
 
   // Otherwise, use specificColor as an index for mapColorPalette
   return colorPalette[colorValue]

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -47,13 +47,9 @@ export const applyColorToLegend = (legendItemIndex: number, config: MapConfig, r
   const colorDistributionArray = colorDistributions[legendItemCount] ?? []
 
   const rowDistributionIndex = colorDistributionArray[legendItemIndex - specialClasses.length]
-  // Only increment if the original index points to "gray" and we have custom colors
-  const finalDistributionIndex = rowDistributionIndex !== undefined ?
-    (customColors && (rowDistributionIndex === 0 || rowDistributionIndex === 2 || rowDistributionIndex === 4) ?
-      rowDistributionIndex + 1 : rowDistributionIndex) : undefined
 
   const colorValue =
-    finalDistributionIndex ?? colorPalette[regularItemColorIndex] ?? colorPalette.at(-1)
+    rowDistributionIndex ?? colorPalette[regularItemColorIndex] ?? colorPalette.at(-1)
 
   // Check if specificColor is a string (e.g., a valid color code)
   if (typeof colorValue === 'string') {

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -30,12 +30,25 @@ export const applyColorToLegend = (legendIdx: number, config: MapConfig, result:
     palette.isReversed ? mapColorPalette.unshift(newColor) : mapColorPalette.push(newColor)
   }
 
-  const colorIdx = legendIdx - specialClasses.length
+  // Count actual special classes in the current legend items (after filtering)
+  const actualSpecialClassCount = result.filter(item => item.special).length
+  const colorIdx = legendIdx - actualSpecialClassCount
+
+  // Handle Region Maps need for a 10th color
+  if (geoType === 'us-region' && mapColorPalette.length < 10 && mapColorPalette.length > 8) {
+    const newColor = chroma(mapColorPalette[palette.isReversed ? 0 : 8])
+      .darken(0.75)
+      .hex()
+    palette.isReversed ? mapColorPalette.unshift(newColor) : mapColorPalette.push(newColor)
+  }
 
   // Handle special classes coloring
   if (result[legendIdx]?.special) {
-    const specialClassColors = chroma.scale(['#D4D4D4', '#939393']).colors(specialClasses.length)
-    return specialClassColors[legendIdx]
+    // Use the actual count of special classes in the legend, not the config count
+    const specialClassColors = chroma.scale(['#D4D4D4', '#939393']).colors(Math.max(actualSpecialClassCount, 1))
+    // Find the index among special classes only
+    const specialClassIndex = result.slice(0, legendIdx + 1).filter(item => item.special).length - 1
+    return specialClassColors[specialClassIndex] || specialClassColors[0]
   }
 
   // Use qualitative color palettes directly
@@ -43,13 +56,13 @@ export const applyColorToLegend = (legendIdx: number, config: MapConfig, result:
 
   // Determine color distribution
   const amt =
-    Math.max(result.length - specialClasses.length, 1) < 10
-      ? Math.max(result.length - specialClasses.length, 1)
+    Math.max(result.length - actualSpecialClassCount, 1) < 10
+      ? Math.max(result.length - actualSpecialClassCount, 1)
       : Object.keys(colorDistributions).length
   const distributionArray = colorDistributions[amt] ?? []
 
   const specificColor =
-    distributionArray[legendIdx - specialClasses.length] ?? mapColorPalette[colorIdx] ?? mapColorPalette.at(-1)
+    distributionArray[legendIdx - actualSpecialClassCount] ?? mapColorPalette[colorIdx] ?? mapColorPalette.at(-1)
 
   return mapColorPalette[specificColor]
 }

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -52,9 +52,9 @@ export const applyColorToLegend = (legendItemIndex: number, config: MapConfig, r
     rowDistributionIndex ?? colorPalette[regularItemColorIndex] ?? colorPalette.at(-1)
 
   // Check if specificColor is a string (e.g., a valid color code)
-  if (typeof colorValue === 'string') {
-    return colorValue
-  }
+  // if (typeof colorValue === 'string') {
+  //   return colorValue
+  // }
 
   // Otherwise, use specificColor as an index for mapColorPalette
   return colorPalette[colorValue]

--- a/packages/map/src/helpers/applyColorToLegend.ts
+++ b/packages/map/src/helpers/applyColorToLegend.ts
@@ -7,123 +7,58 @@ type LegendItem = {
   special: boolean
 }
 
-const SPECIAL_CLASS_COLORS = ['#D4D4D4', '#939393']
-const DEFAULT_COLOR_PALETTE = 'bluegreen'
-const MAX_LEGEND_ITEMS = 10
-const REGION_MAP_COLOR_DARKEN_FACTOR = 0.75
-
-/**
- * Extends a color palette for US region maps by adding a darkened color
- */
-const handleColorPaletteForRegionMap = (
-  colorPalette: string[],
-  palette: { isReversed: boolean }
-): void => {
-  const sourceIndex = palette.isReversed ? 0 : 8
-  const darkenedColor = chroma(colorPalette[sourceIndex])
-    .darken(REGION_MAP_COLOR_DARKEN_FACTOR)
-    .hex()
-
-  if (palette.isReversed) {
-    colorPalette.unshift(darkenedColor)
-  } else {
-    colorPalette.push(darkenedColor)
-  }
-}
-
-/**
- * Generates colors for special classes using a grayscale gradient
- */
-const getSpecialClassColor = (index: number, specialClassCount: number): string => {
-  const specialClassColors = chroma.scale(SPECIAL_CLASS_COLORS).colors(specialClassCount)
-  return specialClassColors[index]
-}
-
-/**
- * Gets color for qualitative palettes with safe index bounds
- */
-const getQualitativeColor = (colorIndex: number, colorPalette: string[]): string => {
-  const safeIndex = Math.max(0, Math.min(colorIndex, colorPalette.length - 1))
-  return colorPalette[safeIndex]
-}
-
-/**
- * Calculates the effective legend item count for color distribution
- */
-const calculateLegendItemCount = (totalItems: number, specialClassCount: number): number => {
-  const regularItemCount = Math.max(totalItems - specialClassCount, 1)
-  return regularItemCount < MAX_LEGEND_ITEMS
-    ? regularItemCount
-    : Object.keys(colorDistributions).length
-}
-
-/**
- * Gets color using distribution-based indexing
- */
-const getDistributionBasedColor = (
-  legendItemIndex: number,
-  specialClassCount: number,
-  legendItemCount: number,
-  colorPalette: string[]
-): string | undefined => {
-  const colorDistributionArray = colorDistributions[legendItemCount] ?? []
-  const distributionIndex = colorDistributionArray[legendItemIndex - specialClassCount]
-  const regularItemColorIndex = legendItemIndex - specialClassCount
-
-  // If regularItemColorIndex is negative, return undefined (like original behavior)
-  if (regularItemColorIndex < 0) {
-    return undefined
-  }
-
-  // Use distribution index if available, otherwise use regular index
-  const colorIndex = distributionIndex ?? regularItemColorIndex
-
-  return colorPalette[colorIndex] ?? colorPalette[colorPalette.length - 1]
-}
-
-/**
- * Applies color to a legend item based on its index and special classes.
- */
-export const applyColorToLegend = (
-  legendItemIndex: number,
-  config: MapConfig,
-  result: LegendItem[] = []
-): string | undefined => {
-  if (!config) {
-    throw new Error('Config is required')
-  }
+//  Applies color to a legend item based on its index and special classes.
+export const applyColorToLegend = (legendItemIndex: number, config: MapConfig, result: LegendItem[] = []): string => {
+  if (!config) throw new Error('Config is required')
 
   const { legend, customColors, general, color } = config
   const { geoType, palette } = general
   const specialClasses = legend?.specialClasses ?? []
-  const colorPalette = customColors ?? colorPalettes[color] ?? colorPalettes[DEFAULT_COLOR_PALETTE]
+  const colorPalette = customColors ?? colorPalettes[color] ?? colorPalettes['bluegreen']
 
   // Handle Region Maps need for a 10th color
-  if (geoType === 'us-region' &&
-    colorPalette.length < MAX_LEGEND_ITEMS &&
-    colorPalette.length > 8) {
-    handleColorPaletteForRegionMap(colorPalette, palette)
+  if (geoType === 'us-region' && colorPalette.length < 10 && colorPalette.length > 8) {
+    const darkenedColor = chroma(colorPalette[palette.isReversed ? 0 : 8])
+      .darken(0.75)
+      .hex()
+    palette.isReversed ? colorPalette.unshift(darkenedColor) : colorPalette.push(darkenedColor)
   }
 
-  const regularItemColorIndex = legendItemIndex - specialClasses.length
+  // Check if there are actually any special classes in the current result
+  const actualSpecialClassesCount = result.filter(item => item.special).length
+
+  const regularItemColorIndex = legendItemIndex - actualSpecialClassesCount
 
   // Handle special classes coloring
   if (result[legendItemIndex]?.special) {
-    return getSpecialClassColor(legendItemIndex, specialClasses.length)
+    const specialClassColors = chroma.scale(['#D4D4D4', '#939393']).colors(specialClasses.length)
+    return specialClassColors[legendItemIndex]
   }
 
   // Use qualitative color palettes directly
   if (color.includes('qualitative')) {
-    return getQualitativeColor(regularItemColorIndex, colorPalette)
+    const safeIndex = Math.max(0, Math.min(regularItemColorIndex, colorPalette.length - 1))
+    return colorPalette[safeIndex]
   }
 
-  // Handle distribution-based coloring
-  const legendItemCount = calculateLegendItemCount(result.length, specialClasses.length)
+  // Determine color distribution - use actual special classes count for consistent coloring
+  const legendItemCount =
+    Math.max(result.length - actualSpecialClassesCount, 1) < 10
+      ? Math.max(result.length - actualSpecialClassesCount, 1)
+      : Object.keys(colorDistributions).length
 
-  return getDistributionBasedColor(
-    legendItemIndex,
-    specialClasses.length,
-    legendItemCount,
-    colorPalette
-  )
+  const colorDistributionArray = colorDistributions[legendItemCount] ?? []
+
+  const rowDistributionIndex = colorDistributionArray[legendItemIndex - actualSpecialClassesCount]
+
+  const colorValue =
+    rowDistributionIndex ?? colorPalette[regularItemColorIndex] ?? colorPalette.at(-1)
+
+  // Check if specificColor is a string (e.g., a valid color code)
+  // if (typeof colorValue === 'string') {
+  //   return colorValue
+  // }
+
+  // Otherwise, use specificColor as an index for mapColorPalette
+  return colorPalette[colorValue]
 }

--- a/packages/map/src/helpers/applyLegendToRow.ts
+++ b/packages/map/src/helpers/applyLegendToRow.ts
@@ -29,7 +29,7 @@ export const applyLegendToRow = (
       return generateColorsArray(mapColorPalette[3])
     }
 
-    const hash = hashObj(rowObj)
+    const hash = String(hashObj(rowObj))
 
     if (!legendMemo.current.has(hash)) {
       return generateColorsArray()
@@ -42,8 +42,11 @@ export const applyLegendToRow = (
       return generateColorsArray()
     }
 
-    const legendBinColor = runtimeLegend.items.find(o => o.bin === idx)?.color
-    return generateColorsArray(legendBinColor, runtimeLegend.items[idx]?.special)
+    // Get the legend item directly by index instead of searching by bin
+    const legendItem = runtimeLegend.items?.[idx]
+    const legendBinColor = legendItem?.color
+
+    return generateColorsArray(legendBinColor, legendItem?.special)
   } catch (e) {
     console.error('COVE: ', e)
     return null

--- a/packages/map/src/helpers/applyLegendToRow.ts
+++ b/packages/map/src/helpers/applyLegendToRow.ts
@@ -36,13 +36,12 @@ export const applyLegendToRow = (
     }
 
     const idx = legendMemo.current.get(hash)!
-    const disabledIdx = showSpecialClassesLast ? legendSpecialClassLastMemo.current.get(hash) ?? idx : idx
 
-    if (runtimeLegend.items?.[disabledIdx]?.disabled) {
+    if (runtimeLegend.items?.[idx]?.disabled) {
       return generateColorsArray()
     }
 
-    // Get the legend item directly by index instead of searching by bin
+    // Use the index from legendMemo which should already be updated for reordered items
     const legendItem = runtimeLegend.items?.[idx]
     const legendBinColor = legendItem?.color
 

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -258,11 +258,13 @@ export const generateRuntimeLegend = (
 
           if (originalData) {
             // Use the original index for color calculation to maintain proper color sequence
-            const appliedColor = applyColorToLegend(originalData.originalIndex, configObj, originalCategoricalItems.map(o => o.item))
+            const contextArray = originalCategoricalItems.slice(0, originalData.originalIndex + 1).map(o => o.item)
+            const appliedColor = applyColorToLegend(originalData.originalIndex, configObj, contextArray)
             result.items[i].color = appliedColor
           } else {
             // Fallback: apply color normally
-            const appliedColor = applyColorToLegend(i, configObj, result.items)
+            const contextArray = result.items.slice(0, i + 1)
+            const appliedColor = applyColorToLegend(i, configObj, contextArray)
             result.items[i].color = appliedColor
           }
         }
@@ -271,7 +273,9 @@ export const generateRuntimeLegend = (
         legendMemo.current = newLegendMemo
 
         for (let i = 0; i < result.items.length; i++) {
-          const appliedColor = applyColorToLegend(i, configObj, result.items)
+          // Create a context array that simulates the original incremental state
+          const contextArray = result.items.slice(0, i + 1)
+          const appliedColor = applyColorToLegend(i, configObj, contextArray)
           result.items[i].color = appliedColor
         }
       }
@@ -660,11 +664,13 @@ export const generateRuntimeLegend = (
 
         if (originalData) {
           // Use the original index for color calculation to maintain proper color sequence
-          const appliedColor = applyColorToLegend(originalData.originalIndex, configObj, originalItems.map(o => o.item))
+          const contextArray = originalItems.slice(0, originalData.originalIndex + 1).map(o => o.item)
+          const appliedColor = applyColorToLegend(originalData.originalIndex, configObj, contextArray)
           result.items[i].color = appliedColor
         } else {
           // Fallback: apply color normally
-          const appliedColor = applyColorToLegend(i, configObj, result.items)
+          const contextArray = result.items.slice(0, i + 1)
+          const appliedColor = applyColorToLegend(i, configObj, contextArray)
           result.items[i].color = appliedColor
         }
       }
@@ -684,11 +690,11 @@ export const generateRuntimeLegend = (
         }
       })
     } else {
-      // Simple case: no special sorting, just apply colors normally
       legendMemo.current = newLegendMemo
 
       for (let i = 0; i < result.items.length; i++) {
-        const appliedColor = applyColorToLegend(i, configObj, result.items)
+        const contextArray = result.items.slice(0, i + 1)
+        const appliedColor = applyColorToLegend(i, configObj, contextArray)
         result.items[i].color = appliedColor
       }
     }

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -415,6 +415,7 @@ export const generateRuntimeLegend = (
         }
 
         // eslint-disable-next-line array-callback-return
+        let previousMax = null
         cachedBreaks.map((item, index) => {
           const setMin = index => {
             let min = cachedBreaks[index]
@@ -429,10 +430,10 @@ export const generateRuntimeLegend = (
               min = 1
             }
 
-            // For non-first ranges, add small increment to prevent overlap
-            if (index > 0 && !legend.separateZero) {
+            // For non-first ranges, use the previous max + small increment to prevent overlap
+            if (index > 0 && !legend.separateZero && previousMax !== null) {
               const decimalPlace = Number(configObj?.columns?.primary?.roundToPlace) || 1
-              min = convertAndRoundValue(Number(cachedBreaks[index]) + Math.pow(10, -decimalPlace), decimalPlace)
+              min = convertAndRoundValue(previousMax + Math.pow(10, -decimalPlace), decimalPlace)
             }
 
             return convertAndRoundValue(min, roundToPlace)
@@ -458,6 +459,9 @@ export const generateRuntimeLegend = (
 
           let min = setMin(index)
           let max = setMax(index)
+
+          // Store the max value for the next iteration
+          previousMax = max
 
           result.items.push({
             min,

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -194,8 +194,6 @@ export const generateRuntimeLegend = (
         }
       })
 
-      // Colors will be applied later after sorting
-
       // before returning the legend result
       // add property for bin number and set to index location
       setBinNumbers(result)
@@ -565,7 +563,6 @@ export const generateRuntimeLegend = (
 
         result.items.push(range)
 
-        // Color will be applied later after sorting
       }
     }
 

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -303,28 +303,26 @@ export const generateRuntimeLegend = (
     if (true === legend.separateZero && !general.equalNumberOptIn) {
       let addLegendItem = false
 
+      // First, add the zero bucket
+      result.items.push({
+        min: 0,
+        max: 0
+      })
+
+      // Then process zero values and assign them to the zero bucket (index 0)
       for (let i = 0; i < dataSet.length; i++) {
         if (dataSet[i][primaryColName] === 0) {
           addLegendItem = true
 
           let row = dataSet.splice(i, 1)[0]
 
-          newLegendMemo.set(String(hashObj(row)), result.items.length)
+          newLegendMemo.set(String(hashObj(row)), 0) // Assign to the zero bucket at index 0
           i--
         }
       }
 
       if (addLegendItem) {
         legendNumber -= 1 // This zero takes up one legend item
-
-        // Add new legend item
-        result.items.push({
-          min: 0,
-          max: 0
-        })
-
-        let lastIdx = result.items.length - 1
-
       }
     }
 

--- a/packages/map/src/types/runtimeLegend.ts
+++ b/packages/map/src/types/runtimeLegend.ts
@@ -1,1 +1,6 @@
-export type RuntimeLegend = { disabled; bin; color; special }[]
+export type RuntimeLegend = {
+    items: { disabled?: boolean; bin?: number; color?: string; special?: boolean; value?: any; label?: string; min?: number; max?: number }[]
+    disabledAmt?: number
+    fromHash?: number
+    runtimeDataHash?: number
+}


### PR DESCRIPTION
## Summary
* [DEV-11002]: On maps with filters color palettes generated wrong colors after filtering.
* [DEV-11094]: In certain situations bins had floating point artifacts which caused colors to not be colored in. ie. 35.800000004 instead of 35.8
* [DEV-11093]: When legend > separate zero was checked and use new quantile legend was being used, bin numbers were repeated, ie. 0, 1-10, 10-12 instead of 0, 1-10, 11-12
* [DEV-11095]: When special class was toggled to the end of the legend area the colors were displaying wrong, ie white instead of the first color in the color palette.
* [DEV-11096]: When special classes were set to show last, toggling the special class toggled the first color on the map instead of the special class.

## Testing Steps

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
