### PR TITLE
feat: update editor dataset logic

### DIFF
--- a/packages/core/contexts/editor.reducer.test.ts
+++ b/packages/core/contexts/editor.reducer.test.ts
@@ -1,0 +1,111 @@
+import reducer, { type EditorState } from './editor.reducer'
+
+describe('editor reducer dashboard datasets', () => {
+  const createState = (): EditorState =>
+    ({
+      config: {
+        type: 'dashboard',
+        datasets: {
+          old_source: {
+            data: [{ value: 'old-row' }],
+            dataFileName: 'old.csv',
+            dataFileSourceType: 'url',
+            preview: true
+          },
+          secondary: {
+            data: [{ value: 'secondary-row' }],
+            dataFileName: 'secondary.csv',
+            dataFileSourceType: 'url',
+            preview: false
+          }
+        },
+        rows: [{ dataKey: 'old_source' }],
+        visualizations: {
+          first: {
+            dataKey: 'old_source'
+          }
+        }
+      } as any,
+      errors: [],
+      currentViewport: 'lg',
+      globalActive: 0
+    }) satisfies EditorState
+
+  it('replaces dashboard datasets immutably and marks the new source for preview', () => {
+    const state = createState()
+    const previousDatasets = state.config.datasets
+    const previousSecondary = state.config.datasets.secondary
+
+    const nextState = reducer(state, {
+      type: 'SET_DASHBOARD_DATASET',
+      payload: {
+        datasetKey: 'new_source',
+        oldDatasetKey: 'old_source',
+        dataset: {
+          data: [{ value: 'new-row' }],
+          dataFileName: 'new.csv',
+          dataFileSourceType: 'url',
+          preview: true
+        }
+      }
+    } as any)
+
+    expect(nextState.config.datasets).not.toBe(previousDatasets)
+    expect(nextState.config.datasets.secondary).not.toBe(previousSecondary)
+    expect(nextState.config.datasets.old_source).toBeUndefined()
+    expect(nextState.config.datasets.new_source.data).toEqual([{ value: 'new-row' }])
+    expect(nextState.config.datasets.new_source.preview).toBe(true)
+    expect(nextState.config.datasets.secondary.preview).toBe(false)
+    expect(nextState.config.rows[0].dataKey).toBe('new_source')
+    expect(nextState.config.visualizations.first.dataKey).toBe('new_source')
+  })
+
+  it('removes dashboard datasets immutably and falls back to another loaded preview dataset', () => {
+    const state = createState()
+    const previousDatasets = state.config.datasets
+    const previousSecondary = state.config.datasets.secondary
+
+    const nextState = reducer(state, {
+      type: 'DELETE_DASHBOARD_DATASET',
+      payload: { datasetKey: 'old_source' }
+    } as any)
+
+    expect(nextState.config.datasets).not.toBe(previousDatasets)
+    expect(nextState.config.datasets.secondary).not.toBe(previousSecondary)
+    expect(nextState.config.datasets.old_source).toBeUndefined()
+    expect(nextState.config.datasets.secondary.data).toEqual([{ value: 'secondary-row' }])
+    expect(nextState.config.datasets.secondary.preview).toBe(true)
+    expect(nextState.config.rows[0].dataKey).toBeUndefined()
+    expect(nextState.config.visualizations.first.dataKey).toBeUndefined()
+  })
+
+  it('does not assign preview when no remaining dataset is loaded', () => {
+    const state = {
+      ...createState(),
+      config: {
+        ...createState().config,
+        datasets: {
+          old_source: {
+            data: [{ value: 'old-row' }],
+            dataFileName: 'old.csv',
+            dataFileSourceType: 'url',
+            preview: true
+          },
+          remote_only: {
+            dataUrl: '/next.csv',
+            dataFileName: 'next.csv',
+            dataFileSourceType: 'url',
+            preview: false
+          }
+        }
+      }
+    } as EditorState
+
+    const nextState = reducer(state, {
+      type: 'DELETE_DASHBOARD_DATASET',
+      payload: { datasetKey: 'old_source' }
+    } as any)
+
+    expect(nextState.config.datasets.remote_only.preview).toBe(false)
+  })
+})

--- a/packages/core/contexts/editor.reducer.ts
+++ b/packages/core/contexts/editor.reducer.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import EditorActions from './editor.actions'
 import { Visualization } from '@cdc/core/types/Visualization'
 import { devToolsWrapper } from '@cdc/core/helpers/withDevTools'
@@ -24,6 +23,7 @@ const reducer = (state: EditorState, action: EditorActions): EditorState => {
       const { dataset, datasetKey, oldDatasetKey } = action.payload
       const oldDataset = oldDatasetKey ? state.config?.datasets[oldDatasetKey] : {}
       const config = cloneConfig(state.config)
+      const nextDatasets = cloneDatasets(config.datasets, currentDataset => ({ ...currentDataset, preview: false }))
       if (oldDatasetKey) {
         const changeDatasets = _config => {
           _config.rows?.forEach(row => {
@@ -38,16 +38,15 @@ const reducer = (state: EditorState, action: EditorActions): EditorState => {
           })
         }
         applyMultiDashboards(config, changeDatasets)
-        delete config.datasets[oldDatasetKey]
+        delete nextDatasets[oldDatasetKey]
       }
-      Object.values(config.datasets).forEach(dataset => {
-        dataset.preview = false
-      })
-      config.datasets[datasetKey] = { ...oldDataset, ...dataset }
+      nextDatasets[datasetKey] = { ...oldDataset, ...dataset }
+      config.datasets = nextDatasets
       return { ...state, config }
     }
     case 'DELETE_DASHBOARD_DATASET': {
       const { datasetKey } = action.payload
+      const wasPreviewDataset = !!state.config?.datasets?.[datasetKey]?.preview
       const deleteDatasetKeys = _config => {
         _config.rows?.forEach(row => {
           if (row.dataKey === datasetKey) {
@@ -62,7 +61,11 @@ const reducer = (state: EditorState, action: EditorActions): EditorState => {
       }
       const config = cloneConfig(state.config)
       applyMultiDashboards(config, deleteDatasetKeys)
-      delete config.datasets[datasetKey]
+      const nextDatasets = cloneDatasets(config.datasets, currentDataset => currentDataset, datasetKey)
+      if (wasPreviewDataset) {
+        selectFallbackPreviewDataset(nextDatasets)
+      }
+      config.datasets = nextDatasets
       return { ...state, config }
     }
     case 'EDITOR_TEMP_SAVE': {
@@ -89,6 +92,30 @@ const applyMultiDashboards = (config: Record<string, any>, mutationFunc: Functio
     })
   }
   mutationFunc(config)
+}
+
+const cloneDatasets = (
+  datasets: Record<string, any> = {},
+  transform = dataset => dataset,
+  omittedDatasetKey?: string
+) =>
+  // Rebuild the dataset map with fresh dataset objects so React can observe dataset-level changes.
+  Object.fromEntries(
+    Object.entries(datasets)
+      .filter(([key]) => key !== omittedDatasetKey)
+      .map(([key, dataset]) => [key, transform({ ...dataset })])
+  )
+
+const selectFallbackPreviewDataset = (datasets: Record<string, any>) => {
+  // Keep preview ownership explicit after deletion so the editor never depends on stale flags.
+  Object.values(datasets).forEach((dataset: any) => {
+    dataset.preview = false
+  })
+
+  const nextPreviewDataset = Object.values(datasets).find((dataset: any) => Array.isArray(dataset.data))
+  if (nextPreviewDataset) {
+    nextPreviewDataset.preview = true
+  }
 }
 
 export default devToolsWrapper<EditorState, EditorActions>(reducer)

--- a/packages/editor/src/components/PreviewDataTable.test.tsx
+++ b/packages/editor/src/components/PreviewDataTable.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import ConfigContext, { EditorDispatchContext } from '@cdc/core/contexts/EditorContext'
+import PreviewDataTable from './PreviewDataTable'
+
+describe('PreviewDataTable', () => {
+  const renderPreview = config => {
+    const dispatch = vi.fn()
+
+    return render(
+      <ConfigContext.Provider
+        value={
+          {
+            config,
+            errors: [],
+            currentViewport: 'lg',
+            globalActive: 1,
+            setTempConfig: vi.fn()
+          } as any
+        }
+      >
+        <EditorDispatchContext.Provider value={dispatch}>
+          <PreviewDataTable />
+        </EditorDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+  }
+
+  it('updates the rendered preview rows when the dashboard preview source changes', async () => {
+    const initialConfig = {
+      type: 'dashboard',
+      datasets: {
+        source_a: {
+          data: [{ label: 'Old Source Row', value: 'A' }],
+          preview: true
+        },
+        source_b: {
+          data: [{ label: 'Secondary Row', value: 'B' }],
+          preview: false
+        }
+      }
+    }
+
+    const nextConfig = {
+      ...initialConfig,
+      datasets: {
+        source_b: {
+          data: [{ label: 'New Source Row', value: 'B2' }],
+          preview: true
+        },
+        source_a: {
+          data: [{ label: 'Old Source Row', value: 'A' }],
+          preview: false
+        }
+      }
+    }
+
+    const view = renderPreview(initialConfig)
+
+    expect(await screen.findByText('Old Source Row')).toBeInTheDocument()
+    expect(screen.queryByText('New Source Row')).not.toBeInTheDocument()
+
+    view.rerender(
+      <ConfigContext.Provider
+        value={
+          {
+            config: nextConfig,
+            errors: [],
+            currentViewport: 'lg',
+            globalActive: 1,
+            setTempConfig: vi.fn()
+          } as any
+        }
+      >
+        <EditorDispatchContext.Provider value={vi.fn()}>
+          <PreviewDataTable />
+        </EditorDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('New Source Row')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Old Source Row')).not.toBeInTheDocument()
+  })
+
+  it('shows another loaded dataset after the active preview dataset is removed', async () => {
+    const initialConfig = {
+      type: 'dashboard',
+      datasets: {
+        source_a: {
+          data: [{ label: 'Removed Source Row', value: 'A' }],
+          preview: true
+        },
+        source_b: {
+          data: [{ label: 'Fallback Source Row', value: 'B' }],
+          preview: false
+        }
+      }
+    }
+
+    const nextConfig = {
+      type: 'dashboard',
+      datasets: {
+        source_b: {
+          data: [{ label: 'Fallback Source Row', value: 'B' }],
+          preview: true
+        }
+      }
+    }
+
+    const view = renderPreview(initialConfig)
+
+    expect(await screen.findByText('Removed Source Row')).toBeInTheDocument()
+
+    view.rerender(
+      <ConfigContext.Provider
+        value={
+          {
+            config: nextConfig,
+            errors: [],
+            currentViewport: 'lg',
+            globalActive: 1,
+            setTempConfig: vi.fn()
+          } as any
+        }
+      >
+        <EditorDispatchContext.Provider value={vi.fn()}>
+          <PreviewDataTable />
+        </EditorDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Fallback Source Row')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Removed Source Row')).not.toBeInTheDocument()
+  })
+
+  it('returns to the initial empty preview when the final dataset is removed', async () => {
+    const initialConfig = {
+      type: 'dashboard',
+      datasets: {
+        source_a: {
+          data: [{ label: 'Last Source Row', value: 'A' }],
+          preview: true
+        }
+      }
+    }
+
+    const nextConfig = {
+      type: 'dashboard',
+      datasets: {}
+    }
+
+    const view = renderPreview(initialConfig)
+
+    expect(await screen.findByText('Last Source Row')).toBeInTheDocument()
+
+    view.rerender(
+      <ConfigContext.Provider
+        value={
+          {
+            config: nextConfig,
+            errors: [],
+            currentViewport: 'lg',
+            globalActive: 1,
+            setTempConfig: vi.fn()
+          } as any
+        }
+      >
+        <EditorDispatchContext.Provider value={vi.fn()}>
+          <PreviewDataTable />
+        </EditorDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('No Data')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Import data to preview')).toBeInTheDocument()
+    expect(screen.queryByText('Last Source Row')).not.toBeInTheDocument()
+  })
+})

--- a/packages/editor/src/components/PreviewDataTable.tsx
+++ b/packages/editor/src/components/PreviewDataTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useMemo, useCallback, useEffect, useRef, memo } from 'react'
+import React, { useState, useContext, useMemo, useEffect, useRef, memo } from 'react'
 import {
   useTable,
   useBlockLayout,
@@ -18,7 +18,6 @@ import { GrFormPrevious } from 'react-icons/gr'
 import validateFipsCodeLength from '@cdc/core/helpers/validateFipsCodeLength'
 import { errorMessages } from '../helpers/errorMessages'
 import { DataSet } from '@cdc/core/types/DataSet'
-import Icon from '@cdc/core/components/ui/Icon'
 import Button from '@cdc/core/components/elements/Button'
 
 const TableFilter = memo(({ globalFilter, setGlobalFilter = () => {}, disabled = false }: any) => {
@@ -113,7 +112,12 @@ const PreviewDataTable = () => {
     return normalizedData
   }
   const setTableData = td => {
-    if (!Array.isArray(td) || td.length === 0) return
+    if (!Array.isArray(td) || td.length === 0) {
+      // When the active dataset is removed, clear the cached source so the placeholder can render again.
+      lastDataSourceRef.current = null
+      _setTableData(null)
+      return
+    }
     if (lastDataSourceRef.current === td) return
 
     lastDataSourceRef.current = td
@@ -145,6 +149,10 @@ const PreviewDataTable = () => {
     const loadData = async () => {
       if (!config.data) {
         if (config.type === 'dashboard') {
+          if (!previewData) {
+            setTableData(null)
+            return
+          }
           await handleDashboardData(config.datasets)
         } else {
           if (config.dataUrl) {


### PR DESCRIPTION
This pull request improves the handling of dashboard datasets in the editor, ensuring that dataset replacement and deletion are performed immutably and that the preview dataset is always up-to-date and consistent. It also adds comprehensive tests for these behaviors and updates the preview data table component to handle dataset changes more robustly.

**Dashboard dataset management improvements:**

* Refactored the reducer logic in `editor.reducer.ts` to immutably update the `datasets` object when replacing or deleting dashboard datasets, ensuring React can detect dataset-level changes. Added `cloneDatasets` and `selectFallbackPreviewDataset` helpers to facilitate this. Now, when a preview dataset is deleted, another loaded dataset is marked as preview if available, and the preview flag is never stale. [[1]](diffhunk://#diff-2237f2f843883d36918ef9ceffd1346eb21b2ceceffaded430dc688f8d589d68R26) [[2]](diffhunk://#diff-2237f2f843883d36918ef9ceffd1346eb21b2ceceffaded430dc688f8d589d68L41-R49) [[3]](diffhunk://#diff-2237f2f843883d36918ef9ceffd1346eb21b2ceceffaded430dc688f8d589d68L65-R68) [[4]](diffhunk://#diff-2237f2f843883d36918ef9ceffd1346eb21b2ceceffaded430dc688f8d589d68R97-R120)
* Removed the unused lodash import from `editor.reducer.ts` for cleaner code.

**Testing enhancements:**

* Added new tests in `editor.reducer.test.ts` to cover immutable dataset replacement, correct preview assignment on dataset change or deletion, and fallback behavior when no datasets remain.
* Added tests for `PreviewDataTable` to verify that the preview updates correctly when datasets change, fallbacks occur, or all datasets are removed.

**Preview table robustness:**

* Updated `PreviewDataTable.tsx` to clear cached preview data when the active dataset is removed, ensuring the "No Data" placeholder renders correctly. The component now also handles the absence of a preview dataset gracefully. [[1]](diffhunk://#diff-e56eb53fe007d023dddf77d9d317cc8526f57ef5e00565720486196ff529af77L116-R120) [[2]](diffhunk://#diff-e56eb53fe007d023dddf77d9d317cc8526f57ef5e00565720486196ff529af77R152-R155)
* Cleaned up unused imports in `PreviewDataTable.tsx`. [[1]](diffhunk://#diff-e56eb53fe007d023dddf77d9d317cc8526f57ef5e00565720486196ff529af77L1-R1) [[2]](diffhunk://#diff-e56eb53fe007d023dddf77d9d317cc8526f57ef5e00565720486196ff529af77L21)

These changes together ensure that dashboard dataset updates are consistent, predictable, and thoroughly tested.