### PR TITLE
Round corners of combobox accessibility outline

### DIFF
--- a/packages/core/components/ComboBox/combobox.styles.css
+++ b/packages/core/components/ComboBox/combobox.styles.css
@@ -11,6 +11,7 @@
     width: 100%;
 
     &:focus-within {
+      border-radius: 6px !important;
       outline: dashed 2px rgb(0, 122, 153) !important;
       outline-offset: 3px !important;
     }


### PR DESCRIPTION
## Summary

Rounds the corners of the combobox accessibility outline to match other dropdowns.