### PR TITLE
Fix initialization type for waffle charts

### DIFF
--- a/packages/dashboard/src/components/VisualizationsPanel/VisualizationsPanel.tsx
+++ b/packages/dashboard/src/components/VisualizationsPanel/VisualizationsPanel.tsx
@@ -43,7 +43,7 @@ const VisualizationsPanel = () => {
       <span className='subheading-3'>Misc.</span>
       <div className='drag-grid'>
         <Widget addVisualization={() => addVisualization('data-bite', '')} type='data-bite' />
-        <Widget addVisualization={() => addVisualization('waffle-chart', '')} type='waffle-chart' />
+        <Widget addVisualization={() => addVisualization('waffle-chart', 'Waffle')} type='waffle-chart' />
         <Widget addVisualization={() => addVisualization('markup-include', '')} type='markup-include' />
         <Widget addVisualization={() => addVisualization('filtered-text', '')} type='filtered-text' />
         <Widget addVisualization={() => addVisualization('dashboardFilters', '')} type='dashboardFilters' />

--- a/packages/dashboard/src/helpers/addVisualization.ts
+++ b/packages/dashboard/src/helpers/addVisualization.ts
@@ -35,9 +35,11 @@ export const addVisualization = (type, subType) => {
       }
       break
     case 'data-bite':
-    case 'waffle-chart':
     case 'filtered-text':
       newVisualizationConfig.visualizationType = type
+      break
+    case 'waffle-chart':
+      newVisualizationConfig.visualizationType = subType
       break
     case 'table': {
       const tableConfig: Table = {

--- a/packages/dashboard/src/helpers/tests/addVisualization.test.ts
+++ b/packages/dashboard/src/helpers/tests/addVisualization.test.ts
@@ -46,7 +46,7 @@ describe('addVisualization', () => {
     vi.spyOn(Date, 'now').mockReturnValue(12345)
 
     expect(addVisualization('data-bite')).toMatchObject({ visualizationType: 'data-bite' })
-    expect(addVisualization('waffle-chart')).toMatchObject({ visualizationType: 'waffle-chart' })
+    expect(addVisualization('waffle-chart', 'Waffle')).toMatchObject({ visualizationType: 'Waffle' })
     expect(addVisualization('filtered-text')).toMatchObject({ visualizationType: 'filtered-text' })
   })
 })


### PR DESCRIPTION
## Summary

This fixes an issue with waffle charts created in the editor and sets the `visualizationType` field correctly. It was introduced in [this PR](https://github.com/CDCgov/cdc-open-viz/commit/fe5fad203f7a0ec3c5d99c9db7788c68f5208b62#diff-8ab90418333d5872817eec654ce970ee50be73b43beaa21fb27233a797deb13b).
