### PR TITLE
Speed up test that loads all stories

### DIFF
--- a/packages/core/_stories/StoryRenderingTests.stories.tsx
+++ b/packages/core/_stories/StoryRenderingTests.stories.tsx
@@ -190,6 +190,7 @@ const processStoriesWithWorkerPool = async (
 
       completed++
       logProgress()
+      await new Promise(resolve => setTimeout(resolve, 50))
     }
   }
 
@@ -215,7 +216,7 @@ export const StoryRenderingTests: Story = {
     console.log(`Starting parallel testing of ${storyUrls.length} visualization stories...`) // eslint-disable-line no-console
     const startTime = Date.now()
 
-    const results = await processStoriesWithWorkerPool(storyUrls, 4)
+    const results = await processStoriesWithWorkerPool(storyUrls, 2)
 
     const endTime = Date.now()
     const duration = ((endTime - startTime) / 1000).toFixed(2)

--- a/packages/data-table/src/_stories/DataTable.stories.tsx
+++ b/packages/data-table/src/_stories/DataTable.stories.tsx
@@ -10,12 +10,6 @@ const meta: Meta<typeof CdcDataTable> = {
 
 type Story = StoryObj<typeof CdcDataTable>
 
-export const DataTable: Story = {
-  args: {
-    config: { ...DataTableConfig, filters: [] },
-    isEditor: false
-  }
-}
 export const DataTable_Filters: Story = {
   args: {
     config: DataTableConfig,


### PR DESCRIPTION
## Summary

This speeds up the test that loads all stories by parallelizing it. Also removes one story that rendered a huge data table and occasionally hung.
