### PR TITLE
DEV-11166 Remove suppressed data items from tooltips

### DIFF
--- a/packages/chart/examples/suppressed_tooltip.json
+++ b/packages/chart/examples/suppressed_tooltip.json
@@ -1,0 +1,480 @@
+{
+  "errors": [],
+  "currentViewport": "lg",
+  "id": 1,
+  "category": "Charts",
+  "label": "Bar",
+  "type": "chart",
+  "subType": "Bar",
+  "orientation": "vertical",
+  "barThickness": "0.37",
+  "visualizationSubType": "regular",
+  "xAxis": {
+    "sortDates": false,
+    "anchors": [],
+    "type": "date",
+    "showTargetLabel": true,
+    "targetLabel": "Target",
+    "hideAxis": false,
+    "hideLabel": false,
+    "hideTicks": false,
+    "size": 75,
+    "tickRotation": 0,
+    "min": "",
+    "max": "",
+    "labelColor": "#333",
+    "tickLabelColor": "#333",
+    "tickColor": "#333",
+    "numTicks": "",
+    "labelOffset": 0,
+    "axisPadding": 200,
+    "target": 0,
+    "maxTickRotation": 45,
+    "padding": 5,
+    "showYearsOnce": false,
+    "sortByRecentDate": false,
+    "brushActive": true,
+    "dataKey": "Date",
+    "dateParseFormat": "%m/%d/%Y",
+    "dateDisplayFormat": "%m/%Y",
+    "axisBBox": 29.860000610351562,
+    "tickWidthMax": 63
+  },
+  "icon": {
+    "key": null,
+    "ref": null,
+    "props": {},
+    "_owner": null
+  },
+  "content": "Use bars to show comparisons between data categories.",
+  "visualizationType": "Bar",
+  "datasets": {},
+  "activeVizButtonID": 1,
+  "data": [
+    {
+      "Date": "1/15/2016",
+      "Data 1": "ABC",
+      "Data 2": "110",
+      "Data 3": "100",
+      "Data 4": "XYZ",
+      "Monthly-Goal": "100"
+    },
+    {
+      "Date": "2/15/2016",
+      "Data 1": "100",
+      "Data 2": "110",
+      "Data 3": "100",
+      "Data 4": "",
+      "Monthly-Goal": "100"
+    },
+    {
+      "Date": "3/15/2016",
+      "Data 1": "80",
+      "Data 2": "90",
+      "Data 3": "0",
+      "Data 4": "120",
+      "Monthly-Goal": "110"
+    },
+    {
+      "Date": "4/15/2016",
+      "Data 1": "80",
+      "Data 2": "MRC",
+      "Data 3": "110",
+      "Data 4": "0",
+      "Monthly-Goal": "110"
+    },
+    {
+      "Date": "5/15/2016",
+      "Data 1": "70",
+      "Data 2": "90",
+      "Data 3": "110",
+      "Data 4": "130",
+      "Monthly-Goal": "120"
+    },
+    {
+      "Date": "6/15/2016",
+      "Data 1": "XYZ",
+      "Data 2": "120",
+      "Data 3": "120",
+      "Data 4": "ABC",
+      "Monthly-Goal": "120"
+    },
+    {
+      "Date": "7/15/2016",
+      "Data 1": "110",
+      "Data 2": "ABC",
+      "Data 3": "ABC",
+      "Data 4": "130",
+      "Monthly-Goal": "130"
+    },
+    {
+      "Date": "8/15/2016",
+      "Data 1": "110",
+      "Data 2": "130",
+      "Data 3": "ABC",
+      "Data 4": "140",
+      "Monthly-Goal": "130"
+    },
+    {
+      "Date": "9/15/2016",
+      "Data 1": "120",
+      "Data 2": "130",
+      "Data 3": "120",
+      "Data 4": "XYZ",
+      "Monthly-Goal": "140"
+    }
+  ],
+  "dataFileName": "https://wwwdev.cdc.gov/wcms/cailin/result-7.csv",
+  "dataFileSourceType": "url",
+  "dataDescription": {
+    "horizontal": false,
+    "series": true,
+    "singleRow": true
+  },
+  "annotations": [],
+  "debugSvg": false,
+  "chartMessage": {
+    "noData": "No Data Available"
+  },
+  "title": "<em>4.25.07</em> Suppressed & Isolated Bar Chart",
+  "showTitle": true,
+  "showDownloadMediaButton": false,
+  "theme": "theme-blue",
+  "animate": false,
+  "lineDatapointStyle": "hover",
+  "lineDatapointColor": "Same as Line",
+  "barHasBorder": "true",
+  "isLollipopChart": false,
+  "lollipopShape": "circle",
+  "lollipopColorStyle": "two-tone",
+  "barStyle": "",
+  "roundingStyle": "standard",
+  "tipRounding": "top",
+  "isResponsiveTicks": false,
+  "general": {
+    "annotationDropdownText": "Annotations",
+    "showMissingDataLabel": false,
+    "showSuppressedSymbol": false,
+    "showZeroValueData": false,
+    "hideNullValue": true
+  },
+  "padding": {
+    "left": 5,
+    "right": 5
+  },
+  "preliminaryData": [
+    {
+      "type": "suppression",
+      "seriesKeys": [],
+      "label": "Suppressed",
+      "column": "",
+      "value": "ABC",
+      "style": "",
+      "displayTooltip": true,
+      "displayLegend": true,
+      "displayTable": true,
+      "symbol": "Double Asterisk",
+      "iconCode": "**",
+      "lineCode": "",
+      "hideBarSymbol": false,
+      "hideLineStyle": false,
+      "circleSize": 6,
+      "displayGray": true
+    },
+    {
+      "type": "suppression",
+      "seriesKeys": [],
+      "label": "Suppressed",
+      "column": "",
+      "value": "XYZ",
+      "style": "",
+      "displayTooltip": true,
+      "displayLegend": true,
+      "displayTable": true,
+      "symbol": "Dagger",
+      "iconCode": "†",
+      "lineCode": "",
+      "hideBarSymbol": false,
+      "hideLineStyle": false,
+      "circleSize": 6,
+      "displayGray": true
+    }
+  ],
+  "yAxis": {
+    "hideAxis": false,
+    "displayNumbersOnBar": false,
+    "hideLabel": false,
+    "hideTicks": false,
+    "size": 50,
+    "gridLines": false,
+    "enablePadding": false,
+    "min": "",
+    "max": "",
+    "labelColor": "#333",
+    "tickLabelColor": "#333",
+    "tickColor": "#333",
+    "rightHideAxis": false,
+    "rightAxisSize": 0,
+    "rightLabel": "",
+    "rightLabelOffsetSize": 0,
+    "rightAxisLabelColor": "#333",
+    "rightAxisTickLabelColor": "#333",
+    "rightAxisTickColor": "#333",
+    "numTicks": "",
+    "axisPadding": 0,
+    "scalePadding": 10,
+    "tickRotation": 0,
+    "anchors": [],
+    "shoMissingDataLabel": true,
+    "showMissingDataLine": true,
+    "categories": []
+  },
+  "boxplot": {
+    "plots": [],
+    "borders": "true",
+    "plotOutlierValues": false,
+    "plotNonOutlierValues": true,
+    "labels": {
+      "q1": "Lower Quartile",
+      "q2": "q2",
+      "q3": "Upper Quartile",
+      "q4": "q4",
+      "minimum": "Minimum",
+      "maximum": "Maximum",
+      "mean": "Mean",
+      "median": "Median",
+      "sd": "Standard Deviation",
+      "iqr": "Interquartile Range",
+      "count": "Count",
+      "outliers": "Outliers",
+      "values": "Values",
+      "lowerBounds": "Lower Bounds",
+      "upperBounds": "Upper Bounds"
+    }
+  },
+  "topAxis": {
+    "hasLine": false
+  },
+  "isLegendValue": false,
+  "barHeight": 25,
+  "barSpace": 15,
+  "heights": {
+    "vertical": 300,
+    "horizontal": 750
+  },
+  "table": {
+    "label": "Data Table",
+    "expanded": false,
+    "limitHeight": false,
+    "height": "",
+    "caption": "",
+    "showDownloadUrl": false,
+    "showDataTableLink": true,
+    "showDownloadLinkBelow": true,
+    "indexLabel": "",
+    "download": true,
+    "showVertical": true,
+    "dateDisplayFormat": "",
+    "showMissingDataLabel": true,
+    "showSuppressedSymbol": true,
+    "show": true
+  },
+  "color": "pinkpurple",
+  "columns": {},
+  "legend": {
+    "hide": false,
+    "behavior": "isolate",
+    "axisAlign": true,
+    "singleRow": true,
+    "colorCode": "",
+    "reverseLabelOrder": false,
+    "description": "",
+    "dynamicLegend": false,
+    "dynamicLegendDefaultText": "Show All",
+    "dynamicLegendItemLimit": 5,
+    "dynamicLegendItemLimitMessage": "Dynamic Legend Item Limit Hit.",
+    "dynamicLegendChartMessage": "Select Options from the Legend",
+    "label": "",
+    "lineMode": false,
+    "verticalSorted": false,
+    "highlightOnHover": false,
+    "hideSuppressedLabels": false,
+    "hideSuppressionLink": false,
+    "seriesHighlight": [],
+    "style": "circles",
+    "subStyle": "linear blocks",
+    "groupBy": "",
+    "shape": "circle",
+    "tickRotation": "",
+    "order": "dataColumn",
+    "hideBorder": {
+      "side": false,
+      "topBottom": true
+    },
+    "position": "right",
+    "orderedValues": [],
+    "unified": true
+  },
+  "exclusions": {
+    "active": true,
+    "keys": [],
+    "dateStart": "2016-01-01",
+    "dateEnd": "2016-05-01"
+  },
+  "palette": "qualitative-bold",
+  "isPaletteReversed": false,
+  "twoColor": {
+    "palette": "monochrome-1",
+    "isPaletteReversed": false
+  },
+  "labels": true,
+  "dataFormat": {
+    "commas": false,
+    "prefix": "",
+    "suffix": "",
+    "abbreviated": false,
+    "bottomSuffix": "",
+    "bottomPrefix": "",
+    "bottomAbbreviated": false
+  },
+  "filters": [],
+  "confidenceKeys": {},
+  "visual": {
+    "border": true,
+    "accent": true,
+    "background": true,
+    "verticalHoverLine": false,
+    "horizontalHoverLine": false,
+    "lineDatapointSymbol": "none",
+    "maximumShapeAmount": 7
+  },
+  "useLogScale": false,
+  "filterBehavior": "Filter Change",
+  "highlightedBarValues": [],
+  "series": [
+    {
+      "dataKey": "Data 1",
+      "type": "Bar",
+      "axis": "Left",
+      "tooltip": true
+    },
+    {
+      "dataKey": "Data 2",
+      "type": "Bar",
+      "axis": "Left",
+      "tooltip": true
+    },
+    {
+      "dataKey": "Data 3",
+      "type": "Bar",
+      "axis": "Left",
+      "tooltip": true
+    },
+    {
+      "dataKey": "Data 4",
+      "type": "Bar",
+      "axis": "Left",
+      "tooltip": true
+    }
+  ],
+  "tooltips": {
+    "opacity": 90,
+    "singleSeries": false,
+    "dateDisplayFormat": ""
+  },
+  "forestPlot": {
+    "startAt": 0,
+    "colors": {
+      "line": "",
+      "shape": ""
+    },
+    "lineOfNoEffect": {
+      "show": true
+    },
+    "type": "",
+    "pooledResult": {
+      "diamondHeight": 5,
+      "column": ""
+    },
+    "estimateField": "",
+    "estimateRadius": "",
+    "shape": "square",
+    "rowHeight": 20,
+    "description": {
+      "show": true,
+      "text": "description",
+      "location": 0
+    },
+    "result": {
+      "show": true,
+      "text": "result",
+      "location": 100
+    },
+    "radius": {
+      "min": 2,
+      "max": 10,
+      "scalingColumn": ""
+    },
+    "regression": {
+      "lower": 0,
+      "upper": 0,
+      "estimateField": 0
+    },
+    "leftWidthOffset": 0,
+    "rightWidthOffset": 0,
+    "showZeroLine": false,
+    "leftLabel": "",
+    "rightLabel": ""
+  },
+  "area": {
+    "isStacked": false
+  },
+  "sankey": {
+    "title": {
+      "defaultColor": "black"
+    },
+    "iterations": 1,
+    "rxValue": 0.9,
+    "overallSize": {
+      "width": 900,
+      "height": 700
+    },
+    "margin": {
+      "margin_y": 25,
+      "margin_x": 0
+    },
+    "nodeSize": {
+      "nodeWidth": 26,
+      "nodeHeight": 40
+    },
+    "nodePadding": 55,
+    "nodeFontColor": "black",
+    "nodeColor": {
+      "default": "#ff8500",
+      "inactive": "#808080"
+    },
+    "linkColor": {
+      "default": "#ffc900",
+      "inactive": "#D3D3D3"
+    },
+    "opacity": {
+      "nodeOpacityDefault": 1,
+      "nodeOpacityInactive": 0.1,
+      "LinkOpacityDefault": 1,
+      "LinkOpacityInactive": 0.1
+    },
+    "storyNodeFontColor": "#006778",
+    "storyNodeText": [],
+    "nodeValueStyle": {
+      "textBefore": "(",
+      "textAfter": ")"
+    },
+    "data": []
+  },
+  "version": "4.25.7",
+  "migrations": {
+    "addColorMigration": true
+  },
+  "dynamicMarginTop": 0,
+  "allowLineToBarGraph": "__​undefined__"
+}

--- a/packages/chart/index.html
+++ b/packages/chart/index.html
@@ -113,18 +113,11 @@
   <!-- <div class="react-container" data-config="/examples/feature/tests-big-small/line-chart-max-increase.json"></div> -->
 
   <!-- TESTS NONNUMERICS -->
-  <!-- <div
-      class="react-container"
-      data-config="/examples/feature/tests-non-numerics/planet-pie-example-config-nonnumeric.json"
-    ></div> -->
-  <div class="react-container" data-config="/examples/feature/tests-non-numerics/example-combo-bar-nonnumeric.json">
-  </div>
+  <!-- <div class="react-container" data-config="/examples/feature/tests-non-numerics/planet-pie-example-config-nonnumeric.json"></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-non-numerics/example-combo-bar-nonnumeric.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/feature/tests-non-numerics/example-bar-chart-nonnumeric.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/sparkline.json"></div> -->
-  <!-- <div
-      class="react-container"
-      data-config="/examples/feature/tests-non-numerics/sparkline-chart-nonnumeric.json"
-    ></div> -->
+  <!-- <div class="react-container" data-config="/examples/feature/tests-non-numerics/sparkline-chart-nonnumeric.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/region-issue.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/feature/tests-non-numerics/stacked-vertical-bar-example-nonnumerics.json"></div> -->
 
@@ -134,6 +127,9 @@
   <!-- TESTS COVID -->
   <!-- <div class="react-container" data-config="/examples/feature/tests-covid/covid-confidence-example-config.json"></div> -->
   <!-- <div class="react-container" data-config="/examples/feature/tests-covid/covid-example-config.json"></div> -->
+
+  <!-- TESTS TOOLTIPS -->
+  <!-- <div class="react-container" data-config="/examples/suppressed_tooltip.json"></div> -->
 
   <!--
       GALLERY EXAMPLES BELOW THIS LINE...

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -135,12 +135,12 @@ export const useTooltip = props => {
         // Track hover analytics event for pie chart series
         if (pieData[config.xAxis.dataKey] && interactionLabel) {
           const seriesName = String(pieData[config.xAxis.dataKey]).replace(/[^a-zA-Z0-9]/g, '_')
-          publishAnalyticsEvent(`chart_hover_${seriesName.toLowerCase()}`, 'hover', interactionLabel, 'chart', { 
+          publishAnalyticsEvent(`chart_hover_${seriesName.toLowerCase()}`, 'hover', interactionLabel, 'chart', {
             title: config?.title,
             series: pieData[config.xAxis.dataKey]
           })
         }
-        
+
         tooltipItems.push(
           [config.xAxis.dataKey, pieData[config.xAxis.dataKey]],
           [
@@ -178,17 +178,23 @@ export const useTooltip = props => {
               const seriesObjWithName = config.runtime.series.find(
                 series => series.dataKey === seriesKey && series.name !== undefined
               )
-              
+
               // Track hover analytics event for linear chart series
               if (interactionLabel && seriesKey && seriesKey !== config.xAxis?.dataKey) {
                 const seriesName = seriesObjWithName?.name || seriesKey
                 const safeSeriesName = String(seriesName).replace(/[^a-zA-Z0-9]/g, '_')
-                publishAnalyticsEvent(`chart_hover_${safeSeriesName.toLowerCase()}`, 'hover', interactionLabel, 'chart', { 
-                  title: config?.title,
-                  series: seriesName
-                })
+                publishAnalyticsEvent(
+                  `chart_hover_${safeSeriesName.toLowerCase()}`,
+                  'hover',
+                  interactionLabel,
+                  'chart',
+                  {
+                    title: config?.title,
+                    series: seriesName
+                  }
+                )
               }
-              
+
               if (
                 (value === null || value === undefined || value === '' || formattedValue === 'N/A') &&
                 config.general.hideNullValue
@@ -592,18 +598,26 @@ export const useTooltip = props => {
 
     // TOOLTIP BODY
     // handle suppressed tooltip items
-    const { label, displayGray } =
-      (config.visualizationSubType !== 'stacked' &&
-        config.general.showSuppressedSymbol &&
-        config.preliminaryData?.find(
-          pd =>
-            pd.label &&
-            pd.type === 'suppression' &&
-            pd.displayTooltip &&
-            value === pd.value &&
-            (!pd.column || key === pd.column)
-        )) ||
-      {}
+    const shouldCheckSuppression = config.visualizationSubType !== 'stacked'
+    let suppressionEntry
+    if (shouldCheckSuppression && config.preliminaryData) {
+      suppressionEntry = config.preliminaryData.find(
+        pd =>
+          pd.label &&
+          pd.type === 'suppression' &&
+          pd.displayTooltip &&
+          value === pd.value &&
+          (!pd.column || key === pd.column)
+      )
+    }
+
+    // Remove suppressed items entirely if not showing symbols
+    if (suppressionEntry && !config.general.showSuppressedSymbol) {
+      return null
+    }
+
+    const { label, displayGray } = suppressionEntry || {}
+
     let newValue = label || value
     const style = displayGray ? { color: '#8b8b8a' } : {}
 


### PR DESCRIPTION
## Summary
Remove suppressed data items from tooltips if not showing suppression symbols

## Testing Steps
Check with suppressed_tooltip.json in PR/Ticket, toggling on and off suppression symbols while checking tooltips

## Optional
### Storybook Links
n/a

### Screenshots
n/a
