### PR TITLE
Fix [DEV-12123 & DEV-11976] waffle and data bite feedback

### DIFF
--- a/packages/dashboard/src/scss/main.scss
+++ b/packages/dashboard/src/scss/main.scss
@@ -340,8 +340,8 @@
         }
       }
 
-      // Hide icon when in multi-column layout, unless using white background
-      .bite__style--tp5:not(.white-background-style) .cdc-callout__icon {
+      // Hide flag when in multi-column layout
+      .bite__style--tp5 .cdc-callout__flag {
         display: none;
       }
     }
@@ -358,8 +358,16 @@
 
         .cdc-callout {
           flex: 1;
-          display: flex;
-          flex-direction: column;
+        }
+
+        // Hide icon when in multi-column layout
+        .cdc-callout__icon {
+          display: none;
+        }
+
+        // Hide flag when in multi-column layout
+        .cdc-callout__flag {
+          display: none;
         }
 
         .cdc-callout__heading {

--- a/packages/data-bite/src/CdcDataBite.tsx
+++ b/packages/data-bite/src/CdcDataBite.tsx
@@ -622,15 +622,15 @@ const CdcDataBite = (props: CdcDataBiteProps) => {
 
                 {config.visual?.showTitle && title && title.trim() && (
                   <h3 className='cdc-callout__heading fw-bold flex-shrink-0 d-flex align-items-start'>
-                    {parse(processContentWithMarkup(title))}
+                    <span>{parse(processContentWithMarkup(title))}</span>
                   </h3>
                 )}
-                <div className='cdc-callout__body d-flex flex-row align-items-center align-content-start flex-grow-1'>
+                <div className='cdc-callout__body d-flex flex-row align-content-start flex-grow-1'>
                   {showBite && (
                     <div className='cdc-callout__databite flex-shrink-0  me-3'>{calculateDataBite(true)}</div>
                   )}
                   <div className='cdc-callout__content flex-grow-1 d-flex flex-column  min-w-0'>
-                    {parse(processContentWithMarkup(biteBody))}
+                    <p className='mb-0'>{parse(processContentWithMarkup(biteBody))}</p>
                     {subtext && !config.general.isCompactStyle && (
                       <p className='bite-subtext fst-italic flex-shrink-0 mt-3'>
                         {parse(processContentWithMarkup(subtext))}

--- a/packages/data-bite/src/scss/bite.scss
+++ b/packages/data-bite/src/scss/bite.scss
@@ -156,6 +156,7 @@
     }
 
     .cdc-callout__databite {
+      padding-top: 2px;
       width: auto;
       line-height: 1; // Tight line height for numbers
       color: var(--colors-cyan-60v, #007a99);
@@ -193,8 +194,7 @@
     // White background with border (when both white background and Display Border are checked)
     &.white-background-style.display-border {
       .cdc-callout {
-        border: none !important;
-        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+        box-shadow: 0 2px 4px rgb(159 159 159 / 10%);
       }
     }
   }

--- a/packages/waffle-chart/src/CdcWaffleChart.tsx
+++ b/packages/waffle-chart/src/CdcWaffleChart.tsx
@@ -265,8 +265,6 @@ const WaffleChart = ({ config, isEditor, link = '', showConfigConfirm, updateCon
     let waffleData = []
     // Use standardized values for TP5 style
     const isTP5 = config.visualizationType === 'TP5 Waffle'
-    const isWhiteBackground = config.visual?.whiteBackground
-    const tp5StrokeColor = isWhiteBackground ? '#009EC1' : null
     let nodeWidthNum = isTP5 ? TP5_NODE_WIDTH : parseInt(nodeWidth, 10)
     let nodeSpacerNum = isTP5 ? TP5_NODE_SPACER : parseInt(nodeSpacer, 10)
 
@@ -296,28 +294,10 @@ const WaffleChart = ({ config, isEditor, link = '', showConfigConfirm, updateCon
           y={isTP5 && !node.isFilled ? node.y + 1 : node.y}
           width={isTP5 && !node.isFilled ? nodeWidthNum - 2 : nodeWidthNum}
           height={isTP5 && !node.isFilled ? nodeWidthNum - 2 : nodeWidthNum}
-          fill={
-            isTP5
-              ? tp5StrokeColor
-                ? node.isFilled
-                  ? '#009EC1'
-                  : '#DFF2F6'
-                : node.isFilled
-                ? node.color
-                : '#dff2f6'
-              : node.color
-          }
+          fill={isTP5 ? (node.isFilled ? '#009EC1' : '#DFF2F6') : node.color}
           fillOpacity={isTP5 ? 1 : node.opacity}
-          stroke={
-            isTP5
-              ? tp5StrokeColor && !node.isFilled
-                ? tp5StrokeColor
-                : node.isFilled
-                ? undefined
-                : node.color
-              : undefined
-          }
-          strokeWidth={isTP5 ? (tp5StrokeColor && !node.isFilled ? 1 : node.isFilled ? 0 : 1) : 0}
+          stroke={isTP5 ? (!node.isFilled ? '#009EC1' : undefined) : undefined}
+          strokeWidth={isTP5 ? (!node.isFilled ? 1 : 0) : 0}
           key={key}
         />
       ) : node.shape === 'person' ? (
@@ -331,30 +311,10 @@ const WaffleChart = ({ config, isEditor, link = '', showConfigConfirm, updateCon
               : `translateX(${node.x + nodeWidthNum / 4}px) translateY(${node.y}px) scale(${nodeWidthNum / 20})`,
             transitionDelay: `${0.1 * key}ms`
           }}
-          fill={
-            isTP5
-              ? tp5StrokeColor
-                ? node.isFilled
-                  ? '#009EC1'
-                  : 'white'
-                : node.isFilled
-                ? node.color
-                : 'transparent'
-              : node.color
-          }
+          fill={isTP5 ? (node.isFilled ? '#009EC1' : 'transparent') : node.color}
           fillOpacity={isTP5 ? 1 : node.opacity}
-          stroke={
-            isTP5
-              ? tp5StrokeColor && !node.isFilled
-                ? tp5StrokeColor
-                : node.isFilled
-                ? undefined
-                : node.color
-              : undefined
-          }
-          strokeWidth={
-            isTP5 ? (tp5StrokeColor && !node.isFilled ? 448 / nodeWidthNum : node.isFilled ? 0 : 448 / nodeWidthNum) : 0
-          }
+          stroke={isTP5 ? (!node.isFilled ? '#009EC1' : undefined) : undefined}
+          strokeWidth={isTP5 ? (!node.isFilled ? 448 / nodeWidthNum : 0) : 0}
           key={key}
           d={
             isTP5
@@ -369,28 +329,10 @@ const WaffleChart = ({ config, isEditor, link = '', showConfigConfirm, updateCon
           cx={node.x}
           cy={node.y}
           r={isTP5 && !node.isFilled ? nodeWidthNum / 2 - 1 : nodeWidthNum / 2}
-          fill={
-            isTP5
-              ? tp5StrokeColor
-                ? node.isFilled
-                  ? '#009EC1'
-                  : '#DFF2F6'
-                : node.isFilled
-                ? node.color
-                : '#dff2f6'
-              : node.color
-          }
+          fill={isTP5 ? (node.isFilled ? '#009EC1' : '#DFF2F6') : node.color}
           fillOpacity={isTP5 ? 1 : node.opacity}
-          stroke={
-            isTP5
-              ? tp5StrokeColor && !node.isFilled
-                ? tp5StrokeColor
-                : node.isFilled
-                ? undefined
-                : node.color
-              : undefined
-          }
-          strokeWidth={isTP5 ? (tp5StrokeColor && !node.isFilled ? 1 : node.isFilled ? 0 : 1) : 0}
+          stroke={isTP5 ? (!node.isFilled ? '#009EC1' : undefined) : undefined}
+          strokeWidth={isTP5 ? (!node.isFilled ? 1 : 0) : 0}
           key={key}
         />
       )
@@ -466,8 +408,8 @@ const WaffleChart = ({ config, isEditor, link = '', showConfigConfirm, updateCon
                 {config.showDenominator && waffleDenominator ? waffleDenominator : ' '}
               </div>
               <div className='cove-waffle-chart__data--text'>{parse(content)}</div>
-              <svg height={config.gauge.height} width={'100%'}>
-                <Group>
+              <svg height={config.gauge.height + 4} width={'100%'} style={{ overflow: 'visible' }}>
+                <Group top={2} left={2}>
                   <foreignObject
                     style={{ border: '1px solid black' }}
                     x={0}

--- a/packages/waffle-chart/src/scss/waffle-chart.scss
+++ b/packages/waffle-chart/src/scss/waffle-chart.scss
@@ -167,7 +167,6 @@
     }
 
     .cove-waffle-chart {
-      align-items: center;
       padding: 0;
       row-gap: 1rem;
     }


### PR DESCRIPTION
## Tickets
[DEV-12123](https://cdc-wcms.atlassian.net/browse/DEV-12123)
[DEV-11976 *comments](https://cdc-wcms.atlassian.net/browse/DEV-11976)

## Summary

-  Data bite white background style border missing ex: [4-26-01-data-bite.json](https://github.com/user-attachments/files/24824728/4-26-01-data-bite.json)
-  markup not showing ex: 4-26-01-data-bite.json
- gauge bottom border being cutoff ex: [linear-guage-med-font.json](https://github.com/user-attachments/files/24824742/linear-guage-med-font.json)
- tp5 icon shouldn't show in dashboard row ex: [dashboard-data-bite.json](https://github.com/user-attachments/files/24824969/dashboard-data-bite.json)
- waffle and data bite content should be top aligned vertically

## Testing Steps
Test changes by using the paired config or creating a new chart
