### PR TITLE
FIX [ DEV-11138] Fix Forecasting Chart colors

### DIFF
--- a/packages/chart/src/components/Forecasting/Forecasting.tsx
+++ b/packages/chart/src/components/Forecasting/Forecasting.tsx
@@ -1,9 +1,10 @@
 import React, { useContext } from 'react'
-
+import { replace } from 'lodash'
 // cdc
 import ConfigContext from '../../ConfigContext'
 import ErrorBoundary from '@cdc/core/components/ErrorBoundary'
 import { colorPalettesChart, sequentialPalettes } from '@cdc/core/data/colorPalettes'
+import { getBridgedData } from '../../helpers/getBridgedData'
 
 // visx & d3
 import { curveMonotoneX } from '@visx/curve'
@@ -11,7 +12,7 @@ import { Bar, Area, LinePath } from '@visx/shape'
 import { Group } from '@visx/group'
 
 const Forecasting = ({ xScale, yScale, height, width, handleTooltipMouseOver, handleTooltipMouseOff }) => {
-  const { transformedData: data, rawData, config, seriesHighlight } = useContext(ConfigContext)
+  const { transformedData: data, rawData, config, seriesHighlight, parseDate } = useContext(ConfigContext)
   const { xAxis, yAxis, legend, runtime } = config
   const DEBUG = false
 
@@ -23,16 +24,16 @@ const Forecasting = ({ xScale, yScale, height, width, handleTooltipMouseOver, ha
             if (!group || !group.stages) return false
             return group.stages.map((stage, stageIndex) => {
               const { behavior } = legend
-              const groupData = rawData.filter(d => d[group.stageColumn] === stage.key)
               let transparentArea =
                 behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(stage.key) === -1
               let displayArea =
                 behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(stage.key) !== -1
+              const bridgedData = getBridgedData(stage.key, group.stageColumn, rawData)
 
               return (
                 <Group
                   className={`forecasting-areas-combo-${index}`}
-                  key={`forecasting-areas--stage-${stage.key.replaceAll(' ', '-')}-${index}`}
+                  key={`forecasting-areas--stage-${replace(stage.key, / /g, '—')}-${index}`}
                 >
                   {group.confidenceIntervals?.map((ciGroup, ciGroupIndex) => {
                     const palette = sequentialPalettes[stage.color] || colorPalettesChart[stage.color] || false
@@ -50,17 +51,18 @@ const Forecasting = ({ xScale, yScale, height, width, handleTooltipMouseOver, ha
                     if (ciGroup.high === '' || ciGroup.low === '') return
                     return (
                       <Group
-                        key={`forecasting-areas--stage-${stage.key.replaceAll(
-                          ' ',
-                          '-'
+                        key={`forecasting-areas--stage-${replace(
+                          stage.key,
+                          / /g,
+                          '—'
                         )}--group-${stageIndex}-${ciGroupIndex}`}
                       >
                         {/* prettier-ignore */}
                         <Area
                           curve={curveMonotoneX}
-                          data={data}
+                          data={bridgedData}
                           fill={getFill()}
-                          opacity={0.1 }
+                          opacity={transparentArea? 0.1 : 0.5 }
                           x={d => xScale(Date.parse(d[xAxis.dataKey]))}
                           y0={d => yScale(d[ciGroup.low])}
                           y1={d => yScale(d[ciGroup.high])}
@@ -69,10 +71,10 @@ const Forecasting = ({ xScale, yScale, height, width, handleTooltipMouseOver, ha
                         {ciGroupIndex === 0 && (
                           <>
                             {/* prettier-ignore */}
-                            <LinePath data={groupData} x={d => Number(xScale(Date.parse(d[xAxis.dataKey])))} y={d => Number(yScale(d[ciGroup.high]))} curve={curveMonotoneX} stroke={getStroke()} strokeWidth={1} strokeOpacity={1} />
+                            <LinePath data={bridgedData} x={d => Number(xScale(Date.parse(d[xAxis.dataKey])))} y={d => Number(yScale(d[ciGroup.high]))} curve={curveMonotoneX} stroke={getStroke()} strokeWidth={1} strokeOpacity={1} />
 
                             {/* prettier-ignore */}
-                            <LinePath data={groupData} x={d => Number(xScale(Date.parse(d[xAxis.dataKey])))} y={d => Number(yScale(d[ciGroup.low]))} curve={curveMonotoneX} stroke={getStroke()} strokeWidth={1} strokeOpacity={1} />
+                            <LinePath data={bridgedData} x={d => Number(xScale(Date.parse(d[xAxis.dataKey])))} y={d => Number(yScale(d[ciGroup.low]))} curve={curveMonotoneX} stroke={getStroke()} strokeWidth={1} strokeOpacity={1} />
                           </>
                         )}
                       </Group>

--- a/packages/chart/src/helpers/getBridgedData.ts
+++ b/packages/chart/src/helpers/getBridgedData.ts
@@ -2,6 +2,7 @@ export const getBridgedData = (stageKey: string, stageColumn: string, data: Reco
   const allStages: string[] = Array.from(new Set(data.map(d => d?.[stageColumn]).filter(Boolean)))
 
   const stageIndex: number = allStages.indexOf(stageKey)
+  if (stageIndex === -1) return []
   const currentStage = data.filter(d => d?.[stageColumn] === stageKey)
   const nextKey = allStages[stageIndex + 1]
   if (nextKey) {

--- a/packages/chart/src/helpers/getBridgedData.ts
+++ b/packages/chart/src/helpers/getBridgedData.ts
@@ -1,0 +1,12 @@
+export const getBridgedData = (stageKey: string, stageColumn: string, data: Record<string, any>[]) => {
+  const allStages: string[] = Array.from(new Set(data.map(d => d?.[stageColumn]).filter(Boolean)))
+
+  const stageIndex: number = allStages.indexOf(stageKey)
+  const currentStage = data.filter(d => d?.[stageColumn] === stageKey)
+  const nextKey = allStages[stageIndex + 1]
+  if (nextKey) {
+    const nextSlice = data.filter(d => d[stageColumn] === nextKey)
+    return [...currentStage, nextSlice[0]]
+  }
+  return currentStage
+}

--- a/packages/chart/src/helpers/tests/getBridgedData.test.ts
+++ b/packages/chart/src/helpers/tests/getBridgedData.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { getBridgedData } from '../getBridgedData'
+
+describe('getBridgedData', () => {
+  const sampleData = [
+    { Month: 'Jan', value: 1 },
+    { Month: 'Jan', value: 2 },
+    { Month: 'Feb', value: 3 },
+    { Month: 'Feb', value: 4 },
+    { Month: 'Mar', value: 5 }
+  ]
+
+  it('returns correct slice for stageKey with next stage', () => {
+    const result = getBridgedData('Jan', 'Month', sampleData)
+
+    expect(result).toEqual([
+      { Month: 'Jan', value: 1 },
+      { Month: 'Jan', value: 2 },
+      { Month: 'Feb', value: 3 } // only first item from next stage
+    ])
+  })
+
+  it('returns correct slice for stageKey with no next stage', () => {
+    const result = getBridgedData('Mar', 'Month', sampleData)
+
+    expect(result).toEqual([{ Month: 'Mar', value: 5 }])
+  })
+
+  it('returns empty if stageKey not found', () => {
+    const result = getBridgedData('Dec', 'Month', sampleData)
+
+    expect(result).toEqual([])
+  })
+
+  it('handles unordered input data and preserves stage order by first appearance', () => {
+    const unorderedData = [
+      { step: 'B', val: 1 },
+      { step: 'A', val: 2 },
+      { step: 'C', val: 3 },
+      { step: 'A', val: 4 },
+      { step: 'B', val: 5 }
+    ]
+
+    const result = getBridgedData('A', 'step', unorderedData)
+
+    expect(result).toEqual([
+      { step: 'A', val: 2 },
+      { step: 'A', val: 4 },
+      { step: 'C', val: 3 }
+    ])
+  })
+
+  it('returns only items matching current stage if next stage has no data', () => {
+    const dataWithEmptyStage = [
+      { stage: '1', x: 10 },
+      { stage: '2', x: 20 },
+      { stage: '3', x: 30 }
+    ]
+
+    const result = getBridgedData('3', 'stage', dataWithEmptyStage)
+
+    expect(result).toEqual([{ stage: '3', x: 30 }])
+  })
+})

--- a/packages/core/types/ForecastingSeriesKey.ts
+++ b/packages/core/types/ForecastingSeriesKey.ts
@@ -1,0 +1,16 @@
+export type ForecastingSeriesKey = {
+  dataKey: string
+  axis: 'Left'
+  tooltip: boolean
+  type: 'Forecasting'
+  confidenceIntervals: {
+    high: string
+    low: string
+    showInTooltip: boolean
+  }[]
+  stageColumn: string
+  stages: {
+    key: string
+    color: string
+  }[]
+}

--- a/packages/core/types/Runtime.ts
+++ b/packages/core/types/Runtime.ts
@@ -1,12 +1,6 @@
 import { Axis } from './Axis'
+import { ForecastingSeriesKey } from './ForecastingSeriesKey'
 import { Series } from './Series'
-
-export type ForecastingSeriesKey = {
-  stages: {
-    key: string
-    color: string
-  }[]
-}
 
 export type Runtime = {
   barSeriesKeys?: string[]


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
Fixed forecasting chart colors (segmented colors) and also connected segments using helper function getBridge data.

<img width="2002" height="652" alt="Screenshot 2025-07-24 at 16 58 39" src="https://github.com/user-attachments/assets/cbad4512-1012-4313-b89e-0ffbc51c470c" />

<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
