### PR TITLE
fix: state picked filtering logic

### DIFF
--- a/packages/dashboard/index.html
+++ b/packages/dashboard/index.html
@@ -22,7 +22,7 @@
 </head>
 
 <body>
-  <div class="react-container" data-config="/examples/private/oral-health.json"></div>
+  <div class="react-container" data-config="/examples/private/north-dakota.json"></div>
   <script src="https://www.cdc.gov/TemplatePackage/contrib/libs/jquery/latest/jquery.min.js?_=91329"></script>
   <script type="module" src="./src/index.tsx"></script>
 </body>

--- a/packages/map/src/components/UsaMap/helpers/map.ts
+++ b/packages/map/src/components/UsaMap/helpers/map.ts
@@ -101,7 +101,7 @@ export const getFilterControllingStatesPicked = (state, runtimeData) => {
     return state?.general?.statesPicked?.map(sp => sp.stateName) || []
   } else {
     if (hasMoreThanFromHash(runtimeData)) {
-      let statesPickedFromFilter = Object.values(runtimeData)?.map(
+      let statesPickedFromFilter = Object.values(state.data)?.map(
         s => s[state.general.filterControlsStatesPicked]
       )?.[0]
 


### PR DESCRIPTION
This pull request makes a couple of targeted updates to the dashboard and map helper logic, primarily focusing on changing the dashboard configuration and correcting how states are picked in the map component.

Configuration update:

* The dashboard now loads its configuration from `/examples/private/north-dakota.json` instead of `/examples/private/oral-health.json` in `index.html`, which changes the dataset or region displayed on the dashboard.

Map helper logic correction:

* In `map.ts`, the `getFilterControllingStatesPicked` function now correctly uses `state.data` instead of `runtimeData` when mapping state filter selections, ensuring the filter logic references the intended data structure.