### PR TITLE
Markup Inc. > No Data Message Enhancement

### DIFF
--- a/packages/dashboard/examples/no-data-markup.json
+++ b/packages/dashboard/examples/no-data-markup.json
@@ -1,0 +1,206 @@
+{
+  "dashboard": {
+    "theme": "theme-blue",
+    "sharedFilters": [
+      {
+        "key": "New Dashboard Filter 1",
+        "showDropdown": true,
+        "values": [
+          "Hispanic or Latino",
+          "Non-Hispanic American Indian",
+          "Non-Hispanic Asian or Pacific Islander",
+          "Non-Hispanic Black",
+          "Non-Hispanic White"
+        ],
+        "type": "datafilter",
+        "orderedValues": [
+          "Hispanic or Latino",
+          "Non-Hispanic American Indian",
+          "Non-Hispanic Asian or Pacific Islander",
+          "Non-Hispanic Black",
+          "Non-Hispanic White"
+        ],
+        "columnName": "Race",
+        "tier": 1
+      }
+    ]
+  },
+  "rows": [
+    {
+      "columns": [
+        {
+          "width": 12,
+          "widget": "dashboardFilters1753133899539"
+        }
+      ],
+      "uuid": 1753133896802
+    },
+    {
+      "uuid": 1753133896802,
+      "toggle": "__​undefined__",
+      "equalHeight": "__​undefined__",
+      "columns": [
+        {
+          "width": 12,
+          "widget": "markup-include1753133736118"
+        },
+        {},
+        {}
+      ]
+    }
+  ],
+  "visualizations": {
+    "markup-include1753133736118": {
+      "filters": [],
+      "filterBehavior": "Filter Change",
+      "openModal": false,
+      "uid": "markup-include1753133736118",
+      "type": "markup-include",
+      "contentEditor": {
+        "inlineHTML": "test {{some_variable}}",
+        "markupVariables": [
+          {
+            "columnName": "Age-adjusted rate",
+            "conditions": [
+              {
+                "columnName": "Race",
+                "isOrIsNotEqualTo": "is",
+                "value": "Hispanic or Latino"
+              }
+            ],
+            "name": "some_variable",
+            "tag": "{{some_variable}}",
+            "addCommas": "__​undefined__"
+          }
+        ],
+        "showHeader": true,
+        "srcUrl": "#example",
+        "title": "Markup Include",
+        "useInlineHTML": true,
+        "allowHideSection": false,
+        "showNoDataMessage": true
+      },
+      "theme": "theme-blue",
+      "visual": {
+        "border": false,
+        "accent": false,
+        "background": false,
+        "hideBackgroundColor": false,
+        "borderColorTheme": false
+      },
+      "showEditorPanel": true,
+      "visualizationType": "markup-include",
+      "version": "4.25.7",
+      "migrations": {
+        "addColorMigration": true
+      },
+      "dataDescription": {
+        "horizontal": false,
+        "series": false
+      },
+      "dataKey": "valid-data-chart.csv"
+    },
+    "dashboardFilters1753133899539": {
+      "filters": [],
+      "filterBehavior": "Filter Change",
+      "newViz": true,
+      "openModal": true,
+      "uid": "dashboardFilters1753133899539",
+      "type": "dashboardFilters",
+      "sharedFilterIndexes": [
+        0
+      ],
+      "visualizationType": "dashboardFilters"
+    }
+  },
+  "table": {
+    "label": "Data Table",
+    "show": true,
+    "showDownloadUrl": false,
+    "showDownloadLinkBelow": true,
+    "showVertical": true
+  },
+  "errors": [],
+  "currentViewport": "lg",
+  "id": 15,
+  "category": "General",
+  "label": "Dashboard",
+  "type": "dashboard",
+  "subType": null,
+  "orientation": null,
+  "icon": {
+    "key": null,
+    "ref": null,
+    "props": {},
+    "_owner": null,
+    "_store": {}
+  },
+  "content": "Present multiple data visualizations with shared filter controls.",
+  "datasets": {
+    "valid-data-chart.csv": {
+      "data": [
+        {
+          "Race": "Hispanic or Latino",
+          "Age-adjusted rate": "644.2"
+        },
+        {
+          "Race": "Non-Hispanic American Indian",
+          "Age-adjusted rate": "636.1"
+        },
+        {
+          "Race": "Non-Hispanic Black",
+          "Age-adjusted rate": "563.7"
+        },
+        {
+          "Race": "Non-Hispanic Asian or Pacific Islander",
+          "Age-adjusted rate": "202.5"
+        },
+        {
+          "Race": "Non-Hispanic White",
+          "Age-adjusted rate": "183.6"
+        }
+      ],
+      "dataFileSize": 178,
+      "dataFileName": "valid-data-chart.csv",
+      "dataFileSourceType": "file",
+      "dataFileFormat": "CSV",
+      "preview": true
+    }
+  },
+  "visualizationType": null,
+  "activeVizButtonID": 15,
+  "version": "4.25.7",
+  "migrations": {
+    "addColorMigration": true
+  },
+  "data": [
+    {
+      "Race": "Hispanic or Latino",
+      "Age-adjusted rate": "644.2"
+    },
+    {
+      "Race": "Non-Hispanic American Indian",
+      "Age-adjusted rate": "636.1"
+    },
+    {
+      "Race": "Non-Hispanic Black",
+      "Age-adjusted rate": "563.7"
+    },
+    {
+      "Race": "Non-Hispanic Asian or Pacific Islander",
+      "Age-adjusted rate": "202.5"
+    },
+    {
+      "Race": "Non-Hispanic White",
+      "Age-adjusted rate": "183.6"
+    }
+  ],
+  "dataFileName": "valid-data-chart.csv",
+  "dataFileSourceType": "file",
+  "formattedData": "__​undefined__",
+  "dataDescription": {
+    "horizontal": false
+  },
+  "runtime": {},
+  "uuid": 1753133895902
+}

--- a/packages/markup-include/src/CdcMarkupInclude.tsx
+++ b/packages/markup-include/src/CdcMarkupInclude.tsx
@@ -60,6 +60,7 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({
 
   const { innerContainerClasses, contentClasses } = useDataVizClasses(config || {})
   const { contentEditor, theme } = config || {}
+  const { showNoDataMessage, allowHideSection, noDataMessageText } = contentEditor || {}
   const data = configObj?.data
 
   const { inlineHTML, markupVariables, srcUrl, title, useInlineHTML } = contentEditor || {}
@@ -166,6 +167,7 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({
   }
 
   const emptyVariableChecker = []
+  const noDataMessageChecker = []
 
   const convertVariablesInMarkup = inlineMarkup => {
     if (_.isEmpty(markupVariables)) return inlineMarkup
@@ -200,9 +202,14 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({
       if (length > 2) {
         variableValues[length - 1] = `${listConjunction} ${variableValues[length - 1]}`
       }
+
       variableDisplay.push(variableValues.join(', '))
 
       const finalDisplay = variableDisplay[0]
+
+      if (showNoDataMessage && finalDisplay === '') {
+        noDataMessageChecker.push(true)
+      }
 
       if (finalDisplay === '' && contentEditor.allowHideSection) {
         emptyVariableChecker.push(true)
@@ -251,11 +258,13 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({
   const markup = useInlineHTML ? convertVariablesInMarkup(inlineHTML) : parseBodyMarkup(urlMarkup)
 
   const hideMarkupInclude = contentEditor?.allowHideSection && emptyVariableChecker.length > 0 && !isEditor
+  const _showNoDataMessage = showNoDataMessage && noDataMessageChecker.length > 0 && !isEditor
 
   if (loading === false) {
     content = (
       <>
         {isEditor && <EditorPanel datasets={datasets} />}
+
         {!hideMarkupInclude && (
           <Layout.Responsive isEditor={isEditor}>
             <div className='markup-include-content-container cove-component__content no-borders'>
@@ -263,8 +272,13 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({
                 <Title title={title} isDashboard={isDashboard} classes={[`${theme}`, 'mb-0']} />
                 <div className={`${innerContainerClasses.join(' ')}`}>
                   <div className='cove-component__content-wrap'>
-                    {!markupError && <Markup allowElements={!!urlMarkup} content={markup} />}
-                    {markupError && srcUrl && <div className='warning'>{errorMessage}</div>}
+                    {_showNoDataMessage && (
+                      <div className='no-data-message'>
+                        <p>{`${noDataMessageText}`}</p>
+                      </div>
+                    )}
+                    {!markupError && !_showNoDataMessage && <Markup allowElements={!!urlMarkup} content={markup} />}
+                    {markupError && srcUrl && !_showNoDataMessage && <div className='warning'>{errorMessage}</div>}
                   </div>
                 </div>
               </div>

--- a/packages/markup-include/src/components/EditorPanel.tsx
+++ b/packages/markup-include/src/components/EditorPanel.tsx
@@ -48,7 +48,8 @@ type MarkupIncludeEditorPanelProps = {
 const EditorPanel: React.FC<MarkupIncludeEditorPanelProps> = ({ datasets }) => {
   const { config, data, isDashboard, loading, setParentConfig, updateConfig } = useContext(ConfigContext)
   const { contentEditor, theme, visual } = config
-  const { inlineHTML, markupVariables, srcUrl, title, useInlineHTML, allowHideSection } = contentEditor
+  const { inlineHTML, markupVariables, srcUrl, title, useInlineHTML, allowHideSection, shoNoDataMessage } =
+    contentEditor
   const [displayPanel, setDisplayPanel] = useState(true)
   const updateField = updateFieldFactory(config, updateConfig, true)
   const hasData = data?.[0] !== undefined ?? false
@@ -222,6 +223,14 @@ const EditorPanel: React.FC<MarkupIncludeEditorPanelProps> = ({ datasets }) => {
                         </Tooltip.Content>
                       </Tooltip>
                     }
+                  />
+
+                  <CheckBox
+                    value={showNoDataMessage}
+                    section='contentEditor'
+                    fieldName='showNoDataMessage'
+                    label='Add No Data Message'
+                    updateField={updateField}
                   />
                 </div>
 

--- a/packages/markup-include/src/components/EditorPanel.tsx
+++ b/packages/markup-include/src/components/EditorPanel.tsx
@@ -226,7 +226,7 @@ const EditorPanel: React.FC<MarkupIncludeEditorPanelProps> = ({ datasets }) => {
                   />
 
                   <CheckBox
-                    value={showNoDataMessage}
+                    value={contentEditor.showNoDataMessage}
                     section='contentEditor'
                     fieldName='showNoDataMessage'
                     label='Add No Data Message'

--- a/packages/markup-include/src/data/initial-state.js
+++ b/packages/markup-include/src/data/initial-state.js
@@ -5,7 +5,9 @@ export default {
     showHeader: true,
     srcUrl: '#example',
     title: 'Markup Include',
-    useInlineHTML: false
+    useInlineHTML: false,
+    showNoDataMessage: false,
+    noDataMessageText: 'No Data Available'
   },
   data: [],
   legend: {},

--- a/packages/markup-include/src/types/Config.ts
+++ b/packages/markup-include/src/types/Config.ts
@@ -11,6 +11,8 @@ export type Config = {
     srcUrl: string
     title: string
     useInlineHTML: boolean
+    showNoDataMessage: boolean
+    noDataMessageText: string
   }
   data?: Object[]
   legend: {}


### PR DESCRIPTION
## Summary
Adds a checkbox for stating "No Data Available" when the markup include has nothing to show.

## Testing Steps
Open the attached example `no-data-markup.json` and change the filter to something that doesn't match.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
