### PR TITLE
[DEV-11204] Remove auto capitalizing

### DIFF
--- a/packages/map/src/CdcMapComponent.tsx
+++ b/packages/map/src/CdcMapComponent.tsx
@@ -627,9 +627,7 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
                 <ReactTooltip
                   id={`tooltip__${tooltipId}`}
                   float={true}
-                  className={`${
-                    tooltips.capitalizeLabels ? 'capitalize tooltip tooltip-test' : 'tooltip tooltip-test'
-                  }`}
+                  className={`${tooltips.capitalizeLabels ? 'tooltip tooltip-test' : 'tooltip tooltip-test'}`}
                   style={{ background: `rgba(255,255,255, ${config.tooltips.opacity / 100})`, color: 'black' }}
                 />
               )}

--- a/packages/map/src/CdcMapComponent.tsx
+++ b/packages/map/src/CdcMapComponent.tsx
@@ -627,7 +627,7 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
                 <ReactTooltip
                   id={`tooltip__${tooltipId}`}
                   float={true}
-                  className={`${tooltips.capitalizeLabels ? 'tooltip tooltip-test' : 'tooltip tooltip-test'}`}
+                  className={`tooltip tooltip-test`}
                   style={{ background: `rgba(255,255,255, ${config.tooltips.opacity / 100})`, color: 'black' }}
                 />
               )}

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -656,15 +656,6 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
           }
         })
         break
-      case 'capitalizeLabels':
-        setConfig({
-          ...config,
-          tooltips: {
-            ...config.tooltips,
-            capitalizeLabels: value
-          }
-        })
-        break
       case 'showDataTable':
         setConfig({
           ...config,
@@ -2872,16 +2863,6 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                   updateField={updateField}
                 />
               )}
-              <label className='checkbox'>
-                <input
-                  type='checkbox'
-                  checked={config.tooltips.capitalizeLabels}
-                  onChange={event => {
-                    handleEditorChanges('capitalizeLabels', event.target.checked)
-                  }}
-                />
-                <span className='edit-label'>Capitalize text inside tooltip</span>
-              </label>
             </AccordionItemPanel>
           </AccordionItem>
           <AccordionItem>

--- a/packages/map/src/components/Modal.tsx
+++ b/packages/map/src/components/Modal.tsx
@@ -5,17 +5,13 @@ import useApplyTooltipsToGeo from '../hooks/useApplyTooltipsToGeo'
 import { MapContext } from '../types/MapContext'
 
 const Modal = () => {
-  const { content, config, currentViewport: viewport } = useContext<MapContext>(ConfigContext)
-  const { capitalizeLabels } = config.tooltips
+  const { content, currentViewport: viewport } = useContext<MapContext>(ConfigContext)
   const { applyTooltipsToGeo } = useApplyTooltipsToGeo()
   const tooltip = applyTooltipsToGeo(content.geoName, content.keyedData, 'jsx')
   const dispatch = useContext(MapDispatchContext)
 
   return (
-    <section
-      className={capitalizeLabels ? 'modal-content tooltip ' + viewport : 'modal-content tooltip ' + viewport}
-      aria-hidden='true'
-    >
+    <section className={'modal-content tooltip ' + viewport} aria-hidden='true'>
       <div className='content'>{tooltip}</div>
       <Icon
         display='close'

--- a/packages/map/src/components/Modal.tsx
+++ b/packages/map/src/components/Modal.tsx
@@ -13,9 +13,7 @@ const Modal = () => {
 
   return (
     <section
-      className={
-        capitalizeLabels ? 'modal-content tooltip capitalize ' + viewport : 'modal-content tooltip ' + viewport
-      }
+      className={capitalizeLabels ? 'modal-content tooltip ' + viewport : 'modal-content tooltip ' + viewport}
       aria-hidden='true'
     >
       <div className='content'>{tooltip}</div>

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -97,7 +97,6 @@ export default {
   tooltips: {
     appearanceType: 'hover',
     linkLabel: 'Learn More',
-    capitalizeLabels: true,
     opacity: 90
   },
   runtime: {

--- a/packages/map/src/scss/main.scss
+++ b/packages/map/src/scss/main.scss
@@ -15,7 +15,8 @@
 .cdc-map-outer-container {
   position: relative;
   display: flex; // Needed for the main content
-  .loading > div.la-ball-beat {
+
+  .loading>div.la-ball-beat {
     margin-top: 20%;
   }
 
@@ -52,12 +53,14 @@
     &.bottom {
       flex-direction: column;
     }
+
     &.top {
       flex-direction: column-reverse;
     }
 
     &.modal-background {
       position: relative;
+
       &::before {
         content: ' ';
         position: absolute;
@@ -65,6 +68,7 @@
         bottom: 0;
         z-index: 7;
       }
+
       .modal-content {
         background: #fff;
         position: absolute;
@@ -80,8 +84,10 @@
         padding: 16px 40px;
         min-width: 250px;
         width: auto;
-        max-height: 90vh; /* Constrain the modal's height to 90% of the viewport */
-        overflow-y: auto; /* Enable vertical scrolling if content overflows */
+        max-height: 90vh;
+        /* Constrain the modal's height to 90% of the viewport */
+        overflow-y: auto;
+        /* Enable vertical scrolling if content overflows */
         font-size: 1rem;
         line-height: 1.4em;
       }
@@ -122,16 +128,15 @@
         margin-left: 0.5em;
       }
 
-      .modal-content.capitalize p {
-        text-transform: capitalize;
-      }
-
       /* Responsive adjustments for smaller screens */
       @media (max-width: 1048px) {
         .modal-content {
-          width: 90%; /* Adjust width to fit smaller screens */
-          top: 10%; /* Offset from the top for better usability */
-          transform: translate(-50%, 0); /* Remove vertical centering */
+          width: 90%;
+          /* Adjust width to fit smaller screens */
+          top: 10%;
+          /* Offset from the top for better usability */
+          transform: translate(-50%, 0);
+          /* Remove vertical centering */
         }
       }
     }
@@ -141,6 +146,7 @@
     em {
       font-style: italic;
     }
+
     strong {
       font-weight: bold;
     }
@@ -167,25 +173,30 @@
     z-index: 6;
     width: 100%;
     border-top: var(--lightGray) 1px solid;
+
     label {
       flex-grow: 1;
-      > div.select-heading {
+
+      >div.select-heading {
         font-size: 1.1em;
         font-weight: 600;
         margin-bottom: 0.75em;
       }
     }
+
     form {
       max-width: 400px;
       display: flex;
       align-items: flex-end;
     }
+
     select {
       font-size: 1.2em;
       display: inline-block;
       vertical-align: top;
       width: 100%;
     }
+
     input {
       color: #fff;
       font-weight: 700;

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -176,7 +176,6 @@ export type MapConfig = Visualization & {
   tooltips: {
     appearanceType: 'hover' | 'click'
     linkLabel: string
-    capitalizeLabels: boolean
     opacity: number
   }
   runtime: {


### PR DESCRIPTION
 # Summary

  This PR removes the automatic capitalization functionality from map tooltips and modals in the COVE map
  component. The changes eliminate the capitalizeLabels configuration option and related UI controls, removing
  automatic text transformation that was previously applied to tooltip content.

  ## Changes Made

  - Removed capitalizeLabels configuration: Eliminated the capitalizeLabels boolean property from tooltip
  configuration in MapConfig.ts and initial state
  - Updated tooltip rendering: Removed conditional CSS class application that added capitalize styling to
  tooltips in CdcMapComponent.tsx
  - Cleaned up modal styling: Removed capitalization logic from modal content rendering in Modal.tsx
  - Removed editor controls: Eliminated the checkbox control for "Capitalize text inside tooltip" from the map
  editor panel
  - Updated SCSS: Removed CSS rules for .modal-content.capitalize p and cleaned up formatting
  
## Testing Steps

  - Verify map tooltips no longer automatically capitalize text content
  - Confirm modal content displays text in original casing
  - Test that tooltip editor panel no longer shows "Capitalize text inside tooltip" option
  - Validate existing tooltip functionality remains intact
  - Check that custom text formatting (bold, italic) still works properly
  - Test tooltip appearance on both hover and click modes
  - Verify modal displays correctly on various screen sizes
