### PR TITLE
Fix: Suppress small multiple synchronized tooltip when x value doesn't exist

### DIFF
--- a/packages/chart/src/components/Axis/BottomAxis.tsx
+++ b/packages/chart/src/components/Axis/BottomAxis.tsx
@@ -205,7 +205,7 @@ const BottomAxis: React.FC<BottomAxisProps> = ({
               const tickLength = showTick === 'block' ? MAJOR_TICK_LENGTH : DEFAULT_TICK_LENGTH
               const to = { x: tick.to.x, y: tickLength }
               const tickSlotWidth = filteredTicks.length > 0 ? xMax / filteredTicks.length : xMax
-              const limitedWidth = Math.max(Math.min(maxLengthOfTick, tickSlotWidth), 0)
+              const limitedWidth = Math.max(Math.min(maxLengthOfTick, tickSlotWidth), 1)
 
               // Configure rotation using effective values (computed above without mutations)
               const tickRotation =

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -451,6 +451,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   const internalSvgRef = useProgrammaticTooltip({
     svgRef,
     getCoordinateFromXValue,
+    getXValueFromCoordinate,
     config,
     yAxisWidth,
     setPoint,

--- a/packages/chart/src/hooks/useProgrammaticTooltip.ts
+++ b/packages/chart/src/hooks/useProgrammaticTooltip.ts
@@ -3,6 +3,7 @@ import { useRef, useImperativeHandle, ForwardedRef } from 'react'
 interface UseProgrammaticTooltipProps {
   svgRef: ForwardedRef<SVGAElement>
   getCoordinateFromXValue: (xAxisValue: any) => number
+  getXValueFromCoordinate: (xCoordinate: number) => any
   config: any
   yAxisWidth: number
   setPoint: (point: { x: number; y: number }) => void
@@ -19,6 +20,7 @@ interface UseProgrammaticTooltipProps {
 export const useProgrammaticTooltip = ({
   svgRef,
   getCoordinateFromXValue,
+  getXValueFromCoordinate,
   config,
   yAxisWidth,
   setPoint,
@@ -64,6 +66,15 @@ export const useProgrammaticTooltip = ({
           }
 
           const pixelX = getCoordinateFromXValue(xAxisValue)
+          const resolvedXValue = Number.isFinite(pixelX) ? getXValueFromCoordinate(pixelX) : null
+
+          if (!Number.isFinite(pixelX) || resolvedXValue !== xAxisValue) {
+            hideTooltip()
+            setShowHoverLine(false)
+            setSynchronizedXValue?.(null)
+            return
+          }
+
           const adjustedX = pixelX + yAxisWidth
 
           const svgRect = internalSvgRef.current!.getBoundingClientRect()
@@ -105,6 +116,7 @@ export const useProgrammaticTooltip = ({
     },
     [
       getCoordinateFromXValue,
+      getXValueFromCoordinate,
       yAxisWidth,
       config.visualizationType,
       setPoint,


### PR DESCRIPTION
## Summary

Suppresses the small multiple synchronized tooltip in other charts when x value doesn't exist.