### PR TITLE
Fix: Improve spacing below title and around data table

### DIFF
--- a/packages/chart/src/scss/main.scss
+++ b/packages/chart/src/scss/main.scss
@@ -59,11 +59,6 @@
     }
   }
 
-  .cove-visualization__title,
-  .cove-visualization__header {
-    margin-bottom: 0 !important;
-  }
-
   .legend-top {
     .legend-wrapper .tooltip-boundary {
       display: flex;
@@ -188,7 +183,7 @@
       white-space: nowrap;
     }
 
-    .legend-item>.legend-item {
+    .legend-item > .legend-item {
       display: inline-block;
       flex: 0 0 auto;
     }
@@ -222,11 +217,11 @@
         left: 0%;
         top: 108%;
 
-        &>* {
+        & > * {
           margin: 0;
         }
 
-        &>p,
+        & > p,
         a {
           margin-left: 5px;
         }
@@ -235,7 +230,6 @@
   }
 
   .dynamic-legend-list {
-
     // overide traditional legend item that uses !important
     .legend-item {
       align-items: flex-end !important;
@@ -268,7 +262,7 @@
     font-size: 1em;
     vertical-align: middle;
 
-    &>span {
+    & > span {
       display: flex;
       justify-items: center;
       align-items: center;
@@ -278,25 +272,25 @@
       max-height: 1px;
     }
 
-    &>span[class*='Asterisk'] {
+    & > span[class*='Asterisk'] {
       transform: scale(1.8);
       margin-top: 15px;
     }
 
-    &>span[class*='Dagger'] {
+    & > span[class*='Dagger'] {
       margin-top: 2px;
     }
 
-    &>span[class*='Sign'] {
+    & > span[class*='Sign'] {
       margin-top: 1px;
     }
 
-    &>svg {
+    & > svg {
       width: 50px;
       height: 23px;
     }
 
-    &>p {
+    & > p {
       margin: 0;
     }
   }
@@ -325,8 +319,8 @@
       min-width: 0;
       max-width: 100%;
 
-      >div,
-      >aside {
+      > div,
+      > aside {
         min-width: 0;
         max-width: 100%;
       }
@@ -339,7 +333,7 @@
 
     &.legend-top:not(.legend-hidden) {
       .legend-wrapper {
-        &>div {
+        & > div {
           order: 2;
           width: 100%;
         }
@@ -354,7 +348,7 @@
 
     &.legend-left:not(.legend-hidden) {
       .legend-wrapper {
-        &>div {
+        & > div {
           order: 2;
           width: 75%;
         }
@@ -369,7 +363,7 @@
 
     &.legend-right:not(.legend-hidden) {
       .legend-wrapper {
-        &>div {
+        & > div {
           order: 1;
           width: 75%;
         }
@@ -391,7 +385,7 @@
       flex-wrap: nowrap;
       flex-direction: column-reverse;
 
-      &>div.tooltip-boundary {
+      & > div.tooltip-boundary {
         margin-top: 1.5em;
       }
     }
@@ -401,7 +395,7 @@
       flex-direction: column;
     }
 
-    &.legend-hidden>svg {
+    &.legend-hidden > svg {
       width: 100% !important;
     }
 
@@ -434,7 +428,7 @@
       pointer-events: none;
     }
 
-    >svg {
+    > svg {
       overflow: visible;
       font-size: 14px;
       margin: 1rem 0 2rem;
@@ -449,7 +443,7 @@
     }
 
     &.chart-line--hover {
-      >svg circle {
+      > svg circle {
         opacity: 0;
 
         &:hover {
@@ -459,12 +453,12 @@
     }
 
     &.chart-line--always {
-      >svg circle {
+      > svg circle {
         opacity: 1;
       }
 
       // Animations for line chart and data points
-      >svg.animated {
+      > svg.animated {
         circle {
           opacity: 0;
           animation: revealLolly 0.25s linear forwards;
@@ -525,7 +519,7 @@
 
   @include breakpointClass(md) {
     .visualization-container {
-      >svg {
+      > svg {
         font-size: 16px;
         width: 75%;
         order: 1;
@@ -609,7 +603,6 @@
     }
 
     &.animated {
-
       .vertical path,
       .vertical rect,
       .vertical foreignObject div {
@@ -627,7 +620,6 @@
       }
 
       &.animate {
-
         path,
         rect,
         foreignObject div {
@@ -686,7 +678,7 @@
   text-align: center;
   transform: scale(1);
 
-  >.visx-group[style] {
+  > .visx-group[style] {
     transform: scale(1);
   }
 }
@@ -708,7 +700,7 @@
 }
 
 .cove-visualization.type-chart.type-sparkline {
-  &.lg .visualization-container>svg {
+  &.lg .visualization-container > svg {
     width: 100%;
   }
 
@@ -739,7 +731,6 @@
         transform: translate(-20px, 0);
       }
     }
-
   }
 
   .subtext,

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -262,10 +262,6 @@ const DataTable = (props: DataTableProps) => {
   const getClassNames = (): string => {
     const classes = ['data-table-container']
 
-    const hasDownloadLinkAbove =
-      (config.table.download || showDownloadImgButton || showDownloadPdfButton) && !config.table.showDownloadLinkBelow
-    const isStandaloneTable = config.type === 'table'
-
     classes.push(viewport)
 
     return classes.join(' ')

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -266,10 +266,6 @@ const DataTable = (props: DataTableProps) => {
       (config.table.download || showDownloadImgButton || showDownloadPdfButton) && !config.table.showDownloadLinkBelow
     const isStandaloneTable = config.type === 'table'
 
-    if (!hasDownloadLinkAbove && !isStandaloneTable && !hasSubtextAbove) {
-      classes.push('mt-4')
-    }
-
     classes.push(viewport)
 
     return classes.join(' ')
@@ -362,7 +358,7 @@ const DataTable = (props: DataTableProps) => {
       const classes = ['download-links']
       if (!belowTable) {
         if (hasDownloadLink) {
-          classes.push('mt-4', 'mb-2')
+          classes.push('mb-2')
         }
       } else {
         if (hasDownloadLink) {

--- a/packages/core/components/Layout/components/Visualization/visualizations.scss
+++ b/packages/core/components/Layout/components/Visualization/visualizations.scss
@@ -201,11 +201,9 @@
       z-index: 9999;
     }
   }
-
 }
 
 .cove-visualization {
-
   .cove-visualization__body,
   .cove-visualization__body-wrap,
   .cove-visualization__message-section,
@@ -240,7 +238,6 @@
     font-size: var(--visualization-meta-font-size, 0.889rem);
   }
 
-  .cove-visualization__title~.cove-visualization__body .cove-visualization__body-wrap,
   .cove-visualization__body.component--has-legacy-border .cove-visualization__body-wrap,
   .cove-visualization__body.component--has-border-color-theme .cove-visualization__body-wrap,
   .cove-visualization__body.component--has-background .cove-visualization__body-wrap {
@@ -265,11 +262,11 @@
     row-gap: var(--cove-visualization-section-gap, 1.5rem);
 
     // Prevent content margins from stacking with row-gap
-    >*> :first-child {
+    > * > :first-child {
       margin-top: 0;
     }
 
-    >*> :last-child {
+    > * > :last-child {
       margin-bottom: 0;
     }
   }

--- a/packages/map/src/scss/main.scss
+++ b/packages/map/src/scss/main.scss
@@ -17,7 +17,7 @@
   position: relative;
   display: flex; // Needed for the main content
 
-  .loading>div.la-ball-beat {
+  .loading > div.la-ball-beat {
     margin-top: 20%;
   }
 
@@ -37,11 +37,6 @@
   text-align: left;
   max-width: 100%;
   background-color: white;
-
-  .cove-visualization__title,
-  .cove-visualization__header {
-    margin-bottom: 0 !important;
-  }
 
   &.theme-blue {
     --map-theme-color: #005eaa;
@@ -178,7 +173,7 @@
       flex-direction: column;
       row-gap: var(--cove-visualization-section-gap, 1.5rem);
 
-      >.legends {
+      > .legends {
         margin-top: var(--cove-visualization-section-gap, 1.5rem) !important;
       }
     }
@@ -271,7 +266,7 @@
     }
   }
 
-  .visualization-container.legend-wrapped-bottom>.legends,
+  .visualization-container.legend-wrapped-bottom > .legends,
   .legends.legend-wrapped-bottom {
     margin-top: var(--cove-visualization-section-gap, 1.5rem) !important;
   }
@@ -311,7 +306,7 @@
     label {
       flex-grow: 1;
 
-      >div.select-heading {
+      > div.select-heading {
         font-size: 1.1em;
         font-weight: 600;
         margin-bottom: 0.75em;


### PR DESCRIPTION
## Summary

This improves spacing between the title and body on charts and maps. It moves the spacing from the body's `padding-top` to the title's `margin-bottom`. This is needed because different title styles should have different spacing below them. It also fixes an issue in markup includes where we were getting double spacing (mb from title and pt from body).

This also removes some conditional spacing in data tables that's unneeded because of the new `row-gap` layout.

## Testing Steps

Inspect some charts, maps and dashboards locally.