### PR TITLE
Fix [DEV-10399] Consider falsey values to be right-alignable

### DIFF
--- a/packages/core/helpers/isRightAlignedTableValue.js
+++ b/packages/core/helpers/isRightAlignedTableValue.js
@@ -3,7 +3,7 @@ import { footnotesSymbols } from '@cdc/core/helpers/footnoteSymbols'
 const numericStrings = ['N/A', 'NA', '', 'Suppressed'].concat(footnotesSymbols.map(s => s[0]))
 
 export default function isRightAlignedTableValue(value = '') {
-  if (!value) return false
+  if (!value) return true
   if (typeof value === 'number') {
     return !Number.isNaN(value)
   }


### PR DESCRIPTION
## Summary

This considers falsey values (e.g. `0`) to be right-alignable in data tables. 

## Testing Steps

Check data tables in storybook, make sure they are right-aligned appropriately.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
