### PR TITLE
Feat [dev-12883] show neighboring states data

### DIFF
--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -1332,30 +1332,39 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                       />
                     )}
                     {config.general.geoType === 'us-county' && (
-                      <CheckBox
-                        value={config.general.showHSABoundaries || false}
-                        fieldName='showHSABoundaries'
-                        label='Show HSA Boundaries'
-                        updateField={updateField}
-                        section='general'
-                        tooltip={
-                          <Tooltip style={{ textTransform: 'none' }}>
-                            <Tooltip.Target>
-                              <Icon
-                                display='question'
-                                style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
-                              />
-                            </Tooltip.Target>
-                            <Tooltip.Content>
-                              <p>
-                                Health Service Areas (HSAs) are a county or cluster of contiguous counties which are
-                                relatively self-contained with respect to hospital care. Set HSA description in tooltip
-                                under the Columns accordion.
-                              </p>
-                            </Tooltip.Content>
-                          </Tooltip>
-                        }
-                      />
+                      <>
+                        <CheckBox
+                          value={config.general.showNeighboringStates || false}
+                          fieldName='showNeighboringStates'
+                          label="Show Neighboring States' Data"
+                          updateField={updateField}
+                          section='general'
+                        />
+                        <CheckBox
+                          value={config.general.showHSABoundaries || false}
+                          fieldName='showHSABoundaries'
+                          label='Show HSA Boundaries'
+                          updateField={updateField}
+                          section='general'
+                          tooltip={
+                            <Tooltip style={{ textTransform: 'none' }}>
+                              <Tooltip.Target>
+                                <Icon
+                                  display='question'
+                                  style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
+                                />
+                              </Tooltip.Target>
+                              <Tooltip.Content>
+                                <p>
+                                  Health Service Areas (HSAs) are a county or cluster of contiguous counties which are
+                                  relatively self-contained with respect to hospital care. Set HSA description in
+                                  tooltip under the Columns accordion.
+                                </p>
+                              </Tooltip.Content>
+                            </Tooltip>
+                          }
+                        />
+                      </>
                     )}
                     {(config.general.geoType === 'us-county' || config.general.geoType === 'single-state') && (
                       <Select

--- a/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
@@ -845,7 +845,9 @@ const CountyMap = () => {
     let countyHighlight = null
     topoData.mapData.forEach(geo => {
       if (!geo.id) return
-      if (focus.id && geo.id.length > 2 && geo.id.indexOf(focus.id) !== 0) return
+      const hideCounty =
+        !config.general.showNeighboringStates && focus.id && geo.id.length > 2 && geo.id.indexOf(focus.id) !== 0
+      if (hideCounty) return
       if (!focus.id && config.general.type === 'us-geocode' && geo.id.length > 2) return
 
       const path2d = cache.get(geo.id)
@@ -900,7 +902,7 @@ const CountyMap = () => {
       const focusGeoId = topoData.mapData[focus.index]?.id
       const path2d = focusGeoId && cache.get(focusGeoId)
       if (path2d) {
-        context.strokeStyle = geoStrokeColor
+        context.strokeStyle = config.general.showNeighboringStates ? '#000000' : geoStrokeColor
         context.lineWidth = lineWidth * 2 * strokeScale
         context.stroke(path2d)
       }

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -167,6 +167,7 @@ export type MapConfig = Visualization & {
     includeContextInDownload?: boolean
     showDownloadPdfButton: boolean
     showHSABoundaries?: boolean
+    showNeighboringStates?: boolean
     showSidebar: boolean
     showStateDropdown?: boolean
     showTitle: boolean


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->

Add ability to toggle neighboring states on when state is zoomed in. 

## Testing Steps
<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

Scenario: tester has imported county-hsa-toggle.json config into the map package and has the editor panel toggled open.

1) open the Type accordion and click the checkbox 'Show Neighboring States' Data'
2) Click on the state of Georgia in the map to the right.
Expected: The map should zoom into Georgia and you should still see the data of surrounding states.

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->

<img width="1024" height="541" alt="image" src="https://github.com/user-attachments/assets/785751da-b944-4985-9a96-fc6ea3cdc589" />

