### PR TITLE
enhancement: add padding on screenshots when title isn't present

### DIFF
--- a/packages/core/components/MediaControls.jsx
+++ b/packages/core/components/MediaControls.jsx
@@ -75,10 +75,19 @@ const generateMedia = (state, type, elementToCapture) => {
 
   switch (type) {
     case 'image':
+      const container = document.createElement('div')
+
+      // On screenshots without a title (like some charts), add padding around the chart svg
+      if (!state.showTitle) {
+        container.style.padding = '35px'
+      }
+      container.appendChild(baseSvg.cloneNode(true)) // Clone baseSvg to avoid modifying the original
+
       const downloadImage = async () => {
+        document.body.appendChild(container) // Append container to the DOM
         import(/* webpackChunkName: "html2canvas" */ 'html2canvas').then(mod => {
           mod
-            .default(baseSvg, {
+            .default(container, {
               ignoreElements: el =>
                 el.className?.indexOf &&
                 el.className.search(/download-buttons|download-links|data-table-container/) !== -1
@@ -113,14 +122,6 @@ const generateMedia = (state, type, elementToCapture) => {
       console.warn("COVE: generateMedia param 2 type must be 'image' or 'pdf'")
       break
   }
-}
-
-// Handles different state theme locations between components
-// Apparently some packages use state.headerColor where others use state.theme
-const handleTheme = state => {
-  if (state?.headerColor) return state.headerColor // ie. maps
-  if (state?.theme) return state.theme // ie. charts
-  return 'theme-notFound'
 }
 
 // Download CSV

--- a/packages/core/components/MediaControls.jsx
+++ b/packages/core/components/MediaControls.jsx
@@ -76,10 +76,12 @@ const generateMedia = (state, type, elementToCapture) => {
   switch (type) {
     case 'image':
       const container = document.createElement('div')
-
       // On screenshots without a title (like some charts), add padding around the chart svg
-      if (!state.showTitle) {
-        container.style.padding = '35px'
+      const parent = container.parentElement
+      if (parent) {
+        if (!state.showTitle) {
+          container.style.padding = '35px'
+        }
       }
       container.appendChild(baseSvg.cloneNode(true)) // Clone baseSvg to avoid modifying the original
 


### PR DESCRIPTION
## Summary
On charts without a title we need padding added around the screenshot

## Testing Steps
- On a chart add the download image button and hide the title. 
- Click "Download Image" button
- The downloaded screenshot should have 35px of padding

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
