### PR TITLE
Fix Pie Chart Data Table

### DIFF
--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -594,7 +594,7 @@ export const useTooltip = props => {
 
     return (
       <li style={style} className='tooltip-body mb-1'>
-        {parse(displayText)}
+        {displayText !== undefined ? parse(String(displayText)) : displayText}
       </li>
     )
   }

--- a/packages/core/helpers/cove/number.ts
+++ b/packages/core/helpers/cove/number.ts
@@ -192,10 +192,6 @@ const formatNumber = (num, axis, shouldAbbreviate = false, config = null, addCol
     }
   }
   if (config.visualizationType === 'Pie') {
-    // check if suffix added by user
-    if (suffix && suffix.trim() === '%') {
-      result = result
-    }
     // add default suffix
     if (!suffix) {
       result += '%'

--- a/packages/core/helpers/cove/number.ts
+++ b/packages/core/helpers/cove/number.ts
@@ -1,5 +1,3 @@
-import { VisualizationType } from './../../../../node_modules/@cdc/chart/src/types/ChartConfig'
-import { Visualization } from '@cdc/core/types/Visualization'
 import numberFromString from '@cdc/core/helpers/numberFromString'
 
 const abbreviateNumber = num => {
@@ -191,6 +189,16 @@ const formatNumber = (num, axis, shouldAbbreviate = false, config = null, addCol
 
     if (bottomSuffix && axis === 'bottom') {
       result += bottomSuffix
+    }
+  }
+  if (config.visualizationType === 'Pie') {
+    // check if suffix added by user
+    if (suffix && suffix.trim() === '%') {
+      result = result
+    }
+    // add default suffix
+    if (!suffix) {
+      result += '%'
     }
   }
   if (isNegative) {


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

## Testing Steps
Added default % suffix to the Pie Chart Data table
If % added by user it will not add % by default
if user adds manual suffix the % will be replaced by users added suffix
<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
