### PR TITLE
Fix [DEV-11177] Also add min bar heights to stacked bars

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
@@ -2,10 +2,9 @@ import React, { useContext, useState } from 'react'
 import ConfigContext from '../../../ConfigContext'
 import { BarStack } from '@visx/shape'
 import { Group } from '@visx/group'
-import { Text } from '@visx/text'
 import BarChartContext from './context'
 import Regions from '../../Regions'
-import { isDateScale } from '@cdc/core/helpers/cove/date'
+import { addMinimumBarHeights } from '../helpers'
 
 import createBarElement from '@cdc/core/components/createBarElement'
 
@@ -43,85 +42,87 @@ const BarChartStackedVertical = () => {
           yScale={yScale}
           color={colorScale}
         >
-          {barStacks =>
-            barStacks.reverse().map(barStack =>
-              barStack.bars.map(bar => {
-                let transparentBar =
-                  config.legend.behavior === 'highlight' &&
-                  seriesHighlight.length > 0 &&
-                  seriesHighlight.indexOf(bar.key) === -1
-                let displayBar =
-                  config.legend.behavior === 'highlight' ||
-                  seriesHighlight.length === 0 ||
-                  seriesHighlight.indexOf(bar.key) !== -1
-                let barThickness = isDateAxisType
-                  ? seriesScale.range()[1] - seriesScale.range()[0]
-                  : xMax / barStack.bars.length
-                if (config.runtime.xAxis.type !== 'date') barThickness = config.barThickness * barThickness
-                // tooltips
-                const rawXValue = bar.bar.data[config.runtime.xAxis.dataKey]
-                const xAxisValue = isDateAxisType ? formatDate(parseDate(rawXValue)) : rawXValue
-                const yAxisValue = formatNumber(bar.bar ? bar.bar.data[bar.key] : 0, 'left')
-                if (!yAxisValue) return
-                const barX =
-                  xScale(isDateAxisType ? parseDate(rawXValue) : rawXValue) -
-                  (isDateTimeScaleAxisType ? barThickness / 2 : 0)
-                const xAxisTooltip = config.runtime.xAxis.label
-                  ? `${config.runtime.xAxis.label}: ${xAxisValue}`
-                  : xAxisValue
-                const additionalColTooltip = getAdditionalColumn(bar.key, hoveredBar)
-                const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${yAxisValue}`
-                const tooltip = `<ul>
+          {barStacks => {
+            return addMinimumBarHeights(barStacks)
+              .reverse()
+              .map(barStack => {
+                return barStack.bars.map(bar => {
+                  let transparentBar =
+                    config.legend.behavior === 'highlight' &&
+                    seriesHighlight.length > 0 &&
+                    seriesHighlight.indexOf(bar.key) === -1
+                  let displayBar =
+                    config.legend.behavior === 'highlight' ||
+                    seriesHighlight.length === 0 ||
+                    seriesHighlight.indexOf(bar.key) !== -1
+                  let barThickness = isDateAxisType
+                    ? seriesScale.range()[1] - seriesScale.range()[0]
+                    : xMax / barStack.bars.length
+                  if (config.runtime.xAxis.type !== 'date') barThickness = config.barThickness * barThickness
+                  // tooltips
+                  const rawXValue = bar.bar.data[config.runtime.xAxis.dataKey]
+                  const xAxisValue = isDateAxisType ? formatDate(parseDate(rawXValue)) : rawXValue
+                  const yAxisValue = formatNumber(bar.bar ? bar.bar.data[bar.key] : 0, 'left')
+                  if (!yAxisValue) return
+                  const barX =
+                    xScale(isDateAxisType ? parseDate(rawXValue) : rawXValue) -
+                    (isDateTimeScaleAxisType ? barThickness / 2 : 0)
+                  const xAxisTooltip = config.runtime.xAxis.label
+                    ? `${config.runtime.xAxis.label}: ${xAxisValue}`
+                    : xAxisValue
+                  const additionalColTooltip = getAdditionalColumn(bar.key, hoveredBar)
+                  const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${yAxisValue}`
+                  const tooltip = `<ul>
                   <li class="tooltip-heading"">${xAxisTooltip}</li>
                   <li class="tooltip-body ">${tooltipBody}</li>
                   <li class="tooltip-body ">${additionalColTooltip}</li>
                     </li></ul>`
 
-                setBarWidth(barThickness)
+                  setBarWidth(barThickness)
 
-                return (
-                  <Group key={`${barStack.index}--${bar.index}--${orientation}`}>
-                    <Group
-                      key={`bar-stack-${barStack.index}-${bar.index}`}
-                      id={`barStack${barStack.index}-${bar.index}`}
-                      className='stack vertical'
-                    >
-                      {createBarElement({
-                        config: config,
-                        seriesHighlight,
-                        index: barStack.index,
-                        background: colorScale(config.runtime.seriesLabels[bar.key]),
-                        borderColor: '#333',
-                        borderStyle: 'solid',
-                        borderWidth: `${config.barHasBorder === 'true' ? barBorderWidth : 0}px`,
-                        width: barThickness,
-                        height: bar.height,
-                        x: barX,
-                        y: bar.y,
-                        onMouseOver: e => onMouseOverBar(xAxisValue, bar.key, e, data),
-                        onMouseLeave: onMouseLeaveBar,
-                        tooltipHtml: tooltip,
-                        tooltipId: `cdc-open-viz-tooltip-${config.runtime.uniqueId}`,
-                        onClick: e => {
-                          e.preventDefault()
-                          if (setSharedFilter) {
-                            bar[config.xAxis.dataKey] = xAxisValue
-                            setSharedFilter(config.uid, bar)
+                  return (
+                    <Group key={`${barStack.index}--${bar.index}--${orientation}`}>
+                      <Group
+                        key={`bar-stack-${barStack.index}-${bar.index}`}
+                        id={`barStack${barStack.index}-${bar.index}`}
+                        className='stack vertical'
+                      >
+                        {createBarElement({
+                          config: config,
+                          seriesHighlight,
+                          index: barStack.index,
+                          background: colorScale(config.runtime.seriesLabels[bar.key]),
+                          borderColor: '#333',
+                          borderStyle: 'solid',
+                          borderWidth: `${config.barHasBorder === 'true' ? barBorderWidth : 0}px`,
+                          width: barThickness,
+                          height: bar.height,
+                          x: barX,
+                          y: bar.y,
+                          onMouseOver: e => onMouseOverBar(xAxisValue, bar.key, e, data),
+                          onMouseLeave: onMouseLeaveBar,
+                          tooltipHtml: tooltip,
+                          tooltipId: `cdc-open-viz-tooltip-${config.runtime.uniqueId}`,
+                          onClick: e => {
+                            e.preventDefault()
+                            if (setSharedFilter) {
+                              bar[config.xAxis.dataKey] = xAxisValue
+                              setSharedFilter(config.uid, bar)
+                            }
+                          },
+                          styleOverrides: {
+                            animationDelay: `${barStack.index * 0.5}s`,
+                            transformOrigin: `${barThickness / 2}px ${bar.y + bar.height}px`,
+                            opacity: transparentBar ? 0.2 : 1,
+                            display: displayBar ? 'block' : 'none'
                           }
-                        },
-                        styleOverrides: {
-                          animationDelay: `${barStack.index * 0.5}s`,
-                          transformOrigin: `${barThickness / 2}px ${bar.y + bar.height}px`,
-                          opacity: transparentBar ? 0.2 : 1,
-                          display: displayBar ? 'block' : 'none'
-                        }
-                      })}
+                        })}
+                      </Group>
                     </Group>
-                  </Group>
-                )
+                  )
+                })
               })
-            )
-          }
+          }}
         </BarStack>
         <Regions xScale={xScale} yMax={yMax} barWidth={barWidth} totalBarsInGroup={1} />
       </>

--- a/packages/chart/src/components/BarChart/helpers/index.ts
+++ b/packages/chart/src/components/BarChart/helpers/index.ts
@@ -110,3 +110,34 @@ export const testZeroValue = value => {
   const regex = /^0(\.0)?$/
   return regex.test(value.toString())
 }
+
+export const addMinimumBarHeights = barStacks => {
+  const MIN_BAR_HEIGHT = 3
+
+  barStacks[0].bars.forEach((_, i) => {
+    let segments = barStacks.map(bs => bs.bars[i]).reverse()
+
+    const segmentsNeedingAdjustment = segments.filter(segment => segment.height > 0 && segment.height < MIN_BAR_HEIGHT)
+    const segmentsToShrink = segments.filter(segment => segment.height > MIN_BAR_HEIGHT)
+
+    if (segmentsNeedingAdjustment.length > 0 && segmentsToShrink.length > 0) {
+      segmentsNeedingAdjustment.forEach(smallSegment => {
+        const heightToAdd = MIN_BAR_HEIGHT - smallSegment.height
+        const heightToTakePerSegment = heightToAdd / segmentsToShrink.length
+
+        segmentsToShrink.forEach(largeSegment => {
+          largeSegment.height -= heightToTakePerSegment
+        })
+
+        smallSegment.height = MIN_BAR_HEIGHT
+      })
+
+      let cumulativeY = segments[0].y
+      segments.forEach(segment => {
+        segment.y = cumulativeY
+        cumulativeY += segment.height
+      })
+    }
+  })
+  return barStacks
+}


### PR DESCRIPTION
## Summary

This sets a minimum height of 3px for non-zero bars in stacked bar charts.

## Testing Steps

Load [this config](https://github.com/user-attachments/files/21798880/vertical-bar-chart-stacked.json), see that a bit of bar is shown for 2015. Experiment with the `MIN_BAR_HEIGHT` variable, or by changing the data in the config.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
