### PR TITLE
Enhancement [DEV-12685] Add colors to chart tooltips

### DIFF
--- a/packages/chart/src/_stories/Chart.SmallMultiples.smoke.stories.tsx
+++ b/packages/chart/src/_stories/Chart.SmallMultiples.smoke.stories.tsx
@@ -5,7 +5,8 @@ import smallMultiplesBigDataBars from './_mock/small_multiples/small_multiples_b
 import smallMultiplesLinesColors from './_mock/small_multiples/small_multiples_lines_colors.json'
 import smallMultiplesLines from './_mock/small_multiples/small_multiples_lines.json'
 import smallMultiplesStackedBars from './_mock/small_multiples/small_multiples_stacked_bars.json'
-import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import { assertVisualizationRendered, waitForPresence } from '@cdc/core/helpers/testing'
+import { expect } from 'storybook/test'
 
 const meta: Meta<typeof Chart> = {
   title: 'Components/Templates/Chart/Small Multiples',
@@ -14,6 +15,11 @@ const meta: Meta<typeof Chart> = {
 
 type Story = StoryObj<typeof Chart>
 
+const getTooltipHtmlValues = (canvasElement: HTMLElement) =>
+  Array.from(canvasElement.querySelectorAll('[data-tooltip-html]')).map(
+    element => element.getAttribute('data-tooltip-html') || ''
+  )
+
 export const smallMultiples_Bars: Story = {
   args: {
     config: smallMultiplesBars,
@@ -21,6 +27,11 @@ export const smallMultiples_Bars: Story = {
   },
   play: async ({ canvasElement }) => {
     await assertVisualizationRendered(canvasElement)
+    await waitForPresence('[data-tooltip-html]', canvasElement)
+
+    const tooltipHtmlValues = getTooltipHtmlValues(canvasElement)
+    expect(tooltipHtmlValues.length).toBeGreaterThan(0)
+    expect(tooltipHtmlValues.some(html => html.includes('tooltip-marker-swatch'))).toBe(false)
   }
 }
 
@@ -58,6 +69,11 @@ export const smallMultiples_StackedBars: Story = {
   },
   play: async ({ canvasElement }) => {
     await assertVisualizationRendered(canvasElement)
+    await waitForPresence('[data-tooltip-html]', canvasElement)
+
+    const tooltipHtmlValues = getTooltipHtmlValues(canvasElement)
+    expect(tooltipHtmlValues.length).toBeGreaterThan(0)
+    expect(tooltipHtmlValues.some(html => html.includes('tooltip-marker-swatch'))).toBe(true)
   }
 }
 export default meta

--- a/packages/chart/src/_stories/Chart.tooltip.smoke.stories.tsx
+++ b/packages/chart/src/_stories/Chart.tooltip.smoke.stories.tsx
@@ -3,6 +3,10 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import Chart from '../CdcChartComponent'
 import barChartStacked from './_mock/barchart_labels.mock.json'
 import barChartSuppressed from './_mock/bar-chart-suppressed.json'
+import simplifiedLine from './_mock/simplified_line.json'
+import scatterPlot from './_mock/scatterplot_mock.json'
+import gradientLegend from './_mock/legend.gradient_mock.json'
+import patternLegend from './_mock/stacked-pattern-test.json'
 import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
 const meta: Meta<typeof Chart> = {
   title: 'Components/Templates/Chart/Tooltip',
@@ -61,6 +65,70 @@ export const Additional_Tooltip: Story = {
           series: 'Hispanic'
         }
       }
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+  }
+}
+
+export const Line_Tooltip_Markers: Story = {
+  args: {
+    config: {
+      ...simplifiedLine,
+      title: 'Line Tooltip Markers'
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+  }
+}
+
+export const Scatter_Tooltip_Markers: Story = {
+  args: {
+    config: {
+      ...scatterPlot,
+      title: 'Scatter Tooltip Markers'
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+  }
+}
+
+export const No_Markers_When_Legend_Hidden: Story = {
+  args: {
+    config: {
+      ...simplifiedLine,
+      title: 'Tooltip Without Markers When Legend Hidden',
+      legend: {
+        ...simplifiedLine.legend,
+        hide: true
+      }
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+  }
+}
+
+export const No_Markers_For_Gradient_Legend: Story = {
+  args: {
+    config: {
+      ...gradientLegend,
+      title: 'Tooltip Without Markers For Gradient Legend'
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+  }
+}
+
+export const Pattern_Legend_Uses_Color_Markers: Story = {
+  args: {
+    config: {
+      ...patternLegend,
+      title: 'Tooltip Color Markers For Pattern Legend'
     }
   },
   play: async ({ canvasElement }) => {

--- a/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Horizontal.tsx
@@ -26,6 +26,7 @@ import { getBarData } from '../helpers/getBarData'
 import { getHorizontalBarHeights } from '../helpers/getBarHeights'
 import { getPatternUrl as getPatternUrlForBar } from '../helpers/getPatternUrl'
 import { getChartPatternId } from '../../../helpers/getChartPatternId'
+import { buildSeriesTooltipListHtml } from '../../../helpers/tooltipHelpers'
 
 const BarChartHorizontal = () => {
   const { xScale, yScale, yMax, seriesScale, barChart } = useContext<BarChartContextValues>(BarChartContext)
@@ -243,11 +244,14 @@ const BarChartHorizontal = () => {
                     : xAxisValue
                   const additionalColTooltip = getAdditionalColumn(bar.key, hoveredBar)
                   const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${yAxisValue}`
-                  const tooltip = `<ul>
-                  <li class="tooltip-heading"">${yAxisTooltip}</li>
-                  <li class="tooltip-body ">${tooltipBody}</li>
-                  <li class="tooltip-body ">${additionalColTooltip}</li>
-                    </li></ul>`
+                  const tooltip = buildSeriesTooltipListHtml({
+                    config,
+                    colorScale,
+                    heading: yAxisTooltip,
+                    seriesKey: bar.key,
+                    seriesText: tooltipBody,
+                    extraRows: additionalColTooltip ? [additionalColTooltip] : []
+                  })
 
                   // configure colors
                   let labelColor = APP_FONT_COLOR

--- a/packages/chart/src/components/BarChart/components/BarChart.StackedHorizontal.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.StackedHorizontal.tsx
@@ -16,6 +16,7 @@ import createBarElement from '@cdc/core/components/createBarElement'
 import { getHorizontalBarHeights } from '../helpers/getBarHeights'
 import { getPatternUrl as getPatternUrlForBar } from '../helpers/getPatternUrl'
 import { getChartPatternId } from '../../../helpers/getChartPatternId'
+import { buildSeriesTooltipListHtml } from '../../../helpers/tooltipHelpers'
 
 const BarChartStackedHorizontal = () => {
   const { yMax, yScale, xScale, barChart } = useContext<BarChartContextValues>(BarChartContext)
@@ -161,11 +162,14 @@ const BarChartStackedHorizontal = () => {
                 const textWidth = getTextWidth(xAxisValue, `normal ${labelFontSize}px sans-serif`)
                 const additionalColTooltip = getAdditionalColumn(bar.key, hoveredBar)
                 const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${xAxisValue}`
-                const tooltip = `<ul>
-                  <li class="tooltip-heading"">${yAxisTooltip}</li>
-                  <li class="tooltip-body ">${tooltipBody}</li>
-                  <li class="tooltip-body ">${additionalColTooltip}</li>
-                    </li></ul>`
+                const tooltip = buildSeriesTooltipListHtml({
+                  config,
+                  colorScale,
+                  heading: yAxisTooltip,
+                  seriesKey: bar.key,
+                  seriesText: tooltipBody,
+                  extraRows: additionalColTooltip ? [additionalColTooltip] : []
+                })
 
                 // Check if this bar should use a pattern
                 const patternUrl = getPatternUrlForBar({

--- a/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.StackedVertical.tsx
@@ -10,6 +10,7 @@ import { addMinimumBarHeights } from '../helpers'
 import createBarElement from '@cdc/core/components/createBarElement'
 import { getPatternUrl as getPatternUrlForBar } from '../helpers/getPatternUrl'
 import { getChartPatternId } from '../../../helpers/getChartPatternId'
+import { buildSeriesTooltipListHtml } from '../../../helpers/tooltipHelpers'
 
 const BarChartStackedVertical = () => {
   const [barWidth, setBarWidth] = useState(0)
@@ -143,11 +144,14 @@ const BarChartStackedVertical = () => {
                     : xAxisValue
                   const additionalColTooltip = getAdditionalColumn(bar.key, hoveredBar)
                   const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${yAxisValue}`
-                  const tooltip = `<ul>
-                  <li class="tooltip-heading"">${xAxisTooltip}</li>
-                  <li class="tooltip-body ">${tooltipBody}</li>
-                  <li class="tooltip-body ">${additionalColTooltip}</li>
-                    </li></ul>`
+                  const tooltip = buildSeriesTooltipListHtml({
+                    config,
+                    colorScale,
+                    heading: xAxisTooltip,
+                    seriesKey: bar.key,
+                    seriesText: tooltipBody,
+                    extraRows: additionalColTooltip ? [additionalColTooltip] : []
+                  })
 
                   setBarWidth(barThickness)
 

--- a/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
+++ b/packages/chart/src/components/BarChart/components/BarChart.Vertical.tsx
@@ -23,6 +23,7 @@ import _ from 'lodash'
 import { getBarData } from '../helpers/getBarData'
 import { getPatternUrl as getPatternUrlForBar } from '../helpers/getPatternUrl'
 import { getChartPatternId } from '../../../helpers/getChartPatternId'
+import { buildSeriesTooltipListHtml } from '../../../helpers/tooltipHelpers'
 
 const BarChartVertical = () => {
   const { xScale, yScale, xMax, yMax, seriesScale, convertLineToBarGraph, barChart } =
@@ -229,12 +230,14 @@ const BarChartVertical = () => {
                     ? `${config.runtime.xAxis.label}: ${xAxisValue}`
                     : xAxisValue
                   const tooltipBody = `${config.runtime.seriesLabels[bar.key]}: ${yAxisValue}`
-
-                  const tooltip = `<ul>
-                  <li class="tooltip-heading">${xAxisTooltip}</li>
-                  <li class="tooltip-body ">${tooltipBody}</li>
-                  ${additionalColTooltip ? '<li class="tooltip-body ">' + additionalColTooltip + '</li>' : ''}
-                    </li></ul>`
+                  const tooltip = buildSeriesTooltipListHtml({
+                    config,
+                    colorScale,
+                    heading: xAxisTooltip,
+                    seriesKey: bar.key,
+                    seriesText: tooltipBody,
+                    extraRows: additionalColTooltip ? [additionalColTooltip] : []
+                  })
                   const { barHeight, isSuppressed, getBarY, absentDataLabel } = getBarConfig({
                     bar,
                     defaultBarHeight,

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -51,6 +51,7 @@ import Annotation from './Annotations'
 import { countNumOfTicks } from '../helpers/countNumOfTicks'
 import HoverLine from './HoverLine/HoverLine'
 import { SmallMultiples } from './SmallMultiples'
+import { type TooltipDisplayData } from '../helpers/tooltipHelpers'
 
 type LinearChartProps = {
   parentWidth: number
@@ -88,10 +89,7 @@ const WARMING_STRIPES_HEIGHT = 78
 // Time constants
 const MONTH_AS_MS = 1000 * 60 * 60 * 24 * 30
 
-type TooltipData = {
-  dataXPosition?: number
-  dataYPosition?: number
-}
+type TooltipData = Partial<TooltipDisplayData>
 
 type UseTooltipReturn<T = TooltipData> = {
   tooltipData: T | null
@@ -839,10 +837,10 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
         </svg>
         {!isDraggingAnnotation &&
           tooltipData &&
-          Object.entries(tooltipData.data).length > 0 &&
+          tooltipData.data?.length > 0 &&
           tooltipOpen &&
           showTooltip &&
-          !tooltipData?.data?.some(subArray => subArray.some(item => item === undefined)) &&
+          !tooltipData?.data?.some(row => row?.value === undefined) &&
           tooltipData.dataYPosition &&
           tooltipData.dataXPosition &&
           !config.tooltips.singleSeries && (
@@ -860,9 +858,16 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
               >
                 <ul>
                   {typeof tooltipData === 'object' &&
-                    Object.entries(tooltipData.data)
-                      .filter(([_, values]) => Array.isArray(values) && !values.includes(undefined))
-                      .map((item, index) => <TooltipListItem item={item} key={index} />)}
+                    tooltipData.data
+                      .filter(row => row && row.value !== undefined)
+                      .map((row, index) => (
+                        <TooltipListItem
+                          row={row}
+                          index={index}
+                          key={index}
+                          useMarkerColumn={tooltipData.useMarkerColumn}
+                        />
+                      ))}
                 </ul>
               </TooltipWithBounds>
             </>

--- a/packages/chart/src/components/PieChart/PieChart.tsx
+++ b/packages/chart/src/components/PieChart/PieChart.tsx
@@ -24,14 +24,9 @@ import { handleChartAriaLabels } from '../../helpers/handleChartAriaLabels'
 import ErrorBoundary from '@cdc/core/components/ErrorBoundary'
 import { scaleOrdinal } from '@visx/scale'
 import { getContrastColor } from '@cdc/core/helpers/cove/accessibility'
+import { type TooltipDisplayData } from '../../helpers/tooltipHelpers'
 
-type TooltipData = {
-  data: {
-    [key: string]: string | number
-  }
-  dataXPosition: number
-  dataYPosition: number
-}
+type TooltipData = TooltipDisplayData
 
 type PieChartProps = {
   parentWidth?: number
@@ -426,7 +421,7 @@ const PieChart = React.forwardRef<SVGSVGElement, PieChartProps>((props, ref) => 
         <div ref={triggerRef} />
         {!isDraggingAnnotation &&
           tooltipData &&
-          Object.entries(tooltipData.data).length > 0 &&
+          tooltipData.data?.length > 0 &&
           tooltipOpen &&
           showTooltip &&
           tooltipData.dataYPosition &&
@@ -442,7 +437,14 @@ const PieChart = React.forwardRef<SVGSVGElement, PieChartProps>((props, ref) => 
               >
                 <ul>
                   {typeof tooltipData === 'object' &&
-                    Object.entries(tooltipData.data).map((item, index) => <TooltipListItem item={item} key={index} />)}
+                    tooltipData.data.map((row, index) => (
+                      <TooltipListItem
+                        row={row}
+                        index={index}
+                        key={index}
+                        useMarkerColumn={tooltipData.useMarkerColumn}
+                      />
+                    ))}
                 </ul>
               </TooltipWithBounds>
             </>

--- a/packages/chart/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/packages/chart/src/components/ScatterPlot/ScatterPlot.jsx
@@ -4,6 +4,7 @@ import { Group } from '@visx/group'
 import { formatNumber as formatColNumber } from '@cdc/core/helpers/cove/number'
 import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
+import { buildSeriesTooltipListHtml } from '../../helpers/tooltipHelpers'
 
 const ScatterPlot = ({ xScale, yScale }) => {
   const {
@@ -12,14 +13,12 @@ const ScatterPlot = ({ xScale, yScale }) => {
     tableData,
     formatNumber,
     seriesHighlight,
-    colorPalettes,
     colorScale,
     interactionLabel
   } = useContext(ConfigContext)
 
   // TODO: copied from line chart should probably be a constant somewhere.
   const circleRadii = 4.5
-  const hasMultipleSeries = Object.keys(config.runtime.seriesLabels).length > 1
 
   // Track current hover for analytics
   const [currentHover, setCurrentHover] = useState({ dataIndex: null, seriesKey: null })
@@ -37,19 +36,22 @@ const ScatterPlot = ({ xScale, yScale }) => {
       }
     ])
   const handleTooltip = (item, s, dataIndex) => `<div>
-    ${
-      config.legend.showLegendValuesTooltip && config.runtime.seriesLabels && hasMultipleSeries
-        ? `${config.runtime.seriesLabels[s] || ''}<br/>`
-        : ''
-    }
-    ${config.runtime?.xAxis?.label || config.xAxis.label}: ${formatNumber(item[config.xAxis.dataKey], 'bottom')} <br/>
-    ${config.runtime?.yAxis?.label || config.yAxis.label}: ${formatNumber(item[s], 'left')}<br/>
-   ${additionalColumns
-     .map(
-       ([label, name, options]) =>
-         `${label} : ${formatColNumber(tableData[dataIndex][name], 'left', false, config, options)}<br/>`
-     )
-     .join('')}
+    ${buildSeriesTooltipListHtml({
+      config,
+      colorScale,
+      heading: `${config.runtime?.xAxis?.label || config.xAxis.label}: ${formatNumber(
+        item[config.xAxis.dataKey],
+        'bottom'
+      )}`,
+      seriesKey: s,
+      seriesText: `${config.runtime.seriesLabels[s] || s}: ${formatNumber(item[s], 'left')}`,
+      extraRows: additionalColumns
+        .map(
+          ([label, name, options]) =>
+            `${label} : ${formatColNumber(tableData[dataIndex][name], 'left', false, config, options)}`
+        )
+        .filter(Boolean)
+    })}
 </div>`
 
   return (

--- a/packages/chart/src/components/SmallMultiples/SmallMultipleTile.tsx
+++ b/packages/chart/src/components/SmallMultiples/SmallMultipleTile.tsx
@@ -114,6 +114,7 @@ const SmallMultipleTile: React.FC<SmallMultipleTileProps> = ({
     hideYAxisLabel: !isFirstInRow,
     legend: {
       ...tileConfig.legend,
+      tooltipLegendVisible: !config.legend?.hide,
       hide: true // Hide legends for all small multiple tiles
     },
     xAxis: {

--- a/packages/chart/src/helpers/tests/tooltipHelpers.test.ts
+++ b/packages/chart/src/helpers/tests/tooltipHelpers.test.ts
@@ -37,14 +37,34 @@ describe('tooltipHelpers', () => {
     expect(shouldUseTooltipLegendMarkers(buildConfig())).toBe(true)
   })
 
-  it('disables markers when the legend is hidden or in a special mode', () => {
+  it('allows small-multiple tiles to use markers when the source legend is visible', () => {
+    expect(shouldUseTooltipLegendMarkers(buildConfig({ legend: { hide: true, tooltipLegendVisible: true } }))).toBe(
+      true
+    )
+  })
+
+  it('disables markers when the source legend is hidden or the legend is in a special mode', () => {
     expect(shouldUseTooltipLegendMarkers(buildConfig({ legend: { hide: true } }))).toBe(false)
+    expect(shouldUseTooltipLegendMarkers(buildConfig({ legend: { hide: true, tooltipLegendVisible: false } }))).toBe(
+      false
+    )
     expect(shouldUseTooltipLegendMarkers(buildConfig({ legend: { style: 'gradient' } }))).toBe(false)
     expect(shouldUseTooltipLegendMarkers(buildConfig({ legend: { groupBy: 'category' } }))).toBe(false)
-    expect(shouldUseTooltipLegendMarkers(buildConfig({ smallMultiples: { mode: 'by-series' } }))).toBe(false)
     expect(
       shouldUseTooltipLegendMarkers(
         buildConfig({
+          runtime: { seriesLabelsAll: ['Cases'], seriesKeys: ['cases'] },
+          series: [{ dataKey: 'cases' }]
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('disables markers for single-series small-multiple tiles even when the source legend is visible', () => {
+    expect(
+      shouldUseTooltipLegendMarkers(
+        buildConfig({
+          legend: { hide: true, tooltipLegendVisible: true },
           runtime: { seriesLabelsAll: ['Cases'], seriesKeys: ['cases'] },
           series: [{ dataKey: 'cases' }]
         })

--- a/packages/chart/src/helpers/tests/tooltipHelpers.test.ts
+++ b/packages/chart/src/helpers/tests/tooltipHelpers.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTooltipListHtml,
+  getTooltipMarkerColor,
+  getTooltipMarkerShape,
+  shouldUseTooltipLegendMarkers,
+  tooltipHasMarkerColumn,
+  tooltipShouldUseMarkerColumn,
+  type TooltipRow
+} from '../tooltipHelpers'
+
+const buildConfig = overrides => ({
+  visualizationType: 'Line',
+  legend: {
+    hide: false,
+    style: 'circles',
+    groupBy: '',
+    patterns: {},
+    ...overrides?.legend
+  },
+  runtime: {
+    seriesLabels: { cases: 'Cases', deaths: 'Deaths' },
+    seriesLabelsAll: ['Cases', 'Deaths'],
+    seriesKeys: ['cases', 'deaths'],
+    ...overrides?.runtime
+  },
+  series: [{ dataKey: 'cases' }, { dataKey: 'deaths' }],
+  smallMultiples: {
+    mode: '',
+    ...overrides?.smallMultiples
+  },
+  ...overrides
+})
+
+describe('tooltipHelpers', () => {
+  it('enables marker rendering for supported multi-series charts with visible legends', () => {
+    expect(shouldUseTooltipLegendMarkers(buildConfig())).toBe(true)
+  })
+
+  it('disables markers when the legend is hidden or in a special mode', () => {
+    expect(shouldUseTooltipLegendMarkers(buildConfig({ legend: { hide: true } }))).toBe(false)
+    expect(shouldUseTooltipLegendMarkers(buildConfig({ legend: { style: 'gradient' } }))).toBe(false)
+    expect(shouldUseTooltipLegendMarkers(buildConfig({ legend: { groupBy: 'category' } }))).toBe(false)
+    expect(shouldUseTooltipLegendMarkers(buildConfig({ smallMultiples: { mode: 'by-series' } }))).toBe(false)
+    expect(
+      shouldUseTooltipLegendMarkers(
+        buildConfig({
+          runtime: { seriesLabelsAll: ['Cases'], seriesKeys: ['cases'] },
+          series: [{ dataKey: 'cases' }]
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('keeps patterned legends eligible and still uses the base series color', () => {
+    expect(shouldUseTooltipLegendMarkers(buildConfig({ legend: { patterns: { striped: { color: '#000' } } } }))).toBe(
+      true
+    )
+  })
+
+  it('resolves marker colors using the legend label mapping', () => {
+    const colorScale = value => ({ Cases: '#1f77b4', deaths: '#d62728' }[value] || null)
+
+    expect(getTooltipMarkerColor(buildConfig(), colorScale as any, 'cases')).toBe('#1f77b4')
+    expect(getTooltipMarkerColor(buildConfig(), colorScale as any, 'unknown')).toBe(null)
+  })
+
+  it('uses square markers only when the legend explicitly uses boxes', () => {
+    expect(getTooltipMarkerShape(buildConfig())).toBe('circle')
+    expect(getTooltipMarkerShape(buildConfig({ legend: { style: 'boxes' } }))).toBe('square')
+  })
+
+  it('only reserves a marker column when at least one series row has a marker', () => {
+    const rows: TooltipRow[] = [
+      { key: 'Date', value: '2024-01-01', kind: 'heading' },
+      { key: 'Cases', value: '10', kind: 'series', markerColor: '#1f77b4' },
+      { key: 'Source', value: 'CDC', kind: 'extra' }
+    ]
+    const rowsWithoutMarkers: TooltipRow[] = [
+      { key: 'Date', value: '2024-01-01', kind: 'heading' },
+      { key: 'Source', value: 'CDC', kind: 'extra' }
+    ]
+
+    expect(tooltipHasMarkerColumn(rows)).toBe(true)
+    expect(tooltipHasMarkerColumn(rowsWithoutMarkers)).toBe(false)
+  })
+
+  it('suppresses the marker column when two series would render identical marker signatures', () => {
+    expect(
+      tooltipShouldUseMarkerColumn([
+        { markerColor: '#f28e2b', markerShape: 'circle' },
+        { markerColor: '#f28e2b', markerShape: 'circle' }
+      ])
+    ).toBe(false)
+
+    expect(
+      tooltipShouldUseMarkerColumn([
+        { markerColor: '#f28e2b', markerShape: 'circle' },
+        { markerColor: '#f28e2b', markerShape: 'square' }
+      ])
+    ).toBe(true)
+  })
+
+  it('renders aligned raw HTML rows only when the tooltip contains a marker', () => {
+    const withMarker = buildTooltipListHtml({
+      heading: 'Date: Jan 1, 2024',
+      bodyRows: [{ text: 'Cases: 10', markerColor: '#1f77b4', markerShape: 'square' }, { text: 'Source: CDC' }]
+    })
+    const withoutMarker = buildTooltipListHtml({
+      heading: 'Date: Jan 1, 2024',
+      bodyRows: [{ text: 'Source: CDC' }]
+    })
+    const ambiguousMarkers = buildTooltipListHtml({
+      heading: 'Date: Jan 1, 2024',
+      bodyRows: [
+        { text: 'Dose 1: 10', markerColor: '#f28e2b', markerShape: 'circle' },
+        { text: 'Dose 2: 20', markerColor: '#f28e2b', markerShape: 'circle' }
+      ]
+    })
+
+    expect(withMarker).toContain('tooltip-body--marker-layout')
+    expect(withMarker).toContain('tooltip-marker-slot')
+    expect(withMarker).toContain('tooltip-marker-swatch')
+    expect(withMarker).toContain('tooltip-marker-swatch--square')
+    expect(withoutMarker).not.toContain('tooltip-body--marker-layout')
+    expect(withoutMarker).not.toContain('tooltip-marker-slot')
+    expect(ambiguousMarkers).not.toContain('tooltip-body--marker-layout')
+    expect(ambiguousMarkers).not.toContain('tooltip-marker-slot')
+  })
+})

--- a/packages/chart/src/helpers/tests/tooltipHelpers.test.ts
+++ b/packages/chart/src/helpers/tests/tooltipHelpers.test.ts
@@ -140,6 +140,7 @@ describe('tooltipHelpers', () => {
 
     expect(withMarker).toContain('tooltip-body--marker-layout')
     expect(withMarker).toContain('tooltip-marker-slot')
+    expect(withMarker).toContain('tooltip-marker-slot" aria-hidden="true"')
     expect(withMarker).toContain('tooltip-marker-swatch')
     expect(withMarker).toContain('tooltip-marker-swatch--square')
     expect(withoutMarker).not.toContain('tooltip-body--marker-layout')

--- a/packages/chart/src/helpers/tooltipHelpers.ts
+++ b/packages/chart/src/helpers/tooltipHelpers.ts
@@ -33,9 +33,6 @@ export type TooltipMarker = {
 
 const TOOLTIP_MARKER_SUPPORTED_TYPES = new Set(['Line', 'Area Chart', 'Combo', 'Bar', 'Scatter Plot'])
 
-export const hasTooltipLegendPatterns = (config: ChartConfig): boolean =>
-  !!config.legend?.patterns && Object.keys(config.legend.patterns).length > 0
-
 export const getTooltipMarkerShape = (config: ChartConfig): 'circle' | 'square' =>
   config.legend?.style === 'boxes' ? 'square' : 'circle'
 
@@ -129,7 +126,7 @@ export const buildTooltipBodyRowHtml = ({
     ? `<span class="tooltip-marker-swatch tooltip-marker-swatch--${markerShape}" style="background-color: ${markerColor};" aria-hidden="true"></span>`
     : ''
 
-  return `<li class="tooltip-body tooltip-body--marker-layout"><span class="tooltip-marker-slot">${marker}</span><span class="tooltip-body-content">${text}</span></li>`
+  return `<li class="tooltip-body tooltip-body--marker-layout"><span class="tooltip-marker-slot" aria-hidden="true">${marker}</span><span class="tooltip-body-content">${text}</span></li>`
 }
 
 export const buildTooltipListHtml = ({

--- a/packages/chart/src/helpers/tooltipHelpers.ts
+++ b/packages/chart/src/helpers/tooltipHelpers.ts
@@ -42,14 +42,14 @@ export const getTooltipMarkerShape = (config: ChartConfig): 'circle' | 'square' 
 export const shouldUseTooltipLegendMarkers = (config: ChartConfig): boolean => {
   const legendItemCount =
     config.runtime?.seriesLabelsAll?.length || config.runtime?.seriesKeys?.length || config.series?.length || 0
+  const sourceLegendVisible = config.legend?.tooltipLegendVisible ?? !config.legend?.hide
 
   return (
     TOOLTIP_MARKER_SUPPORTED_TYPES.has(config.visualizationType) &&
     legendItemCount > 1 &&
-    !config.legend?.hide &&
+    sourceLegendVisible &&
     config.legend?.style !== 'gradient' &&
-    !config.legend?.groupBy &&
-    !config.smallMultiples?.mode
+    !config.legend?.groupBy
   )
 }
 

--- a/packages/chart/src/helpers/tooltipHelpers.ts
+++ b/packages/chart/src/helpers/tooltipHelpers.ts
@@ -1,0 +1,179 @@
+import { type ChartConfig } from '../types/ChartConfig'
+import { type ColorScale } from '../types/ChartContext'
+
+export type TooltipRowKind = 'heading' | 'series' | 'extra'
+
+export type TooltipRow = {
+  key: string
+  value: string | number
+  axisPosition?: string
+  kind: TooltipRowKind
+  markerColor?: string | null
+  markerShape?: 'circle' | 'square'
+  seriesKey?: string
+}
+
+export type TooltipDisplayData = {
+  data: TooltipRow[]
+  dataXPosition: number
+  dataYPosition: number
+  useMarkerColumn: boolean
+}
+
+type RawTooltipBodyRow = {
+  text: string
+  markerColor?: string | null
+  markerShape?: 'circle' | 'square'
+}
+
+export type TooltipMarker = {
+  markerColor: string
+  markerShape: 'circle' | 'square'
+}
+
+const TOOLTIP_MARKER_SUPPORTED_TYPES = new Set(['Line', 'Area Chart', 'Combo', 'Bar', 'Scatter Plot'])
+
+export const hasTooltipLegendPatterns = (config: ChartConfig): boolean =>
+  !!config.legend?.patterns && Object.keys(config.legend.patterns).length > 0
+
+export const getTooltipMarkerShape = (config: ChartConfig): 'circle' | 'square' =>
+  config.legend?.style === 'boxes' ? 'square' : 'circle'
+
+export const shouldUseTooltipLegendMarkers = (config: ChartConfig): boolean => {
+  const legendItemCount =
+    config.runtime?.seriesLabelsAll?.length || config.runtime?.seriesKeys?.length || config.series?.length || 0
+
+  return (
+    TOOLTIP_MARKER_SUPPORTED_TYPES.has(config.visualizationType) &&
+    legendItemCount > 1 &&
+    !config.legend?.hide &&
+    config.legend?.style !== 'gradient' &&
+    !config.legend?.groupBy &&
+    !config.smallMultiples?.mode
+  )
+}
+
+export const getTooltipMarkerColor = (
+  config: ChartConfig,
+  colorScale: ColorScale | undefined,
+  seriesKey?: string
+): string | null => {
+  if (!colorScale || !seriesKey) return null
+
+  const colorInput = config.runtime?.seriesLabels?.[seriesKey] || seriesKey
+  const color = colorScale(colorInput)
+  return typeof color === 'string' ? color : null
+}
+
+export const getTooltipSeriesMarker = (
+  config: ChartConfig,
+  colorScale: ColorScale | undefined,
+  seriesKey?: string
+): TooltipMarker | null => {
+  if (!shouldUseTooltipLegendMarkers(config)) {
+    return null
+  }
+
+  const markerColor = getTooltipMarkerColor(config, colorScale, seriesKey)
+  if (!markerColor) {
+    return null
+  }
+
+  return {
+    markerColor,
+    markerShape: getTooltipMarkerShape(config)
+  }
+}
+
+export const buildTooltipRow = (row: TooltipRow): TooltipRow => row
+
+const getMarkerSignature = ({
+  markerColor,
+  markerShape = 'circle'
+}: {
+  markerColor?: string | null
+  markerShape?: 'circle' | 'square'
+}): string | null => {
+  if (!markerColor) return null
+  return `${markerColor}::${markerShape}`
+}
+
+export const tooltipShouldUseMarkerColumn = (
+  rows: Array<{ markerColor?: string | null; markerShape?: 'circle' | 'square' }>
+): boolean => {
+  const signatures = rows.map(getMarkerSignature).filter(Boolean)
+
+  if (signatures.length === 0) {
+    return false
+  }
+
+  return new Set(signatures).size === signatures.length
+}
+
+export const tooltipHasMarkerColumn = (rows: TooltipRow[]): boolean =>
+  tooltipShouldUseMarkerColumn(rows.filter(row => row.kind === 'series'))
+
+export const buildTooltipBodyRowHtml = ({
+  text,
+  markerColor,
+  markerShape = 'circle',
+  useMarkerColumn
+}: RawTooltipBodyRow & {
+  useMarkerColumn: boolean
+}): string => {
+  if (!useMarkerColumn) {
+    return `<li class="tooltip-body">${text}</li>`
+  }
+
+  const marker = markerColor
+    ? `<span class="tooltip-marker-swatch tooltip-marker-swatch--${markerShape}" style="background-color: ${markerColor};" aria-hidden="true"></span>`
+    : ''
+
+  return `<li class="tooltip-body tooltip-body--marker-layout"><span class="tooltip-marker-slot">${marker}</span><span class="tooltip-body-content">${text}</span></li>`
+}
+
+export const buildTooltipListHtml = ({
+  heading,
+  bodyRows
+}: {
+  heading: string
+  bodyRows: RawTooltipBodyRow[]
+}): string => {
+  const hasMarkerColumn = tooltipShouldUseMarkerColumn(bodyRows)
+  const renderedRows = bodyRows
+    .filter(row => row.text !== undefined && row.text !== null && row.text !== '')
+    .map(row => buildTooltipBodyRowHtml({ ...row, useMarkerColumn: hasMarkerColumn }))
+    .join('')
+
+  return `<ul><li class="tooltip-heading">${heading}</li>${renderedRows}</ul>`
+}
+
+export const buildSeriesTooltipListHtml = ({
+  config,
+  colorScale,
+  heading,
+  seriesKey,
+  seriesText,
+  extraRows = []
+}: {
+  config: ChartConfig
+  colorScale?: ColorScale
+  heading: string
+  seriesKey?: string
+  seriesText: string
+  extraRows?: string[]
+}): string => {
+  const marker = getTooltipSeriesMarker(config, colorScale, seriesKey)
+
+  return buildTooltipListHtml({
+    heading,
+    bodyRows: [
+      {
+        text: seriesText,
+        markerColor: marker?.markerColor,
+        markerShape: marker?.markerShape
+      },
+      ...extraRows.filter(Boolean).map(text => ({ text }))
+    ]
+  })
+}

--- a/packages/chart/src/hooks/useTooltip.tsx
+++ b/packages/chart/src/hooks/useTooltip.tsx
@@ -8,13 +8,21 @@ import { isDateScale } from '@cdc/core/helpers/cove/date'
 // Third-party library imports
 import { localPoint } from '@visx/event'
 import { bisector } from 'd3-array'
-import _, { get } from 'lodash'
+import _ from 'lodash'
 import { getHorizontalBarHeights } from '../components/BarChart/helpers/getBarHeights'
 import {
   findColumnConfigByName,
   getSeriesColumnFormattingParams,
   getSeriesOwnedColumnNames
 } from '../helpers/seriesColumnSettings'
+import {
+  buildTooltipRow,
+  getTooltipSeriesMarker,
+  tooltipHasMarkerColumn,
+  type TooltipRow
+} from '../helpers/tooltipHelpers'
+import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
+import { getVizSubType, getVizTitle } from '@cdc/core/helpers/metrics/utils'
 
 export const useTooltip = props => {
   // Track the last X-axis value to prevent duplicate analytics events
@@ -22,6 +30,7 @@ export const useTooltip = props => {
   const {
     tableData: data,
     config,
+    colorScale,
     formatNumber,
     capitalize,
     formatDate,
@@ -33,7 +42,6 @@ export const useTooltip = props => {
   const { xScale, yScale, seriesScale, showTooltip, hideTooltip, interactionLabel = '' } = props
   const { xAxis, visualizationType, orientation, yAxis, runtime } = config
   const seriesOwnedColumnNames = getSeriesOwnedColumnNames(config.series)
-
   // Track the latest xScale in a ref to prevent stale closures
   const xScaleRef = useRef(xScale)
 
@@ -90,6 +98,33 @@ export const useTooltip = props => {
     return showMissingDataValue ? 'N/A' : formattedValue
   }
 
+  const createTooltipRow = ({
+    key,
+    value,
+    kind,
+    axisPosition,
+    seriesKey
+  }: {
+    key: string
+    value: string | number
+    kind: TooltipRow['kind']
+    axisPosition?: string
+    seriesKey?: string
+  }): TooltipRow =>
+    (() => {
+      const marker = kind === 'series' ? getTooltipSeriesMarker(config, colorScale, seriesKey || key) : null
+
+      return buildTooltipRow({
+        key,
+        value,
+        axisPosition,
+        kind,
+        seriesKey,
+        markerColor: marker?.markerColor ?? null,
+        markerShape: marker?.markerShape
+      })
+    })()
+
   /**
    * Handles the mouse over event for the tooltip.
    * @function handleTooltipMouseOver
@@ -108,7 +143,7 @@ export const useTooltip = props => {
     const singleSeriesValue = getYValueFromCoordinate(y, resolvedScaleValues)
 
     const columnsWithTooltips = []
-    const tooltipItems = [] as any[][]
+    const tooltipItems: TooltipRow[] = []
     for (const [colKey, column] of Object.entries(config.columns)) {
       const columnName = column.name || colKey
       if (seriesOwnedColumnNames.includes(columnName)) continue
@@ -135,10 +170,16 @@ export const useTooltip = props => {
         columnsWithTooltips.push([column.label, formattedValue])
       }
     }
-    const additionalTooltipItems = [] as [string, string | number][]
+    const additionalTooltipItems: TooltipRow[] = []
 
     columnsWithTooltips.forEach(columnData => {
-      additionalTooltipItems.push([columnData[0], columnData[1]])
+      additionalTooltipItems.push(
+        createTooltipRow({
+          key: columnData[0],
+          value: columnData[1],
+          kind: 'extra'
+        })
+      )
     })
 
     if (visualizationType === 'Pie') {
@@ -155,21 +196,46 @@ export const useTooltip = props => {
       const showPiePercent = config.dataFormat.showPiePercent || false
 
       if (showPiePercent && pieData[config.xAxis.dataKey] === 'Calculated Area') {
-        tooltipItems.push(['', 'Calculated Area'])
+        tooltipItems.push(
+          createTooltipRow({
+            key: '',
+            value: 'Calculated Area',
+            kind: 'heading'
+          })
+        )
       } else {
         tooltipItems.push(
-          [config.xAxis.dataKey, pieData[config.xAxis.dataKey]],
-          [
-            config.runtime.yAxis.label || config.runtime.yAxis.dataKey,
-            showPiePercent ? pctString(actualPieValue) : formatNumber(pieData[config.runtime.yAxis.dataKey])
-          ],
-          showPiePercent ? [] : ['Percent', pctString(pctOf360)]
+          createTooltipRow({
+            key: config.xAxis.dataKey,
+            value: pieData[config.xAxis.dataKey],
+            kind: 'heading'
+          }),
+          createTooltipRow({
+            key: config.runtime.yAxis.label || config.runtime.yAxis.dataKey,
+            value: showPiePercent ? pctString(actualPieValue) : formatNumber(pieData[config.runtime.yAxis.dataKey]),
+            kind: 'extra'
+          })
         )
+        if (!showPiePercent) {
+          tooltipItems.push(
+            createTooltipRow({
+              key: 'Percent',
+              value: pctString(pctOf360),
+              kind: 'extra'
+            })
+          )
+        }
       }
     }
 
     if (visualizationType === 'Forest Plot') {
-      tooltipItems.push([config.xAxis.dataKey, getClosestYValue(y)])
+      tooltipItems.push(
+        createTooltipRow({
+          key: config.xAxis.dataKey,
+          value: getClosestYValue(y),
+          kind: 'heading'
+        })
+      )
     }
 
     const isLinearChart = !['Pie', 'Forest Plot'].includes(visualizationType)
@@ -205,9 +271,34 @@ export const useTooltip = props => {
               ) {
                 return []
               } else if (seriesObjWithName && seriesObjWithName.name === '') {
-                return [['', formattedValue, getAxisPosition(seriesKey)]]
+                return [
+                  createTooltipRow({
+                    key: '',
+                    value: formattedValue,
+                    axisPosition: getAxisPosition(seriesKey),
+                    kind: 'series',
+                    seriesKey
+                  })
+                ]
+              } else if (config.xAxis?.dataKey == seriesKey) {
+                return [
+                  createTooltipRow({
+                    key: seriesKey,
+                    value: formattedValue,
+                    axisPosition: getAxisPosition(seriesKey),
+                    kind: 'heading'
+                  })
+                ]
               } else {
-                return [[seriesKey, formattedValue, getAxisPosition(seriesKey)]]
+                return [
+                  createTooltipRow({
+                    key: seriesKey,
+                    value: formattedValue,
+                    axisPosition: getAxisPosition(seriesKey),
+                    kind: 'series',
+                    seriesKey
+                  })
+                ]
               }
             })
         )
@@ -247,7 +338,15 @@ export const useTooltip = props => {
             if (resolvedScaleValue) {
               const value = resolvedScaleValue[series.originalDataKey]
               const formattedValue = getFormattedValue(seriesKey, value, config, getAxisPosition)
-              tooltipItems.push([seriesKey, formattedValue, getAxisPosition(seriesKey)])
+              tooltipItems.push(
+                createTooltipRow({
+                  key: seriesKey,
+                  value: formattedValue,
+                  axisPosition: getAxisPosition(seriesKey),
+                  kind: 'series',
+                  seriesKey
+                })
+              )
             }
           }
         })
@@ -261,12 +360,31 @@ export const useTooltip = props => {
           const xVal = dataColumn[config.xAxis.dataKey]
           const closestXScaleValue = getXValueFromCoordinate(x - Y_AXIS_SIZE)
 
-          tooltipItems.push([config.xAxis.dataKey, closestXScaleValue || xVal])
+          tooltipItems.push(
+            createTooltipRow({
+              key: config.xAxis.dataKey,
+              value: closestXScaleValue || xVal,
+              kind: 'heading'
+            })
+          )
           const formattedValue = getFormattedValue(seriesKey, value, config, getAxisPosition)
-          tooltipItems.push([seriesKey, formattedValue])
+          tooltipItems.push(
+            createTooltipRow({
+              key: seriesKey,
+              value: formattedValue,
+              kind: 'series',
+              seriesKey
+            })
+          )
         } else if (dynamicSeries) {
           Object.keys(dataColumn).forEach(key => {
-            tooltipItems.push([key, dataColumn[key]])
+            tooltipItems.push(
+              createTooltipRow({
+                key,
+                value: dataColumn[key],
+                kind: key === config.xAxis.dataKey ? 'heading' : 'extra'
+              })
+            )
           })
         }
       }
@@ -283,16 +401,11 @@ export const useTooltip = props => {
     }
 
     // Strip link tags from all tooltip values
-    const cleanTooltipItems = [...tooltipItems, ...additionalTooltipItems].map(item => {
-      // item can be [key, value] or [key, value, axisPosition]
-      if (Array.isArray(item)) {
-        // Only strip from value (item[1])
-        const newItem = [...item]
-        newItem[1] = stripLinkTags(newItem[1])
-        return newItem
-      }
-      return item
-    })
+    const cleanTooltipItems = [...tooltipItems, ...additionalTooltipItems].map(item => ({
+      ...item,
+      value: stripLinkTags(item.value)
+    }))
+    const useMarkerColumn = tooltipHasMarkerColumn(cleanTooltipItems)
 
     const tooltipInformation = {
       tooltipLeft: dataXPosition,
@@ -300,7 +413,8 @@ export const useTooltip = props => {
       tooltipData: {
         data: cleanTooltipItems,
         dataXPosition,
-        dataYPosition
+        dataYPosition,
+        useMarkerColumn
       }
     }
     showTooltip(tooltipInformation)
@@ -654,9 +768,8 @@ export const useTooltip = props => {
     return originalColumnName
   }
 
-  const TooltipListItem = ({ item }) => {
-    const [index, additionalData] = item
-    const [key, value, axisPosition] = additionalData
+  const TooltipListItem = ({ row, index, useMarkerColumn = false }) => {
+    const { key, value, axisPosition, kind, markerColor, markerShape = 'circle' } = row
 
     if (visualizationType === 'Forest Plot') {
       if (key === config.xAxis.dataKey)
@@ -718,10 +831,26 @@ export const useTooltip = props => {
     }
     const activeLabel = getSeriesNameFromLabel(key)
     const displayText = activeLabel ? `${activeLabel}: ${newValue}` : newValue
+    const shouldRenderMarkerSlot = useMarkerColumn && kind !== 'heading'
+    const markerSlot = shouldRenderMarkerSlot ? (
+      <span className='tooltip-marker-slot' aria-hidden='true'>
+        {markerColor ? (
+          <span
+            className={`tooltip-marker-swatch tooltip-marker-swatch--${markerShape}`}
+            style={{ backgroundColor: markerColor }}
+          />
+        ) : null}
+      </span>
+    ) : null
+    const content = displayText !== undefined ? parse(String(displayText)) : displayText
 
     return (
-      <li style={style} className='tooltip-body mb-1 cove-prose'>
-        {displayText !== undefined ? parse(String(displayText)) : displayText}
+      <li
+        style={style}
+        className={`tooltip-body mb-1 cove-prose ${shouldRenderMarkerSlot ? 'tooltip-body--marker-layout' : ''}`}
+      >
+        {markerSlot}
+        {shouldRenderMarkerSlot ? <span className='tooltip-body-content'>{content}</span> : content}
       </li>
     )
   }

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -102,6 +102,7 @@ type Legend = CoreLegend & {
   seriesHighlight: string[]
   unified: boolean
   hideSuppressionLink: boolean
+  tooltipLegendVisible?: boolean
   style: 'circles' | 'boxes' | 'gradient' | 'lines'
   subStyle: 'linear blocks' | 'smooth'
   hasShape: boolean

--- a/packages/core/components/ui/tooltip.scss
+++ b/packages/core/components/ui/tooltip.scss
@@ -67,6 +67,42 @@
       }
     }
 
+    .tooltip-body--marker-layout {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.25rem;
+    }
+
+    .tooltip-marker-slot {
+      display: inline-flex;
+      flex: 0 0 12px;
+      width: 12px;
+      min-height: 1em;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .tooltip-marker-swatch {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      border: rgba(0, 0, 0, 0.3) 1px solid;
+      box-sizing: border-box;
+    }
+
+    .tooltip-marker-swatch--circle {
+      border-radius: 999px;
+    }
+
+    .tooltip-marker-swatch--square {
+      border-radius: 0;
+    }
+
+    .tooltip-body-content {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
     .tooltip-heading {
       display: block;
       font-weight: var(--cove-tooltip-heading-fontWeight) !important;


### PR DESCRIPTION
## Summary

This adds colored shapes to chart tooltip indicating which series the items in the tooltip belong to.

- If there is only one series, or the legend is hidden, it does not show colors
- If more than one series resolves to the same color, it does not show colors
- It does not show colors for gradient legends
- If the legend uses boxes, it shows boxes

## Testing Steps

Look at as many charts as possible and see if the colors shown in tooltips make sense.