### PR TITLE
Fix [sorting] empty string sort

### DIFF
--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -150,7 +150,7 @@ const DataTable = (props: DataTableProps) => {
           dataA = timeParse(config.runtime.xAxis.dateParseFormat)(runtimeData[a][config.xAxis.dataKey])
           dataB = timeParse(config.runtime.xAxis.dateParseFormat)(runtimeData[b][config.xAxis.dataKey])
         }
-        return dataA && dataB ? customSort(dataA, dataB, sortBy, config) : 0
+        return dataA || dataB ? customSort(dataA, dataB, sortBy, config) : 0
       })
       : rawRows
 

--- a/packages/core/components/DataTable/helpers/customSort.ts
+++ b/packages/core/components/DataTable/helpers/customSort.ts
@@ -37,8 +37,10 @@ export const customSort = (a, b, sortBy, config) => {
   const isNumB = !isNaN(Number(valueB)) && valueB !== undefined && valueB !== null && trimmedB !== ''
 
   // Handle empty strings or spaces
-  if (trimmedA === '' && trimmedB !== '') return sortBy.asc ? -1 : 1
-  if (trimmedA !== '' && trimmedB === '') return sortBy.asc ? 1 : -1
+  // empty string should always come last no matter the asc
+  if (trimmedA === '' && trimmedB === '') return 0
+  if (trimmedA === '' && trimmedB !== '') return 1
+  if (trimmedA !== '' && trimmedB === '') return -1
 
   // Both are numbers: Compare numerically
   if (isNumA && isNumB) {


### PR DESCRIPTION
## Summary
Currently, when sorting, if there is one falsey value a zero is being returned no matter which value is falsey - which effectively leaves them in place

I believe empty strings/ values should always be sorted to the bottom, even when sort order is descending

## Testing Steps
1. Open 
[test.json](https://github.com/user-attachments/files/21414210/test.json) in map package
2. Sort the "Reason For N/A" column
3. Confirm normal sorting works and strings are sorted to the bottom
