### PR TITLE
FIX : [DEV-10723] -Increase target size for N/A hovers

### DIFF
--- a/packages/chart/src/_stories/Chart.tooltip.stories.tsx
+++ b/packages/chart/src/_stories/Chart.tooltip.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import Chart from '../CdcChartComponent'
-
+import barChartStacked from './_mock/barchart_labels.mock.json'
+import barChartSuppressed from './_mock/bar-chart-suppressed.json'
 const meta: Meta<typeof Chart> = {
   title: 'Components/Templates/Chart/Tooltip',
   component: Chart
@@ -9,294 +10,53 @@ const meta: Meta<typeof Chart> = {
 
 type Story = StoryObj<typeof Chart>
 
+export const Increased_Tooltip_Range: Story = {
+  args: {
+    config: {
+      ...barChartSuppressed,
+      title: 'Increased Tooltip hovers range for missing and suppressed bars',
+      tooltips: {
+        ...barChartSuppressed.tooltips,
+        singleSeries: true
+      }
+    }
+  }
+}
+
 export const Additional_Tooltip: Story = {
   args: {
     config: {
-      type: 'chart',
-      debugSvg: false,
-      chartMessage: {
-        noData: 'No Data Available'
-      },
-      title: 'Example Stacked Bar Chart with Additional tolltip column',
+      ...barChartStacked,
+      title: 'Stacked Bar Chart with Additional Tooltip Column',
       showTitle: true,
-      showDownloadMediaButton: false,
-      theme: 'theme-orange',
-      animate: false,
-      lineDatapointStyle: 'hover',
-      barHasBorder: 'false',
-      isLollipopChart: false,
-      lollipopShape: 'circle',
-      lollipopColorStyle: 'two-tone',
       visualizationSubType: 'stacked',
-      barStyle: '',
-      roundingStyle: 'standard',
-      tipRounding: 'top',
-      isResponsiveTicks: false,
-      general: {
-        showDownloadButton: false
-      },
-      padding: {
-        left: 5,
-        right: 5
-      },
-      yAxis: {
-        hideAxis: false,
-        displayNumbersOnBar: false,
-        hideLabel: false,
-        hideTicks: false,
-        size: '64',
-        gridLines: false,
-        enablePadding: false,
-        min: '',
-        max: '',
-        labelColor: '#333',
-        tickLabelColor: '#333',
-        tickColor: '#333',
-        rightHideAxis: true,
-        rightAxisSize: 0,
-        rightLabel: '',
-        rightLabelOffsetSize: 0,
-        rightAxisLabelColor: '#333',
-        rightAxisTickLabelColor: '#333',
-        rightAxisTickColor: '#333',
-        numTicks: '',
-        axisPadding: 0,
-        tickRotation: 0,
-        anchors: [],
-        label: 'Y-Axis Label Example'
-      },
-      boxplot: {
-        plots: [],
-        borders: 'true',
-        firstQuartilePercentage: 25,
-        thirdQuartilePercentage: 75,
-        boxWidthPercentage: 40,
-        plotOutlierValues: false,
-        plotNonOutlierValues: true,
-        legend: {
-          showHowToReadText: false,
-          howToReadText: ''
-        },
-        labels: {
-          q1: 'Lower Quartile',
-          q2: 'q2',
-          q3: 'Upper Quartile',
-          q4: 'q4',
-          minimum: 'Minimum',
-          maximum: 'Maximum',
-          mean: 'Mean',
-          median: 'Median',
-          sd: 'Standard Deviation',
-          iqr: 'Interquartile Range',
-          total: 'Total',
-          outliers: 'Outliers',
-          values: 'Values',
-          lowerBounds: 'Lower Bounds',
-          upperBounds: 'Upper Bounds'
+      series: [
+        ...barChartStacked.series,
+        {
+          dataKey: 'White, non-Hispanic',
+          type: 'Bar',
+          axis: 'Left',
+          tooltip: true
         }
-      },
-      topAxis: {
-        hasLine: false
-      },
-      isLegendValue: false,
-      barThickness: 0.35,
-      barHeight: 25,
-      barSpace: 15,
-      heights: {
-        vertical: 300,
-        horizontal: 750
-      },
-      xAxis: {
-        sortDates: false,
-        anchors: [],
-        type: 'categorical',
-        showTargetLabel: true,
-        targetLabel: 'Target',
-        hideAxis: false,
-        hideLabel: false,
-        hideTicks: false,
-        size: '67',
-        tickRotation: '25',
-        min: '',
-        max: '',
-        labelColor: '#333',
-        tickLabelColor: '#333',
-        tickColor: '#333',
-        numTicks: '',
-        labelOffset: 65,
-        axisPadding: 0,
-        target: 0,
-        maxTickRotation: 0,
-        dataKey: 'Year',
-        label: 'X-Axis Label Example',
-        tickWidthMax: 41
-      },
-      table: {
-        label: 'Data Table',
-        expanded: true,
-        limitHeight: false,
-        height: '',
-        caption: '',
-        showDownloadUrl: false,
-        showDataTableLink: true,
-        indexLabel: '',
-        download: true,
-        showVertical: false,
-        show: true
-      },
-      orientation: 'vertical',
-      color: 'pinkpurple',
+      ],
       columns: {
-        additionalColumn1: {
-          label: 'New Column',
-          dataTable: false,
+        'American Indian/Alaska Native': {
+          label: 'Additional Tooltip',
+          dataTable: true,
           tooltips: true,
           prefix: '',
           suffix: '',
           forestPlot: false,
           startingPoint: '0',
           forestPlotAlignRight: false,
-          name: 'Data 1'
+          roundToPlace: 0,
+          commas: true,
+          showInViz: false,
+          forestPlotStartingPoint: 0,
+          name: 'American Indian/Alaska Native',
+          series: 'Hispanic'
         }
-      },
-      legend: {
-        hide: false,
-        behavior: 'isolate',
-        singleRow: false,
-        colorCode: '',
-        reverseLabelOrder: false,
-        description: '',
-        dynamicLegend: false,
-        dynamicLegendDefaultText: 'Show All',
-        dynamicLegendItemLimit: 5,
-        dynamicLegendItemLimitMessage: 'Dynamic Legend Item Limit Hit.',
-        dynamicLegendChartMessage: 'Select Options from the Legend',
-        lineMode: false,
-        verticalSorted: false,
-        position: 'right',
-        label: 'Data Type'
-      },
-      brush: {
-        height: 25,
-        data: [],
-        active: false
-      },
-      exclusions: {
-        active: false,
-        keys: []
-      },
-      palette: 'qualitative-bold',
-      isPaletteReversed: false,
-      twoColor: {
-        palette: 'monochrome-1',
-        isPaletteReversed: false
-      },
-      labels: false,
-      dataFormat: {
-        commas: false,
-        prefix: '',
-        suffix: '%',
-        abbreviated: false,
-        bottomSuffix: '',
-        bottomPrefix: '',
-        bottomAbbreviated: false
-      },
-      confidenceKeys: {},
-      visual: {
-        border: true,
-        accent: true,
-        background: true,
-        verticalHoverLine: false,
-        horizontalHoverLine: false
-      },
-      useLogScale: false,
-      filterBehavior: 'Filter Change',
-      highlightedBarValues: [],
-      series: [
-        {
-          dataKey: 'Data 2',
-          type: 'Bar',
-          tooltip: true
-        },
-        {
-          dataKey: 'Data 3',
-          type: 'Bar',
-          tooltip: true
-        }
-      ],
-      tooltips: {
-        opacity: 90
-      },
-      forestPlot: {
-        startAt: 0,
-        width: 'auto',
-        colors: {
-          line: '',
-          shape: ''
-        },
-        estimateField: '',
-        estimateRadius: '',
-        lowerCiField: '',
-        upperCiField: '',
-        shape: '',
-        rowHeight: 20,
-        showZeroLine: false,
-        description: {
-          show: true,
-          text: 'description',
-          location: 0
-        },
-        result: {
-          show: true,
-          text: 'result',
-          location: 100
-        },
-        radius: {
-          min: 1,
-          max: 8,
-          scalingColumn: ''
-        },
-        regression: {
-          lower: 0,
-          upper: 0,
-          estimateField: 0
-        },
-        leftWidthOffset: 0,
-        rightWidthOffset: 0
-      },
-      area: {
-        isStacked: false
-      },
-      height: '375',
-      data: [
-        {
-          Year: '2015',
-          'Data 1': '25',
-          'Data 2': '20',
-          'Data 3': '55'
-        },
-        {
-          Year: '2016',
-          'Data 1': '35',
-          'Data 2': '30',
-          'Data 3': '35'
-        },
-        {
-          Year: '2017',
-          'Data 1': '22',
-          'Data 2': '38',
-          'Data 3': '40'
-        },
-        {
-          Year: '2018',
-          'Data 1': '40',
-          'Data 2': '40',
-          'Data 3': '20'
-        }
-      ],
-      visualizationType: 'Bar',
-      validated: 4.23,
-      dynamicMarginTop: 0
+      }
     }
   }
 }

--- a/packages/chart/src/_stories/_mock/bar-chart-suppressed.json
+++ b/packages/chart/src/_stories/_mock/bar-chart-suppressed.json
@@ -178,84 +178,7 @@
     "position": "right",
     "label": "Data Type"
   },
-  "brush": {
-    "height": 25,
-    "active": false,
-    "data": [
-      {
-        "Date": "1/15/2016",
-        "Data 1": "1000",
-        "Data 2": "110",
-        "Data 3": "100",
-        "Data 4": "90",
-        "Monthly-Goal": "100"
-      },
-      {
-        "Date": "2/15/2016",
-        "Data 1": "100",
-        "Data 2": "110",
-        "Data 3": "100",
-        "Data 4": "100",
-        "Monthly-Goal": "100"
-      },
-      {
-        "Date": "3/15/2016",
-        "Data 1": "80",
-        "Data 2": "90",
-        "Data 3": "100",
-        "Data 4": "120",
-        "Monthly-Goal": "110"
-      },
-      {
-        "Date": "4/15/2016",
-        "Data 1": "80",
-        "Data 2": "90",
-        "Data 3": "110",
-        "Data 4": "120",
-        "Monthly-Goal": "110"
-      },
-      {
-        "Date": "5/15/2016",
-        "Data 1": "70",
-        "Data 2": "90",
-        "Data 3": "110",
-        "Data 4": "130",
-        "Monthly-Goal": "120"
-      },
-      {
-        "Date": "6/15/2016",
-        "Data 1": "100",
-        "Data 2": "120",
-        "Data 3": "120",
-        "Data 4": "130",
-        "Monthly-Goal": "120"
-      },
-      {
-        "Date": "7/15/2016",
-        "Data 1": "110",
-        "Data 2": "140",
-        "Data 3": "120",
-        "Data 4": "130",
-        "Monthly-Goal": "130"
-      },
-      {
-        "Date": "8/15/2016",
-        "Data 1": "110",
-        "Data 2": "130",
-        "Data 3": "120",
-        "Data 4": "140",
-        "Monthly-Goal": "130"
-      },
-      {
-        "Date": "9/15/2016",
-        "Data 1": "120",
-        "Data 2": "130",
-        "Data 3": "120",
-        "Data 4": "150",
-        "Monthly-Goal": "140"
-      }
-    ]
-  },
+
   "exclusions": {
     "active": false,
     "keys": []
@@ -390,7 +313,6 @@
     },
     "data": []
   },
-  "suppressedData": [],
   "height": "332",
   "data": [
     {
@@ -460,7 +382,7 @@
     {
       "Date": "9/15/2016",
       "Data 1": "120",
-      "Data 2": "",
+      "Data 2": "Aza",
       "Data 3": "120",
       "Data 4": "150",
       "Monthly-Goal": "140"

--- a/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
@@ -262,6 +262,21 @@ export const BarChartHorizontal = () => {
                           }
                         })}
 
+                        {(absentDataLabel || isSuppressed) && (
+                          <rect
+                            x={barX}
+                            y={0}
+                            width={yMax}
+                            height={numbericBarHeight}
+                            fill='transparent'
+                            data-tooltip-place='top'
+                            data-tooltip-offset='{"top":3}'
+                            style={{ pointerEvents: 'all', cursor: 'pointer' }}
+                            data-tooltip-html={tooltip}
+                            data-tooltip-id={`cdc-open-viz-tooltip-${config.runtime.uniqueId}`}
+                          />
+                        )}
+
                         {config.preliminaryData?.map((pd, index) => {
                           // check if user selected column
                           const selectedSuppressionColumn = !pd.column || pd.column === bar.key

--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -288,6 +288,21 @@ export const BarChartVertical = () => {
                           }
                         })}
 
+                        {(absentDataLabel || isSuppressed) && (
+                          <rect
+                            x={barX}
+                            y={0}
+                            width={barWidth}
+                            height={yMax}
+                            fill='transparent'
+                            data-tooltip-place='top'
+                            data-tooltip-offset='{"top":3}'
+                            style={{ pointerEvents: 'all', cursor: 'pointer' }}
+                            data-tooltip-html={tooltip}
+                            data-tooltip-id={`cdc-open-viz-tooltip-${config.runtime.uniqueId}`}
+                          />
+                        )}
+
                         {config.preliminaryData.map((pd, index) => {
                           // check if user selected column
                           const selectedSuppressionColumn = !pd.column || pd.column === bar.key


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
Open Bar Charts regular
Add Suppresseed data or if there is missing data value like "ABC"
Turn on "Show missing data value label " from General panel
Turn on "Show Simgle series tooltips" from Visual Panel
Hover to the short bar that is missing.
Increased hover area so hovering over the bar will show tooltip.
Added new story under Charts/Tooltips/Increaed Tooltips
<img width="2992" height="1642" alt="Screenshot 2025-07-10 at 09 20 33" src="https://github.com/user-attachments/assets/f9248e78-8cc3-4a05-a24e-197430a91a3f" />

<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
