### PR TITLE
enhancement: add link to dataset to standalone visualizations

### DIFF
--- a/packages/chart/src/data/initial-state.js
+++ b/packages/chart/src/data/initial-state.js
@@ -156,6 +156,7 @@ const createInitialState = () => {
       height: '',
       caption: '',
       showDownloadUrl: false,
+      downloadUrlLabel: '',
       showDataTableLink: true,
       showDownloadLinkBelow: true,
       indexLabel: '',

--- a/packages/core/components/EditorPanel/DataTableEditor.test.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import DataTableEditor from './DataTableEditor'
+
+vi.mock('@cdc/core/components/ui/Tooltip', () => ({
+  default: ({ children }) => <div>{children}</div>
+}))
+
+vi.mock('../ui/Icon', () => ({
+  default: () => <span data-testid='icon' />
+}))
+
+vi.mock('../MultiSelect', () => ({
+  default: () => <div data-testid='multi-select' />
+}))
+
+vi.mock('./CustomSortOrder', () => ({
+  default: () => <div data-testid='custom-sort-order' />
+}))
+
+vi.mock('./Inputs', () => ({
+  CheckBox: ({ label, fieldName, value }) => (
+    <label>
+      <input type='checkbox' aria-label={label} name={fieldName} checked={Boolean(value)} readOnly />
+      {label}
+    </label>
+  ),
+  TextField: ({ label, value = '', fieldName, type = 'text' }) => (
+    <label>
+      {label}
+      {type === 'textarea' ? (
+        <textarea aria-label={label} name={fieldName} value={value} readOnly />
+      ) : (
+        <input aria-label={label} name={fieldName} type={type} value={value} readOnly />
+      )}
+    </label>
+  ),
+  Select: ({ label, value = '', fieldName, options = [] }) => (
+    <label>
+      {label}
+      <select aria-label={label} name={fieldName} value={value} onChange={() => undefined}>
+        {options.map(option => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}))
+
+describe('DataTableEditor', () => {
+  const baseConfig = {
+    type: 'chart',
+    visualizationType: 'Bar Chart',
+    data: [{ category: 'A', value: 1 }],
+    columns: {
+      category: { name: 'category', dataTable: true },
+      value: { name: 'value', dataTable: true }
+    },
+    table: {
+      label: 'Data Table',
+      show: true,
+      showVertical: true,
+      indexLabel: '',
+      caption: '',
+      limitHeight: false,
+      collapsible: true,
+      expanded: false,
+      download: false,
+      showDownloadUrl: false,
+      downloadUrlLabel: '',
+      showDownloadImgButton: false,
+      defaultSort: {}
+    }
+  }
+
+  const renderEditor = config =>
+    render(<DataTableEditor config={config} columns={['category', 'value']} updateField={vi.fn()} isDashboard={false} />)
+
+  it('shows the dataset link checkbox for url-backed standalone charts', () => {
+    renderEditor({
+      ...baseConfig,
+      dataFileSourceType: 'url',
+      dataFileName: '/wcms/vizdata/chart-data.json'
+    })
+
+    expect(screen.getByLabelText('Show URL to Automatically Updated Data')).toBeInTheDocument()
+  })
+
+  it('shows the dataset link checkbox for standalone tables with dataUrl', () => {
+    renderEditor({
+      ...baseConfig,
+      type: 'table',
+      dataUrl: '/wcms/vizdata/table-data.json'
+    })
+
+    expect(screen.getByLabelText('Show URL to Automatically Updated Data')).toBeInTheDocument()
+  })
+
+  it('hides the dataset link checkbox for file-backed standalone charts', () => {
+    renderEditor({
+      ...baseConfig,
+      dataFileSourceType: 'file',
+      dataFileName: 'chart-data.csv'
+    })
+
+    expect(screen.queryByLabelText('Show URL to Automatically Updated Data')).not.toBeInTheDocument()
+  })
+
+  it('shows the dataset link text field when the dataset link is enabled', () => {
+    renderEditor({
+      ...baseConfig,
+      table: {
+        ...baseConfig.table,
+        showDownloadUrl: true
+      },
+      dataFileSourceType: 'url',
+      dataFileName: '/wcms/vizdata/chart-data.json'
+    })
+
+    expect(screen.getByLabelText('Dataset Link Text')).toBeInTheDocument()
+  })
+})

--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -19,7 +19,10 @@ interface DataTableProps {
 const PLACEHOLDER = '-Select-'
 
 const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDashboard, columns: dataColumns }) => {
-  const isLoadedFromUrl = config.dataKey?.includes('http://') || config?.dataKey?.includes('https://')
+  const hasUrlBackedDataSource =
+    config.type === 'table'
+      ? Boolean(config.runtimeDataUrl || config.dataUrl)
+      : config.dataFileSourceType === 'url' && Boolean(config.runtimeDataUrl || config.dataUrl || config.dataFileName)
   const excludedColumns = useMemo(() => {
     return Object.keys(config.columns)
       .map<[string, boolean]>(key => [config.columns[key].name, config.columns[key].dataTable])
@@ -374,14 +377,28 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
           updateField={updateField}
         />
       )}
-      {isLoadedFromUrl && (
-        <CheckBox
-          value={config.table.showDownloadUrl}
-          fieldName='showDownloadUrl'
-          label='Show URL to Automatically Updated Data'
-          section='table'
-          updateField={updateField}
-        />
+      {hasUrlBackedDataSource && (
+        <>
+          <CheckBox
+            value={config.table.showDownloadUrl}
+            fieldName='showDownloadUrl'
+            label='Show URL to Automatically Updated Data'
+            section='table'
+            updateField={updateField}
+          />
+          {config.table.showDownloadUrl && (
+            <div className='ms-4 mt-2' style={{ maxWidth: 'calc(100% - 1.5rem)' }}>
+              <TextField
+                value={config.table.downloadUrlLabel}
+                section='table'
+                fieldName='downloadUrlLabel'
+                label='Dataset Link Text'
+                placeholder='Link to Dataset'
+                updateField={updateField}
+              />
+            </div>
+          )}
+        </>
       )}
       {config.type !== 'table' && (
         <CheckBox

--- a/packages/core/components/MediaControls.test.tsx
+++ b/packages/core/components/MediaControls.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import MediaControls from './MediaControls'
+
+describe('MediaControls.Link', () => {
+  it('renders a dataset link for standalone url-backed charts', () => {
+    render(
+      <MediaControls.Link
+        config={{
+          type: 'chart',
+          table: { showDownloadUrl: true },
+          dataFileSourceType: 'url',
+          dataUrl: '/wcms/vizdata/example.json'
+        }}
+        interactionLabel='test'
+      />
+    )
+
+    expect(screen.getByRole('link', { name: 'Link to Dataset' })).toHaveAttribute('href', '/wcms/vizdata/example.json')
+  })
+
+  it('renders a dataset link for standalone tables that load from dataUrl', () => {
+    render(
+      <MediaControls.Link
+        config={{
+          type: 'table',
+          table: { showDownloadUrl: true },
+          dataUrl: '/wcms/vizdata/table-data.json'
+        }}
+        interactionLabel='test'
+      />
+    )
+
+    expect(screen.getByRole('link', { name: 'Link to Dataset' })).toHaveAttribute(
+      'href',
+      '/wcms/vizdata/table-data.json'
+    )
+  })
+
+  it('uses a custom dataset link label when configured', () => {
+    render(
+      <MediaControls.Link
+        config={{
+          type: 'chart',
+          table: { showDownloadUrl: true, downloadUrlLabel: 'Open Source Data' },
+          dataFileSourceType: 'url',
+          dataUrl: '/wcms/vizdata/example.json'
+        }}
+        interactionLabel='test'
+      />
+    )
+
+    expect(screen.getByRole('link', { name: 'Open Source Data' })).toHaveAttribute('href', '/wcms/vizdata/example.json')
+  })
+
+  it('does not render a dataset link for standalone file-backed charts', () => {
+    const { container } = render(
+      <MediaControls.Link
+        config={{
+          type: 'chart',
+          table: { showDownloadUrl: true },
+          dataFileSourceType: 'file',
+          dataFileName: 'local.csv'
+        }}
+        interactionLabel='test'
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('preserves dashboard dataset link behavior', () => {
+    render(
+      <MediaControls.Link
+        config={{
+          type: 'dashboard',
+          table: { showDownloadUrl: true }
+        }}
+        dashboardDataConfig={{
+          dataUrl: 'https://data.cdc.gov/resource/example.json'
+        }}
+        interactionLabel='test'
+      />
+    )
+
+    expect(screen.getByRole('link', { name: 'Link to Dataset' })).toHaveAttribute(
+      'href',
+      'https://data.cdc.gov/resource/example.json'
+    )
+  })
+})

--- a/packages/core/components/MediaControls.tsx
+++ b/packages/core/components/MediaControls.tsx
@@ -10,6 +10,20 @@ const buttonText = {
   link: 'Link to Dataset'
 }
 
+const getStandaloneDatasetUrl = config => {
+  if (!config?.table?.showDownloadUrl) return null
+
+  if (config.type === 'table') {
+    return config.runtimeDataUrl || config.dataUrl || null
+  }
+
+  if (config.dataFileSourceType === 'url') {
+    return config.runtimeDataUrl || config.dataUrl || config.dataFileName || null
+  }
+
+  return null
+}
+
 const saveImageAs = (uri, filename) => {
   const ie = navigator.userAgent.match(/MSIE\s([\d.]+)/)
   const ie11 = navigator.userAgent.match(/Trident\/7.0/) && navigator.userAgent.match(/rv:11/)
@@ -212,12 +226,14 @@ const DownloadLink = ({
 // Link to CSV/JSON data
 const Link = ({ config, dashboardDataConfig, interactionLabel }) => {
   let dataConfig = dashboardDataConfig || config
+  const standaloneDatasetUrl = getStandaloneDatasetUrl(config)
+  const linkText = config?.table?.downloadUrlLabel || buttonText.link
   // Handles Maps & Charts
-  if (dataConfig.dataFileSourceType === 'url' && dataConfig.dataFileName && config.table.showDownloadUrl) {
+  if (standaloneDatasetUrl && !dashboardDataConfig) {
     return (
       <a
-        href={dataConfig.dataFileName}
-        title={buttonText.link}
+        href={standaloneDatasetUrl}
+        title={linkText}
         target='_blank'
         onClick={() => {
           publishAnalyticsEvent({
@@ -230,7 +246,7 @@ const Link = ({ config, dashboardDataConfig, interactionLabel }) => {
           })
         }}
       >
-        {buttonText.link}
+        {linkText}
       </a>
     )
   }
@@ -252,7 +268,7 @@ const Link = ({ config, dashboardDataConfig, interactionLabel }) => {
         })
       }}
     >
-      {buttonText.link}
+      {linkText}
     </a>
   ) : null
 }

--- a/packages/core/types/Table.ts
+++ b/packages/core/types/Table.ts
@@ -18,6 +18,7 @@ export type Table = {
   download?: boolean
   downloadDataLabel?: string
   downloadImageLabel?: string
+  downloadUrlLabel?: string
   downloadVisibleDataOnly?: boolean
   downloadImageButton?: boolean
   downloadPdfButton?: boolean

--- a/packages/dashboard/src/data/initial-state.js
+++ b/packages/dashboard/src/data/initial-state.js
@@ -10,6 +10,7 @@ export default {
     label: 'Data Table',
     show: true,
     showDownloadUrl: false,
+    downloadUrlLabel: '',
     showDownloadLinkBelow: true,
     showVertical: true
   }

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -24,6 +24,7 @@ const createBlankDashboard: () => BlankMultiConfig = () => ({
     label: 'Data Table',
     show: false,
     showDownloadUrl: false,
+    downloadUrlLabel: '',
     showVertical: true
   }
 })

--- a/packages/data-table/src/data/initial-state.js
+++ b/packages/data-table/src/data/initial-state.js
@@ -7,6 +7,7 @@ export default {
     height: '',
     caption: '',
     showDownloadUrl: false,
+    downloadUrlLabel: '',
     showDataTableLink: true,
     showDownloadLinkBelow: true,
     indexLabel: '',

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -3199,14 +3199,29 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                         />
                       )}
                       {isLoadedFromUrl && (
-                        <CheckBox
-                          value={config.table.showDownloadUrl}
-                          section='table'
-                          subsection={null}
-                          fieldName='showDownloadUrl'
-                          label='Show URL to Automatically Updated Data'
-                          updateField={updateField}
-                        />
+                        <>
+                          <CheckBox
+                            value={config.table.showDownloadUrl}
+                            section='table'
+                            subsection={null}
+                            fieldName='showDownloadUrl'
+                            label='Show URL to Automatically Updated Data'
+                            updateField={updateField}
+                          />
+                          {config.table.showDownloadUrl && (
+                            <div className='ms-4 mt-2' style={{ maxWidth: 'calc(100% - 1.5rem)' }}>
+                              <TextField
+                                value={config.table.downloadUrlLabel}
+                                section='table'
+                                subsection={null}
+                                fieldName='downloadUrlLabel'
+                                label='Dataset Link Text'
+                                placeholder='Link to Dataset'
+                                updateField={updateField}
+                              />
+                            </div>
+                          )}
+                        </>
                       )}
                       <CheckBox
                         value={config.table.showFullGeoNameInCSV}

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -98,6 +98,7 @@ const createInitialState = () => {
       height: '',
       caption: '',
       showDownloadUrl: false,
+      downloadUrlLabel: '',
       showDataTableLink: true,
       showDownloadLinkBelow: true,
       showFullGeoNameInCSV: false,

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -217,6 +217,7 @@ export type MapConfig = Visualization & {
     download: boolean
     downloadDataLabel?: string
     downloadImageLabel?: string
+    downloadUrlLabel?: string
     showDownloadUrl: boolean
     showFullGeoNameInCSV: boolean
     forceDisplay: boolean


### PR DESCRIPTION
This pull request introduces a new feature allowing users to customize the label for dataset download links in charts, tables, dashboards, and maps. It adds a `downloadUrlLabel` property to relevant configuration objects, updates UI components to support editing and displaying this label, and includes comprehensive tests to ensure correct behavior across different scenarios.

**Feature: Custom dataset link label**

* Added a new `downloadUrlLabel` property to the `table` configuration in charts, tables, dashboards, and maps, including updates to initial state files and TypeScript types. [[1]](diffhunk://#diff-d9201f7c314bf27f6a7d8586a9ccd07e720d3d3719e55121c730bdba9cf71193R159) [[2]](diffhunk://#diff-7ecca07082fbf57c732d25e1318812d701e83925c4682cb5fd573fc367a7035dR13) [[3]](diffhunk://#diff-185fa212e8798c22892d3737b7e3b653706d9c0efe9414ca764fe9bf7c77b418R27) [[4]](diffhunk://#diff-f938b710934ed05200a6bc3f224a429cf8408cc17ca73c26bdc44610b6b9956cR10) [[5]](diffhunk://#diff-dbc8fa4f2c4300b46a1d36d9bea5b71d6db796dddc0f0e57719a98d8614c48ceR101) [[6]](diffhunk://#diff-2eb02b5451e3ae0e56e535a01dc3bced4082e87b211764dfd76834f6a5c57cc0R21) [[7]](diffhunk://#diff-aa11ca6da563b5c3567eb2fdbaad42f57a5fbe59a0e74e9650786dad172da221R220)

**UI/UX Improvements**

* Updated the data table and map editor panels to display a text field for editing the dataset link label when the "Show URL to Automatically Updated Data" option is enabled. [[1]](diffhunk://#diff-55da7b4db844f0f8409b704e5d885c0e9f4d31c9dad4e5c357d023ab67ab89c5L377-R401) [[2]](diffhunk://#diff-36bc1c81c42e002cca80a6c6d32eec97bf23af6b1f2a3ece9fc4fcf04490d222R3202) [[3]](diffhunk://#diff-36bc1c81c42e002cca80a6c6d32eec97bf23af6b1f2a3ece9fc4fcf04490d222R3211-R3224)
* Improved the logic for detecting URL-backed data sources and showing the dataset link option in the data table editor.

**Download Link Rendering**

* Refactored `MediaControls.Link` to use the custom label (`downloadUrlLabel`) for dataset links, defaulting to "Link to Dataset" if not specified, and centralized the logic for resolving the correct dataset URL. [[1]](diffhunk://#diff-63080c4caf695d5321af1ae63641b6432e7f6567cdb36750b97314aa1e8e64e4R13-R26) [[2]](diffhunk://#diff-63080c4caf695d5321af1ae63641b6432e7f6567cdb36750b97314aa1e8e64e4R229-R236) [[3]](diffhunk://#diff-63080c4caf695d5321af1ae63641b6432e7f6567cdb36750b97314aa1e8e64e4L233-R249) [[4]](diffhunk://#diff-63080c4caf695d5321af1ae63641b6432e7f6567cdb36750b97314aa1e8e64e4L255-R271)

**Testing**

* Added thorough tests for both the data table editor and `MediaControls.Link` to verify correct display and labeling of dataset links across various configurations and edge cases. [[1]](diffhunk://#diff-088384550ead116524ae371f02df20066eb948f88252bc09e767ccfe4a9f8406R1-R125) [[2]](diffhunk://#diff-a51a1652b12601d4d7da565bedfdae213c6491df9cb1a6e48fd41eb0918203c5R1-R92)