### PR TITLE
fix: annotation alignment bug

### DIFF
--- a/packages/chart/src/components/Annotations/components/AnnotationDraggable.tsx
+++ b/packages/chart/src/components/Annotations/components/AnnotationDraggable.tsx
@@ -218,7 +218,7 @@ const Annotations = ({
               return (
                 <HtmlLabel
                   className='annotation__desktop-label'
-                  containerStyle={{ width: `${labelWidth}px` }}
+                  containerStyle={{ width: 'fit-content', maxWidth: `${labelWidth}px` }}
                   horizontalAnchor={horizontalAnchor}
                   verticalAnchor={verticalAnchor}
                   showAnchorLine={false}


### PR DESCRIPTION
## Summary
Short text is not aligned when positioned above or to the left because of the hard coded width. this makes the width fit-content so it shrinks accordingly and appears centered

## Testing Steps
Create a very short annotation on a chart and position it above the arrow to confirm it is still aligned