### PR TITLE
Cast seriesName to string

### DIFF
--- a/packages/core/components/DataTable/helpers/chartCellMatrix.tsx
+++ b/packages/core/components/DataTable/helpers/chartCellMatrix.tsx
@@ -91,7 +91,7 @@ const chartCellArray = ({
           ? [
               <>
                 {colorScale && colorScale(seriesName) && <LegendShape fill={colorScale(seriesName)} />}
-                {parse(seriesName)}
+                {parse(String(seriesName))}
               </>
             ]
           : []


### PR DESCRIPTION
## Summary

This is fixing an issue introduced in https://github.com/CDCgov/cdc-open-viz/pull/2284 that shows up only when you have non-string seriesNames.
