### PR TITLE
Fix some legend spacing

### DIFF
--- a/packages/chart/src/components/Legend/LegendGroup/LegendGroup.styles.css
+++ b/packages/chart/src/components/Legend/LegendGroup/LegendGroup.styles.css
@@ -17,6 +17,11 @@
     }
   }
 
+  .legend-group-grid {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
   .legend-group.top,
   .legend-group.bottom {
     grid-gap: 10px;

--- a/packages/chart/src/components/Legend/LegendGroup/LegendGroup.tsx
+++ b/packages/chart/src/components/Legend/LegendGroup/LegendGroup.tsx
@@ -32,7 +32,7 @@ const LegendGroup = ({ formatLabels }) => {
 
   const groups: string[] = getSubGroups(data, config.legend.groupBy)
 
-  const classNames = ['legend-group', 'container', config.legend.position, currentViewport, 'row']
+  const classNames = ['legend-group', 'legend-group-grid', 'container', config.legend.position, currentViewport]
 
   const gridCol =
     currentViewport === 'xs'
@@ -46,6 +46,8 @@ const LegendGroup = ({ formatLabels }) => {
   const isSigleCol = config.legend.position === 'bottom' || config.legend.position === 'top' ? gridCol : 'col-12'
 
   let classNameItem = ['legend-group group-item', isSigleCol]
+
+  if (groups.length === 0) return null
 
   return (
     <div className={classNames.join(' ')}>

--- a/packages/chart/src/components/Legend/helpers/index.ts
+++ b/packages/chart/src/components/Legend/helpers/index.ts
@@ -40,8 +40,6 @@ export const getMarginBottom = (isLegendBottom, config) => {
 
   if (isLegendTop) marginBottom = 27
 
-  if (isLegendTop && config.yAxis?.inlineLabel) marginBottom += 9
-
   if (isLegendBottom) marginBottom += 9
 
   if (hasSuppression) marginBottom += 40


### PR DESCRIPTION
## Summary

Fixes some minor legend spacing issues. Legend groups were rendering an empty div that took up space, even when the legend contained no groups.

The bug timeline:

* grouped legends introduced an internal .row class in March 2025
* dashboard .row got broad spacing in January 2026
* that made the legend-group collision much more obvious in dashboards