### PR TITLE
Fix: Sass warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-visibility-sensor": "^5.1.1",
     "resize-observer-polyfill": "^1.5.1",
     "rollup-plugin-node-externals": "^6.1.2",
-    "sass": "^1.59.3",
+    "sass": "^1.89.2",
     "storybook": "^7.4.6",
     "storybook-addon-fetch-mock": "^1.0.1",
     "use-debounce": "^7.0.1",

--- a/packages/core/generateViteConfig.js
+++ b/packages/core/generateViteConfig.js
@@ -24,7 +24,7 @@ const generateViteConfig = (componentName, configOptions = {}, reactOptions = {}
         scss: {
           // Suppress legacy JS API warnings from Vite's internal Sass usage
           quietDeps: true,
-          silenceDeprecations: ['legacy-js-api']
+          silenceDeprecations: ['legacy-js-api', 'import']
         }
       }
     },

--- a/packages/core/generateViteConfig.js
+++ b/packages/core/generateViteConfig.js
@@ -19,6 +19,15 @@ const __dirname = path.dirname(__filename)
 // - Active dev servers ('lerna run start') must be restarted in order to view the changed settings.
 const generateViteConfig = (componentName, configOptions = {}, reactOptions = {}) => {
   let configOptionsDefault = {
+    css: {
+      preprocessorOptions: {
+        scss: {
+          // Suppress legacy JS API warnings from Vite's internal Sass usage
+          quietDeps: true,
+          silenceDeprecations: ['legacy-js-api']
+        }
+      }
+    },
     server: {
       port: 8080,
       headers: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,6 @@
     "react-select": "^5.3.1",
     "react-tooltip": "5.8.2-beta.3",
     "resize-observer-polyfill": "^1.5.1",
-    "sass": "^1.89.2",
     "use-debounce": "^10.0.5",
     "vega": "^6.1.0",
     "vega-lite": "^6.1.0"
@@ -43,7 +42,7 @@
   },
   "gitHead": "9062881d50c824ee6cdd71868bafd016a5e5694d",
   "devDependencies": {
-    "sass": "^1.79.4",
+    "sass": "^1.89.2",
     "vite": "^4.4.11",
     "@vitejs/plugin-react": "^4.3.4",
     "vite-plugin-css-injected-by-js": "^2.4.0",

--- a/packages/core/styles/_global.scss
+++ b/packages/core/styles/_global.scss
@@ -44,11 +44,11 @@ strong {
 .inline-icon {
   width: 1em !important;
   height: auto !important;
+  font-size: 1rem;
+  color: inherit;
   @media all and (-ms-high-contrast: none) {
     height: 30px !important;
   }
-  font-size: 1rem;
-  color: inherit;
   path {
     fill: currentColor;
   }

--- a/packages/core/styles/_global.scss
+++ b/packages/core/styles/_global.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 strong {
   font-weight: 600;
 }
@@ -76,7 +78,7 @@ strong {
     font-size: 0.8 em;
     color: #fff;
     &:hover {
-      background-color: darken($red, 5%);
+      background-color: color.adjust($red, $lightness: -5%);
     }
   }
 
@@ -168,8 +170,8 @@ section.footnotes {
   background-color: $blue;
   border-color: $blue;
   &:hover:not([disabled]) {
-    background-color: darken($blue, 5%);
-    border-color: darken($blue, 5%);
+    background-color: color.adjust($blue, $lightness: -5%);
+    border-color: color.adjust($blue, $lightness: -5%);
   }
 }
 

--- a/packages/core/styles/base.scss
+++ b/packages/core/styles/base.scss
@@ -66,6 +66,11 @@ body.post-type-cdc_visualization .cdc-editor .configure .editor-panel {
 .cdc-open-viz-module {
   position: relative;
   line-height: 1.4;
+  // Force printing chart images
+  -webkit-print-color-adjust: exact !important; /* Chrome, Safari 6 – 15.3, Edge */
+  color-adjust: exact !important; /* Firefox 48 – 96 */
+  print-color-adjust: exact !important; /* Firefox 97+, Safari 15.4+ */
+
   @import 'global';
   @import 'button-section';
   @import 'series-list';
@@ -74,11 +79,6 @@ body.post-type-cdc_visualization .cdc-editor .configure .editor-panel {
   input[type='range'] {
     appearance: auto !important;
   }
-
-  // Force printing chart images
-  -webkit-print-color-adjust: exact !important; /* Chrome, Safari 6 – 15.3, Edge */
-  color-adjust: exact !important; /* Firefox 48 – 96 */
-  print-color-adjust: exact !important; /* Firefox 97+, Safari 15.4+ */
 
   $theme: (
     'amber': (

--- a/packages/core/styles/v2/components/button.scss
+++ b/packages/core/styles/v2/components/button.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @import '../utils/variables';
 @import '../themes/index';
 
@@ -110,7 +111,7 @@
     background-color: #44aa41;
 
     &:hover {
-      background-color: lighten(#44aa41, 5%);
+      background-color: color.adjust(#44aa41, $lightness: 5%);
     }
   }
 
@@ -118,7 +119,7 @@
     background-color: #d73636;
 
     &:hover {
-      background-color: darken(#d73636, 5%);
+      background-color: color.adjust(#d73636, $lightness: -5%);
     }
   }
 
@@ -126,7 +127,7 @@
     background-color: #a0a0a0;
 
     &:hover {
-      background-color: darken(#a0a0a0, 5%);
+      background-color: color.adjust(#a0a0a0, $lightness: -5%);
     }
   }
 

--- a/packages/core/styles/v2/components/editor.scss
+++ b/packages/core/styles/v2/components/editor.scss
@@ -2,11 +2,12 @@
 @import '../themes/index';
 
 .cove-editor {
-  @import './../base/reset';
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-areas: 'panel content';
   height: 100vh;
+
+  @import './../base/reset';
 
   .cove-editor__panel {
     grid-area: panel;

--- a/packages/core/styles/v2/layout/_data-table.scss
+++ b/packages/core/styles/v2/layout/_data-table.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .cove-data-table {
   position: relative;
 }
@@ -144,7 +146,7 @@
   }
 
   .sort {
-    background-color: darken($mediumGray, 10%);
+    background-color: color.adjust($mediumGray, $lightness: -10%);
     background-repeat: no-repeat;
     background-position: right 0.5em center;
     background-size: 10px 5px;
@@ -160,7 +162,6 @@
     touch-action: none;
   }
 }
-
 
 .cove-data-table__footer {
   margin-top: 1rem;

--- a/packages/core/styles/v2/themes/_color-definitions.scss
+++ b/packages/core/styles/v2/themes/_color-definitions.scss
@@ -1,4 +1,5 @@
 @use 'sass:string';
+@use 'sass:list';
 @import './../../variables';
 
 $theme: (
@@ -82,8 +83,8 @@ $theme: (
   @each $theme-name, $theme-colors in $theme {
     // Header
     .theme-#{$theme-name} {
-      background-color: string.unquote(nth($theme-colors, 1));
-      border-color: string.unquote(nth($theme-colors, 2));
+      background-color: string.unquote(list.nth($theme-colors, 1));
+      border-color: string.unquote(list.nth($theme-colors, 2));
       border-bottom-style: solid;
       border-bottom-width: 4px;
     }
@@ -95,7 +96,7 @@ $theme: (
         &:not(.no-borders) {
           /// borders are the theme color
           &.component--has-borderColorTheme {
-            border: 1px solid string.unquote(nth($theme-colors, 1));
+            border: 1px solid string.unquote(list.nth($theme-colors, 1));
           }
           /// using default border color to draw borders
           &:not(.component--has-borderColorTheme) {
@@ -108,23 +109,23 @@ $theme: (
 
         /// left accent bar
         &.component--has-accent {
-          border-left: 0.5rem solid string.unquote(nth($theme-colors, 1)) !important;
+          border-left: 0.5rem solid string.unquote(list.nth($theme-colors, 1)) !important;
         }
 
         /// Apply a background color
         &.component--has-background:not(.component--hideBackgroundColor) {
-          background: string.unquote(nth($theme-colors, 3));
+          background: string.unquote(list.nth($theme-colors, 3));
         }
       }
 
       .cove-component__header {
-        border-color: string.unquote(nth($theme-colors, 2));
+        border-color: string.unquote(list.nth($theme-colors, 2));
       }
     }
 
     &.theme-#{$theme-name} {
       .cove-component__header {
-        border-color: string.unquote(nth($theme-colors, 2));
+        border-color: string.unquote(list.nth($theme-colors, 2));
       }
     }
   }
@@ -135,42 +136,42 @@ $theme: (
   @each $theme-name, $theme-colors in $theme {
     &.theme-#{$theme-name} {
       .single-filters--tab .tab--active:not(.tab--simple) {
-        border: 1px solid string.unquote(nth($theme-colors, 1));
-        border-top: 3px solid string.unquote(nth($theme-colors, 1));
+        border: 1px solid string.unquote(list.nth($theme-colors, 1));
+        border-top: 3px solid string.unquote(list.nth($theme-colors, 1));
         border-bottom: none;
       }
 
       .single-filters--tab .tab:not(.tab--active):not(.tab--simple) {
-        border-bottom: 1px solid string.unquote(nth($theme-colors, 1));
+        border-bottom: 1px solid string.unquote(list.nth($theme-colors, 1));
       }
 
       .single-filters--pill .pill--active {
-        background-color: string.unquote(nth($theme-colors, 1));
+        background-color: string.unquote(list.nth($theme-colors, 1));
         color: #fff;
       }
     }
 
     .theme-#{$theme-name} {
       .single-filters--tab .tab--active:not(.tab--simple) {
-        border: 1px solid string.unquote(nth($theme-colors, 1));
-        border-top: 3px solid string.unquote(nth($theme-colors, 1));
+        border: 1px solid string.unquote(list.nth($theme-colors, 1));
+        border-top: 3px solid string.unquote(list.nth($theme-colors, 1));
         border-bottom: none;
       }
 
       .single-filters--tab .tab:not(.tab--active):not(.tab--simple) {
-        border-bottom: 1px solid string.unquote(nth($theme-colors, 1));
+        border-bottom: 1px solid string.unquote(list.nth($theme-colors, 1));
       }
 
       .single-filters--pill .pill--active {
-        background-color: string.unquote(nth($theme-colors, 1));
+        background-color: string.unquote(list.nth($theme-colors, 1));
         color: #fff;
       }
 
       .button__tab-bar--active {
-        outline: 2px solid string.unquote(nth($theme-colors, 1));
+        outline: 2px solid string.unquote(list.nth($theme-colors, 1));
       }
       .apply:not([disabled]) {
-        background-color: string.unquote(nth($theme-colors, 1));
+        background-color: string.unquote(list.nth($theme-colors, 1));
       }
     }
   }

--- a/packages/dashboard/src/scss/grid.scss
+++ b/packages/dashboard/src/scss/grid.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $blue-light: #8bc6f7;
 $red: #f74242;
 
@@ -88,7 +90,7 @@ $red: #f74242;
   &:hover {
     transition: width 0.2s cubic-bezier(0.16, 1, 0.3, 1);
     width: 180px;
-    background-color: lighten($blue, 8%);
+    background-color: color.adjust($blue, $lightness: 8%);
     li {
       display: flex;
     }
@@ -136,7 +138,7 @@ $red: #f74242;
   flex: 1 1 auto;
 
   &:hover {
-    border-color: darken(#c2c2c2, 20%);
+    border-color: color.adjust(#c2c2c2, $lightness: -20%);
   }
 
   &.column--populated {
@@ -194,15 +196,15 @@ $red: #f74242;
   &:hover {
     $lightGray: #c7c7c7;
     $mediumGray: #565656;
-    border-color: darken($lightGray, 20%);
+    border-color: color.adjust($lightGray, $lightness: -20%);
 
     .widget-menu-item svg {
-      fill: darken($mediumGray, 20%);
+      fill: color.adjust($mediumGray, $lightness: -20%);
     }
 
     .drag-icon,
     .drag-icon svg {
-      fill: darken($lightGray, 20%);
+      fill: color.adjust($lightGray, $lightness: -20%);
     }
   }
 

--- a/packages/editor/src/components/DataImport/components/data-import.scss
+++ b/packages/editor/src/components/DataImport/components/data-import.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @import './../../../scss/variables.scss';
 
 .cdc-editor .data-designer {
@@ -114,7 +115,7 @@
     }
     .btn.active {
       $primary: #005eaa;
-      background: darken($primary, 15%);
+      background: color.adjust($primary, $lightness: -15%);
     }
     .input-group {
       display: flex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13691,7 +13691,7 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@^1.59.3, sass@^1.89.2:
+sass@^1.89.2:
   version "1.89.2"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.89.2.tgz#a771716aeae774e2b529f72c0ff2dfd46c9de10e"
   integrity sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==


### PR DESCRIPTION
## Summary

This removes all the sass deprecation warnings from the console. Migrating to sass 2 and 3 will be a decent chunk of work, whenever they come out.

## Testing Steps

`lerna run --scope @cdc/dashboard start`no longer shows a bunch of warnings.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
