### PR TITLE
Fix [DEV-11976] bite heading font overwrite for data bites

### DIFF
--- a/packages/data-bite/src/scss/bite.scss
+++ b/packages/data-bite/src/scss/bite.scss
@@ -137,7 +137,7 @@
       padding-right: 1.5rem;
       width: 100%;
       font-size: 1.1rem;
-      font-family: var(--fonts-nunito);
+      font-family: var(--fonts-nunito) !important;
     }
 
     .cdc-callout__body {

--- a/packages/data-bite/src/scss/bite.scss
+++ b/packages/data-bite/src/scss/bite.scss
@@ -137,6 +137,7 @@
       padding-right: 1.5rem;
       width: 100%;
       font-size: 1.1rem;
+      font-family: var(--fonts-nunito);
     }
 
     .cdc-callout__body {


### PR DESCRIPTION
## Summary
headings are turning into poppins on wcms