### PR TITLE
Large dataset performance

### DIFF
--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1827,6 +1827,27 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
   const hasDynamicCategory = ![undefined, '- Select - '].includes(config.series?.[0]?.dynamicCategory)
   const hasMultipleSeries = config.series?.length > 1
 
+  const highlightedSeriesOptions = useMemo(() => {
+    if (
+      !(
+        config.visualizationType === 'Bar' &&
+        config.series?.length === 1 &&
+        config.highlightedBarValues?.length > 0 &&
+        getHighlightedSeriesValues
+      )
+    ) {
+      return []
+    }
+
+    return [...new Set(getHighlightedSeriesValues())].sort().map(option => ({ value: option, label: option }))
+  }, [
+    config.visualizationType,
+    config.series?.length,
+    config.highlightedBarValues?.length,
+    config.data,
+    config.xAxis.dataKey
+  ])
+
   const editorContextValues = {
     addNewExclusion,
     data,
@@ -3659,11 +3680,7 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
                                         onChange={e => handleUpdateHighlightedBar(e, i)}
                                         options={[
                                           { value: '', label: '- Select Value -' },
-                                          ...(getHighlightedSeriesValues
-                                            ? [...new Set(getHighlightedSeriesValues())]
-                                                .sort()
-                                                .map(option => ({ value: option, label: option }))
-                                            : [])
+                                          ...highlightedSeriesOptions
                                         ]}
                                       />
                                       <label>

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1217,7 +1217,7 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
   // prettier-ignore
   const {
     highlightedBarValues,
-    highlightedSeriesValues,
+    getHighlightedSeriesValues,
     handleUpdateHighlightedBar,
     handleAddNewHighlightedBar,
     handleRemoveHighlightedBar,
@@ -1845,7 +1845,7 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
     handleUpdateHighlightedBar,
     handleRemoveHighlightedBar,
     isPaletteReversed: config.general?.palette?.isReversed,
-    highlightedSeriesValues,
+    getHighlightedSeriesValues,
     handleUpdateHighlightedBorderWidth,
     handleUpdateHighlightedBarColor,
     setLollipopShape,
@@ -3659,8 +3659,8 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
                                         onChange={e => handleUpdateHighlightedBar(e, i)}
                                         options={[
                                           { value: '', label: '- Select Value -' },
-                                          ...(highlightedSeriesValues
-                                            ? [...new Set(highlightedSeriesValues)]
+                                          ...(getHighlightedSeriesValues
+                                            ? [...new Set(getHighlightedSeriesValues())]
                                                 .sort()
                                                 .map(option => ({ value: option, label: option }))
                                             : [])

--- a/packages/chart/src/components/EditorPanel/EditorPanelContext.ts
+++ b/packages/chart/src/components/EditorPanel/EditorPanelContext.ts
@@ -19,7 +19,7 @@ export type EditorPanelContext = {
   handleUpdateHighlightedBarColor?: Function
   handleUpdateHighlightedBorderWidth?: Function
   highlightedBarValues?: Function
-  highlightedSeriesValues?: Function
+  getHighlightedSeriesValues?: Function
   isPaletteReversed?: boolean
   handleRemoveHighlightedBar?: Function
   setLollipopShape?: Function

--- a/packages/chart/src/hooks/useHighlightedBars.ts
+++ b/packages/chart/src/hooks/useHighlightedBars.ts
@@ -5,21 +5,14 @@ import { ChartConfig } from '../types/ChartConfig'
 export const useHighlightedBars = (config: ChartConfig, updateConfig: (config) => void) => {
   const { formatDate, parseDate } = useContext(ConfigContext)
 
-  let highlightedSeries = [] // only allow single series for highlights
-  let highlightedSeriesKey = ''
-  let highlightedBarValues = []
-  let highlightedSeriesValues = []
+  const highlightedSeries = config.series?.length > 0 && config.data ? config.series[0] : [] // only allow single series for highlights
+  const highlightedSeriesKey = config.series?.length > 0 && config.data ? config.series[0].dataKey : ''
+  const highlightedBarValues = config.series?.length > 0 && config.data ? config.highlightedBarValues : []
 
-  if (config.series?.length > 0 && config.data) {
-    highlightedSeries = config.series[0] // only allow single series for highlights
-    highlightedSeriesKey = config.series[0].dataKey
-    highlightedBarValues = config.highlightedBarValues
-    highlightedSeriesValues = config.data.map(item => item[config.xAxis.dataKey])
-  } else {
-    highlightedSeries = [] // only allow single series for highlights
-    highlightedSeriesKey = ''
-    highlightedBarValues = []
-    highlightedSeriesValues = []
+  const getHighlightedSeriesValues = () => {
+    if (!(config.series?.length > 0 && config.data)) return []
+
+    return config.data.map(item => item[config.xAxis.dataKey])
   }
 
   const handleUpdateHighlightedBorderWidth = (e, index) => {
@@ -144,7 +137,7 @@ export const useHighlightedBars = (config: ChartConfig, updateConfig: (config) =
     highlightedSeries,
     highlightedSeriesKey,
     highlightedBarValues,
-    highlightedSeriesValues,
+    getHighlightedSeriesValues,
     handleUpdateHighlightedBar,
     handleAddNewHighlightedBar,
     handleRemoveHighlightedBar,

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -407,7 +407,7 @@ const DataTable = (props: DataTableProps) => {
           <MediaControls.Link config={config} dashboardDataConfig={dataConfig} interactionLabel={interactionLabel} />
           {hasDownloadLink && (
             <DownloadButton
-              rawData={getDownloadData()}
+              getRawData={getDownloadData}
               fileName={`${vizTitle || 'data-table'}.csv`}
               interactionLabel={interactionLabel}
               config={config}

--- a/packages/core/components/DownloadButton.tsx
+++ b/packages/core/components/DownloadButton.tsx
@@ -4,7 +4,7 @@ import { publishAnalyticsEvent } from '../helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
 
 type DownloadButtonProps = {
-  rawData: any[]
+  getRawData: () => any[]
   fileName: string
   skipId?: string | number
   configUrl?: string
@@ -14,7 +14,7 @@ type DownloadButtonProps = {
 }
 
 const DownloadButton = ({
-  rawData,
+  getRawData,
   fileName,
   skipId,
   interactionLabel,
@@ -27,7 +27,8 @@ const DownloadButton = ({
   const handleDownload = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
 
-    const csvData = Papa.unparse(rawData)
+    const data = getRawData()
+    const csvData = Papa.unparse(data)
 
     // Prepend a Byte Order Mark (BOM) to the CSV data.
     // The BOM is a special marker that helps applications like Excel recognize the file as UTF-8 encoded.


### PR DESCRIPTION
## Summary

A few optimizations for charts with large datasets. Cuts render time by roughly 50% in those situations. These fix regressions since the last round of performance work.
