### PR TITLE
Refactor [DEV-10733] Load vega libraries async

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -415,7 +415,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
         let newData = await fetchRemoteData(newConfig.dataUrl)
 
         if (newConfig.vegaConfig) {
-          newData = extractCoveData(updateVegaData(newConfig.vegaConfig, newData))
+          newData = await extractCoveData(updateVegaData(newConfig.vegaConfig, newData))
         }
 
         if (newData && newConfig.dataDescription) {

--- a/packages/core/helpers/vegaAsyncLoader.ts
+++ b/packages/core/helpers/vegaAsyncLoader.ts
@@ -1,0 +1,26 @@
+// Async loader for Vega and Vega-Lite packages to reduce main bundle size
+let vegaPromise: Promise<typeof import('vega')> | null = null
+let vegaLitePromise: Promise<typeof import('vega-lite')> | null = null
+
+export const loadVega = async () => {
+  if (!vegaPromise) {
+    vegaPromise = import(/* webpackChunkName: "vega" */ 'vega')
+  }
+  return vegaPromise
+}
+
+export const loadVegaLite = async () => {
+  if (!vegaLitePromise) {
+    vegaLitePromise = import(/* webpackChunkName: "vega-lite" */ 'vega-lite')
+  }
+  return vegaLitePromise
+}
+
+export const loadVegaModules = async () => {
+  const [vega, vegaLite] = await Promise.all([loadVega(), loadVegaLite()])
+  return {
+    vegaParse: vega.parse,
+    vegaView: vega.View,
+    vegaLiteCompile: vegaLite.compile
+  }
+}

--- a/packages/core/helpers/vegaAsyncLoader.ts
+++ b/packages/core/helpers/vegaAsyncLoader.ts
@@ -1,26 +1,38 @@
 // Async loader for Vega and Vega-Lite packages to reduce main bundle size
-let vegaPromise: Promise<typeof import('vega')> | null = null
-let vegaLitePromise: Promise<typeof import('vega-lite')> | null = null
+let vegaParsePromise: Promise<any> | null = null
+let vegaViewPromise: Promise<any> | null = null
+let vegaLitePromise: Promise<any> | null = null
 
-export const loadVega = async () => {
-  if (!vegaPromise) {
-    vegaPromise = import(/* webpackChunkName: "vega" */ 'vega')
+const loadVegaParse = async () => {
+  if (!vegaParsePromise) {
+    vegaParsePromise = import(/* webpackChunkName: "vega-parser" */ 'vega-parser')
   }
-  return vegaPromise
+  const vegaParseModule = await vegaParsePromise
+  return vegaParseModule.parse
 }
 
-export const loadVegaLite = async () => {
-  if (!vegaLitePromise) {
-    vegaLitePromise = import(/* webpackChunkName: "vega-lite" */ 'vega-lite')
+const loadVegaView = async () => {
+  if (!vegaViewPromise) {
+    vegaViewPromise = import(/* webpackChunkName: "vega-view" */ 'vega-view')
   }
-  return vegaLitePromise
+  const vegaViewModule = await vegaViewPromise
+  return vegaViewModule.View
 }
 
 export const loadVegaModules = async () => {
-  const [vega, vegaLite] = await Promise.all([loadVega(), loadVegaLite()])
+  const [vegaParse, vegaView] = await Promise.all([loadVegaParse(), loadVegaView()])
   return {
-    vegaParse: vega.parse,
-    vegaView: vega.View,
-    vegaLiteCompile: vegaLite.compile
+    vegaParse: vegaParse,
+    vegaView: vegaView
+  }
+}
+
+export const loadVegaLiteModules = async () => {
+  if (!vegaLitePromise) {
+    vegaLitePromise = import(/* webpackChunkName: "vega-lite" */ 'vega-lite')
+  }
+  const vegaLiteModule = await vegaLitePromise
+  return {
+    vegaLiteCompile: vegaLiteModule.compile
   }
 }

--- a/packages/core/helpers/vegaConfig.ts
+++ b/packages/core/helpers/vegaConfig.ts
@@ -1,7 +1,7 @@
 import { DataTransform } from '@cdc/core/helpers/DataTransform'
 import { formatDate } from '@cdc/core/helpers/cove/date.js'
 import _ from 'lodash'
-import { loadVegaModules } from './vegaAsyncLoader'
+import { loadVegaModules, loadVegaLiteModules } from './vegaAsyncLoader'
 
 const CURVE_LOOKUP = {
   linear: 'Linear',
@@ -107,7 +107,7 @@ export const getVegaWarnings = async (vegaOrVegaLiteConfig, vegaConfig) => {
 
 export const parseVegaConfig = async vegaConfig => {
   try {
-    const { vegaLiteCompile } = await loadVegaModules()
+    const { vegaLiteCompile } = await loadVegaLiteModules()
     vegaConfig = vegaLiteCompile(vegaConfig).spec
   } catch {}
   return vegaConfig

--- a/packages/editor/src/components/ChooseTab.tsx
+++ b/packages/editor/src/components/ChooseTab.tsx
@@ -58,14 +58,14 @@ const ChooseTab: React.FC = (): JSX.Element => {
   const handleUpload = e => {
     const file = e.target.files[0]
     const reader = new FileReader()
-    reader.onload = e => {
+    reader.onload = async e => {
       const text = e.target.result
-      importConfig(text as string)
+      await importConfig(text as string)
     }
     reader.readAsText(file)
   }
 
-  const importConfig = text => {
+  const importConfig = async text => {
     let newConfig
     try {
       newConfig = JSON.parse(text)
@@ -76,25 +76,25 @@ const ChooseTab: React.FC = (): JSX.Element => {
 
     const isVega = isVegaConfig(newConfig)
     if (isVega) {
-      newConfig = importVegaConfig(newConfig)
+      newConfig = await importVegaConfig(newConfig)
     }
 
     dispatch({ type: 'EDITOR_SET_CONFIG', payload: newConfig })
     dispatch({ type: 'EDITOR_SET_GLOBALACTIVE', payload: isVega && newConfig.data?.length ? 2 : 1 })
   }
 
-  const importVegaConfig = newConfig => {
+  const importVegaConfig = async newConfig => {
     let vegaErrors
     try {
-      const vegaConfig = parseVegaConfig(newConfig)
-      vegaErrors = getVegaErrors(newConfig, vegaConfig)
+      const vegaConfig = await parseVegaConfig(newConfig)
+      vegaErrors = await getVegaErrors(newConfig, vegaConfig)
       if (vegaErrors.length === 0) {
-        const configType = getVegaConfigType(vegaConfig)
+        const configType = await getVegaConfigType(vegaConfig)
         const configSubType = configType === 'Map' ? 'United States (State- or County-Level)' : configType
         const button = buttons.find(b => b.label === configSubType)
         const coveConfig = generateNewConfig(JSON.parse(JSON.stringify(button)))
-        const vegaWarnings = getVegaWarnings(newConfig, vegaConfig)
-        const config = convertVegaConfig(configType, vegaConfig, coveConfig)
+        const vegaWarnings = await getVegaWarnings(newConfig, vegaConfig)
+        const config = await convertVegaConfig(configType, vegaConfig, coveConfig)
         if (vegaWarnings.length) {
           alert(vegaWarnings.join('\n\n'))
         }
@@ -264,7 +264,7 @@ const ChooseTab: React.FC = (): JSX.Element => {
             type='submit'
             id='load-data'
             disabled={!pastedConfig}
-            onClick={() => importConfig(pastedConfig)}
+            onClick={async () => await importConfig(pastedConfig)}
           >
             Load
           </button>

--- a/packages/editor/src/components/DataImport/components/DataImport.tsx
+++ b/packages/editor/src/components/DataImport/components/DataImport.tsx
@@ -178,7 +178,7 @@ const DataImport = () => {
     // Have to use FileReader instead of just .text because IE11 and the polyfills for this are bugged
     const filereader = new FileReader()
 
-    filereader.onload = function () {
+    filereader.onload = async function () {
       const handleSetConfig = (newData: Object[], useTempConfig = false) => {
         const setDataURL = keepURL && fileSourceType === 'url'
         if (config.type === 'dashboard') {
@@ -225,7 +225,7 @@ const DataImport = () => {
       try {
         let result = parseTextByMimeType(this.result.toString(), mimeType, externalURL, setErrors)
         if (config.vegaConfig) {
-          return updateDataFromVegaData(result, fileSource, fileSourceType)
+          return await updateDataFromVegaData(result, fileSource, fileSourceType)
         }
         const text = transform.autoStandardize(result)
         if (config.data && config.series) {
@@ -430,9 +430,9 @@ const DataImport = () => {
     dispatch({ type: 'DELETE_DASHBOARD_DATASET', payload: { datasetKey } })
   }
 
-  const updateDataFromVegaConfig = pastedConfig => {
-    const vegaConfig = parseVegaConfig(JSON.parse(pastedConfig))
-    const newData = extractCoveData(vegaConfig)
+  const updateDataFromVegaConfig = async pastedConfig => {
+    const vegaConfig = await parseVegaConfig(JSON.parse(pastedConfig))
+    const newData = await extractCoveData(vegaConfig)
     let newConfig = {
       ...config,
       data: newData
@@ -441,8 +441,8 @@ const DataImport = () => {
     setConfig(newConfig)
   }
 
-  const updateDataFromVegaData = (vegaData, fileSource, fileSourceType) => {
-    const newData = extractCoveData(updateVegaData(config.vegaConfig, vegaData))
+  const updateDataFromVegaData = async (vegaData, fileSource, fileSourceType) => {
+    const newData = await extractCoveData(updateVegaData(config.vegaConfig, vegaData))
     let newConfig = {
       ...config,
       dataFileName: fileSource,
@@ -750,7 +750,7 @@ const DataImport = () => {
                           type='submit'
                           id='load-data'
                           disabled={!pastedConfig}
-                          onClick={() => updateDataFromVegaConfig(pastedConfig)}
+                          onClick={async () => await updateDataFromVegaConfig(pastedConfig)}
                         >
                           Save & Load
                         </button>

--- a/packages/map/src/CdcMap.tsx
+++ b/packages/map/src/CdcMap.tsx
@@ -58,7 +58,7 @@ const CdcMap: React.FC<CdcMapProps> = ({
       let newData = await fetchRemoteData(newState.dataUrl, 'map')
 
       if (newState.vegaConfig) {
-        newData = extractCoveData(updateVegaData(newState.vegaConfig, newData))
+        newData = await extractCoveData(updateVegaData(newState.vegaConfig, newData))
       }
 
       if (newData && newState.dataDescription) {


### PR DESCRIPTION
## Summary

This PR loads the vega libraries asynchronously instead of including them in the chart/map bundles. This means the libraries will only be loaded when the Vega feature is being used.

## Testing Steps

Run a build, make sure everything works, and a Vega chart can still be created using the "paste configuration JSON" box.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
