### PR TITLE
fix: enhance customSort to handle null values and improve region sorting

### DIFF
--- a/packages/core/components/DataTable/helpers/customSort.ts
+++ b/packages/core/components/DataTable/helpers/customSort.ts
@@ -10,11 +10,16 @@ export const customSort = (a, b, sortBy, config) => {
     valueB = standardizeStateName(b)
     // sort for Regions table for Map
     if (String(valueA).toLowerCase().includes('region') && String(valueB).toLowerCase().includes('region')) {
-      const numberA = parseInt(a.match(/\d+$/)[0], 10)
-      const numberB = parseInt(b.match(/\d+$/)[0], 10)
+      const regionMatchA = typeof valueA === 'string' ? valueA.match(/\d+$/) : null
+      const regionMatchB = typeof valueB === 'string' ? valueB.match(/\d+$/) : null
 
-      // Compare the numeric parts
-      return sortBy.asc ? Number(numberA) - Number(numberB) : Number(numberB) - Number(numberA)
+      if (regionMatchA && regionMatchB) {
+        const numberA = parseInt(regionMatchA[0], 10)
+        const numberB = parseInt(regionMatchB[0], 10)
+
+        // Compare the numeric parts
+        return sortBy.asc ? Number(numberA) - Number(numberB) : Number(numberB) - Number(numberA)
+      }
     }
   }
 

--- a/packages/core/components/DataTable/helpers/tests/customSort.test.ts
+++ b/packages/core/components/DataTable/helpers/tests/customSort.test.ts
@@ -49,4 +49,18 @@ describe('customSort()', () => {
     expect(customSort(b, a, sortBy, config)).lessThan(0)
     expect(customSort(b, a, sortBy, { type: 'notMap' })).lessThan(0)
   })
+
+  it('does not throw when map region values are null', () => {
+    const sortBy = { column: 'someColumn', asc: true, colIndex: 0 }
+
+    expect(() => customSort('region 2', null, sortBy, { type: 'map' })).not.toThrow()
+    expect(customSort('region 2', null, sortBy, { type: 'map' })).toBeLessThan(0)
+  })
+
+  it('falls back safely when map region labels do not end in digits', () => {
+    const sortBy = { column: 'someColumn', asc: true, colIndex: 0 }
+
+    expect(() => customSort('region east', 'region west', sortBy, { type: 'map' })).not.toThrow()
+    expect(customSort('region east', 'region west', sortBy, { type: 'map' })).toBeLessThan(0)
+  })
 })

--- a/packages/core/components/DataTable/helpers/tests/customSort.test.ts
+++ b/packages/core/components/DataTable/helpers/tests/customSort.test.ts
@@ -55,6 +55,8 @@ describe('customSort()', () => {
 
     expect(() => customSort('region 2', null, sortBy, { type: 'map' })).not.toThrow()
     expect(customSort('region 2', null, sortBy, { type: 'map' })).toBeLessThan(0)
+    expect(() => customSort(null, 'region 2', sortBy, { type: 'map' })).not.toThrow()
+    expect(customSort(null, 'region 2', sortBy, { type: 'map' })).toBeGreaterThan(0)
   })
 
   it('falls back safely when map region labels do not end in digits', () => {


### PR DESCRIPTION
This pull request improves the robustness of the `customSort` helper for the DataTable component, particularly when sorting region labels for map tables. It ensures that the function handles edge cases where region values may be `null` or do not end with digits, and adds tests to verify this behavior.

### Robustness improvements to region sorting:

* Updated `customSort` in `customSort.ts` to safely handle region values that are `null` or do not end with digits, preventing runtime errors by checking for valid matches before parsing.

### Test coverage enhancements:

* Added tests in `customSort.test.ts` to confirm that `customSort` does not throw errors when region values are `null` or when region labels do not end in digits, and that it falls back to a safe comparison.