### PR TITLE
Feature : [DEV-10119] - Allow Markup Includes & Filtered Text to Blank Out on Reset Value

### DIFF
--- a/packages/dashboard/src/helpers/getVizConfig.ts
+++ b/packages/dashboard/src/helpers/getVizConfig.ts
@@ -95,10 +95,11 @@ export const getVizConfig = (
   const isMarkupUsed = filters.some(f => f?.usedBy?.includes(visualizationKey))
   const isFilteredTextUsed = filters.some(f => f?.usedBy?.includes(visualizationKey))
 
-  if (
-    visualizationKey.startsWith('markup-include') ||
-    (visualizationKey.startsWith('filtered-text') && isResetActive && (isMarkupUsed || isFilteredTextUsed))
-  ) {
+  if (visualizationKey.startsWith('markup-include') && isResetActive && isMarkupUsed) {
+    visualizationConfig.data = []
+    visualizationConfig.formattedData = []
+  }
+  if (visualizationKey.startsWith('filtered-text') && isResetActive && isFilteredTextUsed) {
     visualizationConfig.data = []
     visualizationConfig.formattedData = []
   }

--- a/packages/dashboard/src/helpers/getVizConfig.ts
+++ b/packages/dashboard/src/helpers/getVizConfig.ts
@@ -88,6 +88,20 @@ export const getVizConfig = (
     }
     return visConfigWithFootnotes
   }
+  // for markup-include & filtered text reset data on Reset Value on Filters
+  const filters = config.dashboard.sharedFilters
+
+  const isResetActive = filters.some(f => f.resetLabel && f.resetLabel === f.active)
+  const isMarkupUsed = filters.some(f => f?.usedBy?.includes(visualizationKey))
+  const isFilteredTextUsed = filters.some(f => f?.usedBy?.includes(visualizationKey))
+
+  if (
+    visualizationKey.startsWith('markup-include') ||
+    (visualizationKey.startsWith('filtered-text') && isResetActive && (isMarkupUsed || isFilteredTextUsed))
+  ) {
+    visualizationConfig.data = []
+    visualizationConfig.formattedData = []
+  }
 
   return visualizationConfig as AnyVisualization
 }

--- a/packages/dashboard/src/helpers/getVizConfig.ts
+++ b/packages/dashboard/src/helpers/getVizConfig.ts
@@ -91,7 +91,7 @@ export const getVizConfig = (
   // for markup-include & filtered text reset data on Reset Value on Filters
   const filters = config.dashboard.sharedFilters
 
-  const isResetActive = filters.some(f => f.resetLabel && f.resetLabel === f.active)
+  const isResetActive = filters.some(f => f?.resetLabel && f?.resetLabel === f?.active)
   const isMarkupUsed = filters.some(f => f?.usedBy?.includes(visualizationKey))
   const isFilteredTextUsed = filters.some(f => f?.usedBy?.includes(visualizationKey))
 


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
use attached file to test.
When user entered Reset label on Filters, the markup include and filtered text should be blank when reset label selected, while charts will show all data.In example image "All years " is rest label
[dashboard-markup-includeX.json](https://github.com/user-attachments/files/21353414/dashboard-markup-includeX.json)

<img width="2980" height="1642" alt="Screenshot 2025-07-21 at 15 39 38" src="https://github.com/user-attachments/assets/fbb91666-7f42-46bc-bcdc-e770a12697dc" />

<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
