### PR TITLE
Fix [DEV-11296] Suppressed bar label size

### DIFF
--- a/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
@@ -12,6 +12,7 @@ import { BarGroup } from '@visx/shape'
 // CDC core components and helpers
 import { getColorContrast, getContrastColor } from '@cdc/core/helpers/cove/accessibility'
 import { APP_FONT_COLOR } from '@cdc/core/helpers/constants'
+import { isMobileFontViewport } from '@cdc/core/helpers/viewports'
 import createBarElement from '@cdc/core/components/createBarElement'
 import { getBarConfig, testZeroValue } from '../helpers'
 import { getTextWidth } from '@cdc/core/helpers/getTextWidth'
@@ -54,10 +55,13 @@ export const BarChartHorizontal = () => {
     formatNumber,
     formatDate,
     parseDate,
-    setSharedFilter
+    setSharedFilter,
+    currentViewport
   } = useContext<ChartContext>(ConfigContext)
 
   const { HighLightedBarUtils } = useHighlightedBars(config)
+
+  const LABEL_FONT_SIZE = isMobileFontViewport(currentViewport) ? 13 : 16
 
   const hasConfidenceInterval = [config.confidenceKeys?.upper, config.confidenceKeys?.lower].every(
     v => v != null && String(v).trim() !== ''
@@ -132,7 +136,15 @@ export const BarChartHorizontal = () => {
                     barWidthHorizontal: barWidth,
                     isSuppressed,
                     absentDataLabel
-                  } = getBarConfig({ bar, defaultBarWidth, config, isVertical: false, yAxisValue, barWidth: 0 })
+                  } = getBarConfig({
+                    bar,
+                    defaultBarWidth,
+                    config,
+                    isVertical: false,
+                    yAxisValue,
+                    barWidth: 0,
+                    labelFontSize: LABEL_FONT_SIZE
+                  })
 
                   const barPosition = !isPositiveBar ? 'below' : 'above'
 
@@ -298,17 +310,11 @@ export const BarChartHorizontal = () => {
 
                           const hasAsterisk = String(pd.symbol).includes('Asterisk')
                           const verticalAnchor = hasAsterisk ? 'middle' : 'end'
-                          const iconSize =
-                            pd.symbol === 'Asterisk'
-                              ? barHeight * 1.2
-                              : pd.symbol === 'Double Asterisk'
-                              ? barHeight
-                              : barHeight / 1.5
                           const fillColor = pd.displayGray ? '#8b8b8a' : APP_FONT_COLOR
                           return (
                             <Text // prettier-ignore
                               key={index}
-                              fontSize={iconSize}
+                              fontSize={LABEL_FONT_SIZE}
                               display={displayBar ? 'block' : 'none'}
                               opacity={transparentBar ? 0.5 : 1}
                               x={barX}

--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -59,6 +59,8 @@ export const BarChartVertical = () => {
 
   const { HighLightedBarUtils } = useHighlightedBars(config)
 
+  const LABEL_FONT_SIZE = isMobileFontViewport(currentViewport) ? 13 : 16
+
   const root = document.documentElement
 
   let data = transformedData
@@ -170,7 +172,8 @@ export const BarChartVertical = () => {
                     config,
                     barWidth,
                     isVertical: true,
-                    yAxisValue
+                    yAxisValue,
+                    labelFontSize: LABEL_FONT_SIZE
                   })
                   // configure colors
                   let labelColor = APP_FONT_COLOR
@@ -268,8 +271,6 @@ export const BarChartVertical = () => {
 
                   const BAR_LABEL_PADDING = 10
 
-                  const LABEL_FONT_SIZE = isMobileFontViewport(currentViewport) ? 13 : 16
-
                   return (
                     <Group display={hideGroup} key={`${barGroup.index}--${index}`}>
                       <Group key={`bar-sub-group-${barGroup.index}-${barGroup.x0}-${barY}--${index}`}>
@@ -337,13 +338,7 @@ export const BarChartVertical = () => {
                           const hasAsterisk = String(pd.symbol).includes('Asterisk')
                           const yPadding = hasAsterisk ? -5 : -8
                           const verticalAnchor = hasAsterisk ? 'middle' : 'end'
-                          const iconSize =
-                            pd.symbol === 'Asterisk'
-                              ? barWidth * 1.2
-                              : pd.symbol === 'Double Asterisk'
-                              ? barWidth
-                              : barWidth / 1.5
-                          const fillColor = pd.displayGray ? '#8b8b8a' : '#000'
+                          const fillColor = pd.displayGray ? '#8b8b8a' : APP_FONT_COLOR
 
                           return (
                             <Text // prettier-ignore
@@ -356,7 +351,7 @@ export const BarChartVertical = () => {
                               verticalAnchor={verticalAnchor}
                               fill={fillColor}
                               textAnchor='middle'
-                              fontSize={`${iconSize}px`}
+                              fontSize={LABEL_FONT_SIZE}
                             >
                               {pd.iconCode}
                             </Text>

--- a/packages/chart/src/components/BarChart/helpers/index.ts
+++ b/packages/chart/src/components/BarChart/helpers/index.ts
@@ -10,6 +10,7 @@ interface BarConfigProps {
   barWidth: number
   isVertical: boolean
   yAxisValue: number
+  labelFontSize: number
 }
 
 // Function to create bar width based on suppression status and missing data label
@@ -20,7 +21,8 @@ export const getBarConfig = ({
   config,
   barWidth,
   isVertical,
-  yAxisValue
+  yAxisValue,
+  labelFontSize
 }: BarConfigProps) => {
   const heightMini = 3 /// height of small bars aka suppressed/NA/Zero valued
   let barHeight = defaultBarHeight
@@ -50,7 +52,7 @@ export const getBarConfig = ({
 
   // Handle undefined, null, or non-calculable bar.value
   if (!isSuppressed && !isNumber(bar.value) && config.general.showMissingDataLabel) {
-    const labelWidth = getTextWidth(barLabel, `normal ${barWidth / 2}px sans-serif`)
+    const labelWidth = getTextWidth(barLabel, `normal ${labelFontSize}px sans-serif`)
     const labelFits = Number(labelWidth) < barWidth && barWidth > 10
     showMissingDataLabel = true
     barHeight = labelFits ? heightMini : 0
@@ -59,7 +61,7 @@ export const getBarConfig = ({
   // Handle undefined, null, or non-calculable bar.value
 
   if (!isSuppressed && bar.value === '0' && config.general.showZeroValueData) {
-    const labelWidth = getTextWidth('0', `normal ${barWidth / 2}px sans-serif`)
+    const labelWidth = getTextWidth('0', `normal ${labelFontSize}px sans-serif`)
     const labelFits = Number(labelWidth) < barWidth && barWidth > 10
     showZeroValueData = true
     barHeight = labelFits ? heightMini : 0
@@ -91,7 +93,7 @@ export const getBarConfig = ({
     if (showZeroValueData) label = '0'
 
     // determine label width in pixels & check if it fits to the bar width
-    const labelWidth = getTextWidth(barLabel, `normal ${barWidth / 2}px sans-serif`)
+    const labelWidth = getTextWidth(barLabel, `normal ${labelFontSize}px sans-serif`)
     const labelFits = Number(labelWidth) < barWidth && barWidth > 10
     if (config.isLollipopChart) {
       return label


### PR DESCRIPTION
## Summary

Aligns the font size of suppressed bar labels to the rest of the new labels.

## Testing Steps

In this [chart config](https://github.com/user-attachments/files/22048319/bar-suppressed.json), see that the suppressed symbol sizes match the other labels.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
