### PR TITLE
Fix/color palette defaults

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
@@ -49,6 +49,8 @@ const PanelVisual: FC<PanelProps> = props => {
   } = useEditorPermissions()
   const { twoColorPalettes, sequential, nonSequential, accessibleColors } = useColorPalette(config, updateConfig)
 
+  const currentPaletteName = getCurrentPaletteName(config)
+
   const updateColor = (property, _value) => {
     console.error('value', _value)
     if (property === 'storyNodeFontColor') {
@@ -294,7 +296,7 @@ const PanelVisual: FC<PanelProps> = props => {
                   colorPalettes={colorPalettes}
                   config={config}
                   onPaletteSelect={handlePaletteSelection}
-                  selectedPalette={getCurrentPaletteName(config)}
+                  selectedPalette={currentPaletteName}
                   colorIndices={[2, 3, 5]}
                   className='color-palette'
                 />

--- a/packages/chart/src/components/Legend/helpers/createFormatLabels.tsx
+++ b/packages/chart/src/components/Legend/helpers/createFormatLabels.tsx
@@ -7,175 +7,174 @@ import { Label } from '../../../types/Label'
 import { ColorScale, TransformedData } from '../../../types/ChartContext'
 import { ChartConfig } from '../../../types/ChartConfig'
 import _ from 'lodash'
+import { FALLBACK_COLOR_PALETTE } from '@cdc/core/helpers/constants'
 
 export const createFormatLabels =
   (config: ChartConfig, tableData: Object[], data: TransformedData[], colorScale: ColorScale) =>
-    (defaultLabels: Label[]): Label[] => {
-      const { visualizationType, visualizationSubType, series, runtime, legend } = config
-      const sortVertical = labels =>
-        legend.verticalSorted
-          ? _.sortBy(_.cloneDeep(labels), label => {
+  (defaultLabels: Label[]): Label[] => {
+    const { visualizationType, visualizationSubType, series, runtime, legend } = config
+    const sortVertical = labels =>
+      legend.verticalSorted
+        ? _.sortBy(_.cloneDeep(labels), label => {
             const match = label.datum?.match(/-?\d+(\.\d+)?/)
             return match ? parseFloat(match[0]) : Number.MAX_SAFE_INTEGER
           })
-          : labels
-      const reverseLabels = labels => {
-        if (config.series.some(series => series.dynamicCategory)) {
-          return orderDynamicLabels(labels)
-        }
-
-        return config.legend.reverseLabelOrder ? sortVertical(labels).reverse() : sortVertical(labels)
+        : labels
+    const reverseLabels = labels => {
+      if (config.series.some(series => series.dynamicCategory)) {
+        return orderDynamicLabels(labels)
       }
 
-      const orderDynamicLabels = labels => {
-        // Handle different ordering configurations
-        switch (config.legend.order) {
-          case 'dataColumn':
-            return labels
-          case 'asc':
-          case 'desc':
-            return labels.sort((a, b) => {
-              const valA = a.datum || a.text
-              const valB = b.datum || b.text
-              const numA = parseFloat(valA)
-              const numB = parseFloat(valB)
-              if (!isNaN(numA) && !isNaN(numB)) {
-                return config.legend.order === 'asc' ? numA - numB : numB - numA
-              } else {
-                return config.legend.order === 'asc' ? valA.localeCompare(valB) : valB.localeCompare(valA)
-              }
-            })
+      return config.legend.reverseLabelOrder ? sortVertical(labels).reverse() : sortVertical(labels)
+    }
 
-          default:
-            return labels // Default case to handle any unexpected config.legend.order values
-        }
-      }
-      const colorCode = config.legend?.colorCode
-      if (visualizationType === 'Deviation Bar') {
-        const [belowColor, aboveColor] = twoColorPalette[config.twoColor.palette]
-        const labelBelow = {
-          datum: 'X',
-          index: 0,
-          text: `Below ${config.xAxis.targetLabel}`,
-          value: belowColor
-        }
-        const labelAbove = {
-          datum: 'X',
-          index: 1,
-          text: `Above ${config.xAxis.targetLabel}`,
-          value: aboveColor
-        }
-
-        return reverseLabels([labelBelow, labelAbove])
-      }
-      if (visualizationType === 'Bar' && visualizationSubType === 'regular' && colorCode && series?.length === 1) {
-        const currentPaletteName = getCurrentPaletteName(config) || 'qualitative_bold'
-        const paletteName = migrateChartPaletteName(currentPaletteName)
-        let palette = getPaletteAccessor(colorPalettes, config, paletteName)
-
-        console.log('palette', palette)
-
-        while (tableData.length > palette.length) {
-          palette = palette.concat(palette)
-        }
-        palette = palette.slice(0, data.length)
-        //store unique values to Set by colorCode
-        const set = new Set()
-
-        tableData.forEach(d => set.add(d[colorCode]))
-
-        // create labels with unique values
-        const uniqueLabels = Array.from(set).map((val, i) => {
-          const newLabel = {
-            datum: val,
-            index: i,
-            text: val,
-            value: palette[i]
-          }
-          return newLabel
-        })
-
-        return reverseLabels(uniqueLabels)
-      }
-
-      // get forecasting items inside of combo
-      if (runtime?.forecastingSeriesKeys?.length > 0) {
-        let seriesLabels = []
-
-        //store unique values to Set by colorCode
-        // loop through each stage/group/area on the chart and create a label
-        config.runtime?.forecastingSeriesKeys?.map((outerGroup, index) => {
-          return outerGroup?.stages?.map((stage, index) => {
-            let colorValue = sequentialPalettes[stage.color]?.[2]
-              ? sequentialPalettes[stage.color]?.[2]
-              : colorPalettes[stage.color]?.[2]
-                ? colorPalettes[stage.color]?.[2]
-                : '#ccc'
-
-            const newLabel = {
-              datum: stage.key,
-              index: index,
-              text: stage.key,
-              value: colorValue
+    const orderDynamicLabels = labels => {
+      // Handle different ordering configurations
+      switch (config.legend.order) {
+        case 'dataColumn':
+          return labels
+        case 'asc':
+        case 'desc':
+          return labels.sort((a, b) => {
+            const valA = a.datum || a.text
+            const valB = b.datum || b.text
+            const numA = parseFloat(valA)
+            const numB = parseFloat(valB)
+            if (!isNaN(numA) && !isNaN(numB)) {
+              return config.legend.order === 'asc' ? numA - numB : numB - numA
+            } else {
+              return config.legend.order === 'asc' ? valA.localeCompare(valB) : valB.localeCompare(valA)
             }
-
-            seriesLabels.push(newLabel)
-          })
-        })
-
-        // loop through bars for now to meet requirements.
-        config.runtime.barSeriesKeys &&
-          config.runtime.barSeriesKeys.forEach((bar, index) => {
-            const currentPaletteName = getCurrentPaletteName(config) || 'qualitative_bold'
-            const migratedPaletteName = migrateChartPaletteName(currentPaletteName)
-            const palette = getPaletteAccessor(colorPalettes, config, migratedPaletteName)
-            let colorValue = palette?.[index] || '#ccc'
-
-            const newLabel = {
-              datum: bar,
-              index: index,
-              text: bar,
-              value: colorValue
-            }
-
-            seriesLabels.push(newLabel)
           })
 
-        return reverseLabels(seriesLabels)
+        default:
+          return labels // Default case to handle any unexpected config.legend.order values
+      }
+    }
+    const colorCode = config.legend?.colorCode
+    if (visualizationType === 'Deviation Bar') {
+      const [belowColor, aboveColor] = twoColorPalette[config.twoColor.palette]
+      const labelBelow = {
+        datum: 'X',
+        index: 0,
+        text: `Below ${config.xAxis.targetLabel}`,
+        value: belowColor
+      }
+      const labelAbove = {
+        datum: 'X',
+        index: 1,
+        text: `Above ${config.xAxis.targetLabel}`,
+        value: aboveColor
       }
 
-      if (config.series.some(item => item.name)) {
-        const uniqueLabels = Array.from(new Set(config.series.map(d => d.name || d.dataKey))).map((val, i) => ({
+      return reverseLabels([labelBelow, labelAbove])
+    }
+    if (visualizationType === 'Bar' && visualizationSubType === 'regular' && colorCode && series?.length === 1) {
+      const currentPaletteName = getCurrentPaletteName(config) || FALLBACK_COLOR_PALETTE
+      const paletteName = migrateChartPaletteName(currentPaletteName)
+      let palette = getPaletteAccessor(colorPalettes, config, paletteName)
+
+      while (tableData.length > palette.length) {
+        palette = palette.concat(palette)
+      }
+      palette = palette.slice(0, data.length)
+      //store unique values to Set by colorCode
+      const set = new Set()
+
+      tableData.forEach(d => set.add(d[colorCode]))
+
+      // create labels with unique values
+      const uniqueLabels = Array.from(set).map((val, i) => {
+        const newLabel = {
           datum: val,
           index: i,
           text: val,
-          value: colorScale(val)
-        }))
-        return reverseLabels(uniqueLabels)
-      }
+          value: palette[i]
+        }
+        return newLabel
+      })
 
-      if (
-        (config.visualizationType === 'Bar' || config.visualizationType === 'Combo') &&
-        config.visualizationSubType === 'regular' &&
-        config.suppressedData
-      ) {
-        const lastIndex = defaultLabels.length - 1
-        let newLabels = []
+      return reverseLabels(uniqueLabels)
+    }
 
-        config.suppressedData?.forEach(({ label, icon }, index) => {
-          if (label && icon) {
-            const newLabel = {
-              datum: label,
-              index: lastIndex + index,
-              text: label,
-              icon: <FaStar color='#000' size={15} />
-            }
-            newLabels.push(newLabel)
+    // get forecasting items inside of combo
+    if (runtime?.forecastingSeriesKeys?.length > 0) {
+      let seriesLabels = []
+
+      //store unique values to Set by colorCode
+      // loop through each stage/group/area on the chart and create a label
+      config.runtime?.forecastingSeriesKeys?.map((outerGroup, index) => {
+        return outerGroup?.stages?.map((stage, index) => {
+          let colorValue = sequentialPalettes[stage.color]?.[2]
+            ? sequentialPalettes[stage.color]?.[2]
+            : colorPalettes[stage.color]?.[2]
+            ? colorPalettes[stage.color]?.[2]
+            : '#ccc'
+
+          const newLabel = {
+            datum: stage.key,
+            index: index,
+            text: stage.key,
+            value: colorValue
           }
+
+          seriesLabels.push(newLabel)
+        })
+      })
+
+      // loop through bars for now to meet requirements.
+      config.runtime.barSeriesKeys &&
+        config.runtime.barSeriesKeys.forEach((bar, index) => {
+          const currentPaletteName = getCurrentPaletteName(config) || 'qualitative_bold'
+          const migratedPaletteName = migrateChartPaletteName(currentPaletteName)
+          const palette = getPaletteAccessor(colorPalettes, config, migratedPaletteName)
+          let colorValue = palette?.[index] || '#ccc'
+
+          const newLabel = {
+            datum: bar,
+            index: index,
+            text: bar,
+            value: colorValue
+          }
+
+          seriesLabels.push(newLabel)
         })
 
-        return [...defaultLabels, ...newLabels]
-      }
-
-      return reverseLabels(defaultLabels)
+      return reverseLabels(seriesLabels)
     }
+
+    if (config.series.some(item => item.name)) {
+      const uniqueLabels = Array.from(new Set(config.series.map(d => d.name || d.dataKey))).map((val, i) => ({
+        datum: val,
+        index: i,
+        text: val,
+        value: colorScale(val)
+      }))
+      return reverseLabels(uniqueLabels)
+    }
+
+    if (
+      (config.visualizationType === 'Bar' || config.visualizationType === 'Combo') &&
+      config.visualizationSubType === 'regular' &&
+      config.suppressedData
+    ) {
+      const lastIndex = defaultLabels.length - 1
+      let newLabels = []
+
+      config.suppressedData?.forEach(({ label, icon }, index) => {
+        if (label && icon) {
+          const newLabel = {
+            datum: label,
+            index: lastIndex + index,
+            text: label,
+            icon: <FaStar color='#000' size={15} />
+          }
+          newLabels.push(newLabel)
+        }
+      })
+
+      return [...defaultLabels, ...newLabels]
+    }
+
+    return reverseLabels(defaultLabels)
+  }

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -147,7 +147,7 @@ export default {
     collapsible: true
   },
   orientation: 'vertical',
-  color: 'sequential_purple',
+  color: 'sequential_blue',
   columns: {
     // start with a blank list
   },

--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -31,7 +31,7 @@ export default {
     palette: {
       isReversed: false,
       version: '2.0',
-      name: 'qualitative-standard'
+      name: 'sequential_blue'
     }
   },
   padding: {
@@ -147,7 +147,7 @@ export default {
     collapsible: true
   },
   orientation: 'vertical',
-  color: 'pinkpurple',
+  color: 'sequential_purple',
   columns: {
     // start with a blank list
   },

--- a/packages/chart/src/helpers/getColorScale.ts
+++ b/packages/chart/src/helpers/getColorScale.ts
@@ -2,7 +2,8 @@ import { twoColorPalette } from '@cdc/core/data/colorPalettes'
 import { filterChartColorPalettes } from '@cdc/core/helpers/filterColorPalettes'
 import { scaleOrdinal } from '@visx/scale'
 import { ChartConfig } from '../types/ChartConfig'
-import { migrateChartPaletteName } from '@cdc/core/helpers/migratePaletteName'
+import { migratePaletteName } from '@cdc/core/helpers/migratePaletteName'
+import { FALLBACK_COLOR_PALETTE } from '@cdc/core/helpers/constants'
 
 export const getColorScale = (config: ChartConfig): ((value: string) => string) => {
   const configPalette = ['Paired Bar', 'Deviation Bar'].includes(config.visualizationType)
@@ -12,9 +13,12 @@ export const getColorScale = (config: ChartConfig): ((value: string) => string) 
   const allPalettes: Record<string, string[]> = { ...colorPalettes, ...twoColorPalette }
 
   // Migrate old palette name if needed
-  const migratedPaletteName = configPalette ? migrateChartPaletteName(configPalette) : undefined
+  const migratedPaletteName = configPalette ? configPalette : FALLBACK_COLOR_PALETTE
 
-  let palette = config.general?.palette?.customColors || allPalettes[migratedPaletteName] || allPalettes[configPalette]
+  let palette =
+    config.general?.palette?.customColors ||
+    allPalettes[migratePaletteName(migratedPaletteName)] ||
+    allPalettes[configPalette]
 
   // Fallback to a default palette if none found
   if (!palette) {

--- a/packages/core/helpers/constants.ts
+++ b/packages/core/helpers/constants.ts
@@ -2,5 +2,6 @@ export const APP_FONT_SIZE = 18
 
 export const COOL_GRAY_90 = getComputedStyle(document.documentElement).getPropertyValue('--cool-gray-90').trim()
 export const APP_FONT_COLOR = COOL_GRAY_90
+export const FALLBACK_COLOR_PALETTE = 'sequential_purple'
 
 export const EDITOR_WIDTH = 350

--- a/packages/core/helpers/constants.ts
+++ b/packages/core/helpers/constants.ts
@@ -1,7 +1,5 @@
 export const APP_FONT_SIZE = 18
-
 export const COOL_GRAY_90 = getComputedStyle(document.documentElement).getPropertyValue('--cool-gray-90').trim()
 export const APP_FONT_COLOR = COOL_GRAY_90
-export const FALLBACK_COLOR_PALETTE = 'sequential_purple'
-
+export const FALLBACK_COLOR_PALETTE = 'sequential_blue'
 export const EDITOR_WIDTH = 350

--- a/packages/core/helpers/palettes/utils.ts
+++ b/packages/core/helpers/palettes/utils.ts
@@ -1,5 +1,7 @@
 import { FALLBACK_COLOR_PALETTE } from '../constants'
 import { getColorPaletteVersion } from '../getColorPaletteVersion'
+import { getPaletteAccessor } from '../getPaletteAccessor'
+import { migrateChartPaletteName } from '../migratePaletteName'
 
 /**
  * Gets the current palette name from a visualization config
@@ -7,7 +9,21 @@ import { getColorPaletteVersion } from '../getColorPaletteVersion'
  * @returns The current palette name or empty string if not found
  */
 export const getCurrentPaletteName = (config: any): string => {
-  return config?.general?.palette?.name || FALLBACK_COLOR_PALETTE
+  // Check new v2 format first
+  if (config?.general?.palette?.name) {
+    return config.general.palette.name
+  }
+
+  // Check legacy v1 formats
+  if (config?.palette) {
+    return config.palette
+  }
+
+  if (config?.color) {
+    return config.color
+  }
+
+  return FALLBACK_COLOR_PALETTE
 }
 
 /**
@@ -27,10 +43,20 @@ export const getPaletteColors = (config: any, colorPalettes: any): string[] => {
     return config.customColors
   }
 
-  // Then check for palette name
-  const paletteName = getCurrentPaletteName(config)
-  if (paletteName && colorPalettes?.[paletteName]) {
-    return colorPalettes[paletteName]
+  // Get the raw palette name
+  let paletteName = getCurrentPaletteName(config)
+
+  // Apply v1 palette name migrations if this is a v1 config
+  const paletteVersion = getColorPaletteVersion(config)
+  if (paletteVersion === 1 && migrateChartPaletteName(paletteName)) {
+    paletteName = migrateChartPaletteName(paletteName)
+  }
+
+  // Get the versioned palette accessor
+  const versionedPalettes = getPaletteAccessor(colorPalettes, config)
+
+  if (paletteName && versionedPalettes?.[paletteName]) {
+    return versionedPalettes[paletteName]
   }
 
   return []

--- a/packages/core/helpers/palettes/utils.ts
+++ b/packages/core/helpers/palettes/utils.ts
@@ -1,3 +1,4 @@
+import { FALLBACK_COLOR_PALETTE } from '../constants'
 import { getColorPaletteVersion } from '../getColorPaletteVersion'
 
 /**
@@ -6,7 +7,7 @@ import { getColorPaletteVersion } from '../getColorPaletteVersion'
  * @returns The current palette name or empty string if not found
  */
 export const getCurrentPaletteName = (config: any): string => {
-  return config?.general?.palette?.name || config?.palette || ''
+  return config?.general?.palette?.name || FALLBACK_COLOR_PALETTE
 }
 
 /**
@@ -43,8 +44,8 @@ export const getPaletteColors = (config: any, colorPalettes: any): string[] => {
 export const isV1Palette = (config: any): boolean => {
   const currentVersion = getColorPaletteVersion(config)
   return (
-    currentVersion === 1 || 
-    config?.general?.palette?.version === '1.0' || 
+    currentVersion === 1 ||
+    config?.general?.palette?.version === '1.0' ||
     !config?.general?.palette?.version
   )
 }

--- a/packages/core/helpers/ver/4.25.9.ts
+++ b/packages/core/helpers/ver/4.25.9.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import { FALLBACK_COLOR_PALETTE } from '../constants'
 
 // Rname Palettes
 const newMapPaletteNames = {
@@ -38,7 +39,7 @@ const newMapPaletteNames = {
 
 const chartPaletteNameMigrations = {
     'qualitative-bold': 'qualitative_bold',
-    'qualitative-soft': 'qualitative_soft', 
+    'qualitative-soft': 'qualitative_soft',
     'qualitative-standard': 'qualitative_standard',
     'sequential-blue': 'sequential_blue',
     'sequential-blue-2-(MPX)': 'sequential_blue_extended',
@@ -48,7 +49,7 @@ const chartPaletteNameMigrations = {
     'sequential-purple': 'sequential_purple',
     'sequential-teal': 'sequential_teal',
     'divergent-bluecyan': 'divergent_blue_cyan',
-    'divergent-bluepurple': 'divergent_blue_purple', 
+    'divergent-bluepurple': 'divergent_blue_purple',
     'divergent-greenorange': 'divergent_green_orange',
     'divergent-blueorange': 'divergent_blue_orange',
     'qualitative1': 'qualitative1',
@@ -58,7 +59,7 @@ const chartPaletteNameMigrations = {
     'colorblindsafe': 'colorblindsafe',
     // Reverse variants
     'qualitative-boldreverse': 'qualitative_boldreverse',
-    'qualitative-softreverse': 'qualitative_softreverse', 
+    'qualitative-softreverse': 'qualitative_softreverse',
     'qualitative-standardreverse': 'qualitative_standardreverse',
     'sequential-bluereverse': 'sequential_bluereverse',
     'sequential-blue-2-(MPX)reverse': 'sequential_blue_extendedreverse',
@@ -68,7 +69,7 @@ const chartPaletteNameMigrations = {
     'sequential-purplereverse': 'sequential_purplereverse',
     'sequential-tealreverse': 'sequential_tealreverse',
     'divergent-bluecyanreverse': 'divergent_blue_cyanreverse',
-    'divergent-bluepurplereverse': 'divergent_blue_purplereverse', 
+    'divergent-bluepurplereverse': 'divergent_blue_purplereverse',
     'divergent-greenorangereverse': 'divergent_green_orangereverse',
     'divergent-blueorangereverse': 'divergent_blue_orangereverse',
     'qualitative1reverse': 'qualitative1reverse',
@@ -127,13 +128,11 @@ const movePaletteName = config => {
     if (config.type === 'chart') {
         config.general = config.general || {}
         config.general.palette = config.general.palette || {}
-        config.general.palette.name = config.palette || 'qualitative-bold'
+        config.general.palette.name = config.palette || config.color || FALLBACK_COLOR_PALETTE
         saveBackup(config)
         delete config.palette
         delete config.color // outdated
-
         renameOriginalChartPalettes(config)
-
     }
 
     if (config.type === 'dashboard') {


### PR DESCRIPTION
This pull request updates the chart color palette logic to improve consistency, fallback handling, and migration support across the codebase. The main changes include introducing a new fallback palette constant, refactoring palette name retrieval and migration logic, and updating default palette values in initial state and migration utilities.

**Palette fallback and migration improvements:**

* Added a new constant `FALLBACK_COLOR_PALETTE` (`sequential_blue`) in `constants.ts` to standardize fallback palette usage throughout the codebase.
* Refactored the `getCurrentPaletteName` utility to check for palette names in multiple config locations and default to `FALLBACK_COLOR_PALETTE` if none found, improving robustness for both v1 and v2 configs.
* Updated palette migration logic in `getPaletteColors` and related helpers to use the new fallback palette and ensure correct palette selection for legacy configs. [[1]](diffhunk://#diff-a8e5802284b02042c3f1415ef752da91a02eaac3e9f61df8f8265eacf7a198c1L29-R59) [[2]](diffhunk://#diff-ec729d97f32f36c805f856761098a09287b21b4d41d682cbd03a18ad4f0529b6L5-R6) [[3]](diffhunk://#diff-ec729d97f32f36c805f856761098a09287b21b4d41d682cbd03a18ad4f0529b6L15-R21)

**Default palette and initial state updates:**

* Changed the default palette name and color in `initial-state.js` from qualitative palettes to `sequential_blue` to align with new fallback logic. [[1]](diffhunk://#diff-d9201f7c314bf27f6a7d8586a9ccd07e720d3d3719e55121c730bdba9cf71193L34-R34) [[2]](diffhunk://#diff-d9201f7c314bf27f6a7d8586a9ccd07e720d3d3719e55121c730bdba9cf71193L150-R150)

**Migration and legend helper adjustments:**

* Modified migration utility in `ver/4.25.9.ts` to use `FALLBACK_COLOR_PALETTE` when migrating old palette names, ensuring charts and dashboards always have a valid palette name. [[1]](diffhunk://#diff-84b198b946c18440b07372f1ee84924193c7c5d82848bc17aed7c54c45671820R2) [[2]](diffhunk://#diff-84b198b946c18440b07372f1ee84924193c7c5d82848bc17aed7c54c45671820L130-L136)
* Updated legend formatting logic to use the new fallback palette constant, replacing hardcoded palette names for consistency. [[1]](diffhunk://#diff-e3a3efb31e4ecea2475727edaa73546c3b5c383b8f5211d4c09ffe1cfa28f337R10) [[2]](diffhunk://#diff-e3a3efb31e4ecea2475727edaa73546c3b5c383b8f5211d4c09ffe1cfa28f337L72-L77)

**Editor panel integration:**

* Improved palette selection in the visual editor panel by using the refactored `getCurrentPaletteName` utility, ensuring correct palette display and selection. [[1]](diffhunk://#diff-cfcd80d3247de95ad2b2a2acc3fe79e9e0cd9f1b3af8bfdc884a9a26e82b09c8R52-R53) [[2]](diffhunk://#diff-cfcd80d3247de95ad2b2a2acc3fe79e9e0cd9f1b3af8bfdc884a9a26e82b09c8L297-R299)