### PR TITLE
FIX : [DEV-10704]  Fix Forecasting and Area chart offset

### DIFF
--- a/packages/chart/src/components/Forecasting/Forecasting.jsx
+++ b/packages/chart/src/components/Forecasting/Forecasting.jsx
@@ -24,11 +24,16 @@ const Forecasting = ({ xScale, yScale, height, width, handleTooltipMouseOver, ha
             return group.stages.map((stage, stageIndex) => {
               const { behavior } = legend
               const groupData = rawData.filter(d => d[group.stageColumn] === stage.key)
-              let transparentArea = behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(stage.key) === -1
-              let displayArea = behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(stage.key) !== -1
+              let transparentArea =
+                behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(stage.key) === -1
+              let displayArea =
+                behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(stage.key) !== -1
 
               return (
-                <Group className={`forecasting-areas-combo-${index}`} key={`forecasting-areas--stage-${stage.key.replaceAll(' ', '-')}-${index}`}>
+                <Group
+                  className={`forecasting-areas-combo-${index}`}
+                  key={`forecasting-areas--stage-${stage.key.replaceAll(' ', '-')}-${index}`}
+                >
                   {group.confidenceIntervals?.map((ciGroup, ciGroupIndex) => {
                     const palette = sequentialPalettes[stage.color] || colorPalettesChart[stage.color] || false
 
@@ -44,13 +49,18 @@ const Forecasting = ({ xScale, yScale, height, width, handleTooltipMouseOver, ha
 
                     if (ciGroup.high === '' || ciGroup.low === '') return
                     return (
-                      <Group key={`forecasting-areas--stage-${stage.key.replaceAll(' ', '-')}--group-${stageIndex}-${ciGroupIndex}`}>
+                      <Group
+                        key={`forecasting-areas--stage-${stage.key.replaceAll(
+                          ' ',
+                          '-'
+                        )}--group-${stageIndex}-${ciGroupIndex}`}
+                      >
                         {/* prettier-ignore */}
                         <Area
                           curve={curveMonotoneX}
-                          data={groupData}
+                          data={data}
                           fill={getFill()}
-                          opacity={transparentArea ? 0.1 : .5}
+                          opacity={0.1 }
                           x={d => xScale(Date.parse(d[xAxis.dataKey]))}
                           y0={d => yScale(d[ciGroup.low])}
                           y1={d => yScale(d[ciGroup.high])}
@@ -73,7 +83,15 @@ const Forecasting = ({ xScale, yScale, height, width, handleTooltipMouseOver, ha
             })
           })}
           <Group key='tooltip-hover-section'>
-            <Bar key={'bars'} width={Number(width)} height={Number(height)} fill={DEBUG ? 'red' : 'transparent'} fillOpacity={0.05} onMouseMove={e => handleTooltipMouseOver(e, data)} onMouseOut={handleTooltipMouseOff} />
+            <Bar
+              key={'bars'}
+              width={Number(width)}
+              height={Number(height)}
+              fill={DEBUG ? 'red' : 'transparent'}
+              fillOpacity={0.05}
+              onMouseMove={e => handleTooltipMouseOver(e, data)}
+              onMouseOut={handleTooltipMouseOff}
+            />
           </Group>
         </Group>
       </ErrorBoundary>


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
Open Forecasting chart by uploading this provided config file
Before: the chart had grouped chunks
Now : forecasting chart is connected and also CI upper and lower still visible
Also check for axis offset aligment. ticks and chart should start at the same level without offset for both area and foreacsting
[forecasting.json](https://github.com/user-attachments/files/21304080/forecasting.json)

<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
