### PR TITLE
Ensure migrations always run on waffle charts

### DIFF
--- a/packages/waffle-chart/src/CdcWaffleChart.tsx
+++ b/packages/waffle-chart/src/CdcWaffleChart.tsx
@@ -912,10 +912,11 @@ const CdcWaffleChart = ({
     }
   }, [config, container])
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+  // Keep direct config-prop usage in sync with parent data updates
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (!configObj?.dataUrl) {
-      updateConfig({ ...defaults, ...configObj })
+    if (configObj && config && JSON.stringify(configObj.data) !== JSON.stringify(config.data)) {
+      loadConfig().catch(err => console.warn(err))
     }
   }, [configObj?.data])
 

--- a/packages/waffle-chart/src/_stories/WaffleChart.smoke.stories.tsx
+++ b/packages/waffle-chart/src/_stories/WaffleChart.smoke.stories.tsx
@@ -5,7 +5,7 @@ import { expect } from 'storybook/test'
 import WaffleChart from '../CdcWaffleChart'
 import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
 import MinimalExampleConfig from '../../examples/minimal-example.json'
-import LegacyCountExampleConfig from '../../examples/private/waffle-chart-example-count.json'
+import LegacyCountExampleConfig from '../../tests/fixtures/legacy-count-config.json'
 
 const meta: Meta<typeof WaffleChart> = {
   title: 'Components/Templates/WaffleChart',

--- a/packages/waffle-chart/src/_stories/WaffleChart.smoke.stories.tsx
+++ b/packages/waffle-chart/src/_stories/WaffleChart.smoke.stories.tsx
@@ -5,6 +5,7 @@ import { expect } from 'storybook/test'
 import WaffleChart from '../CdcWaffleChart'
 import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
 import MinimalExampleConfig from '../../examples/minimal-example.json'
+import LegacyCountExampleConfig from '../../examples/private/waffle-chart-example-count.json'
 
 const meta: Meta<typeof WaffleChart> = {
   title: 'Components/Templates/WaffleChart',
@@ -195,6 +196,26 @@ export const Gauge: Story = {
   ),
   play: async ({ canvasElement }) => {
     await assertVisualizationRendered(canvasElement)
+  }
+}
+
+export const Legacy_Count_Config_Prop_Path: Story = {
+  args: {
+    config: JSON.parse(JSON.stringify(LegacyCountExampleConfig))
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Loads the legacy count example through the direct config prop path used by dashboard/editor-style renderers. Useful for reproducing config-object initialization behavior without going through configUrl.'
+      }
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    const primaryValue = canvasElement.querySelector('.cove-waffle-chart__data--primary') as HTMLElement | null
+    expect(primaryValue).toBeTruthy()
   }
 }
 

--- a/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
+++ b/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
@@ -6,6 +6,7 @@ import { render, waitFor } from '@testing-library/react'
 import { testStandaloneBuild } from '@cdc/core/helpers/tests/testStandaloneBuild.ts'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import CdcWaffleChart from '../CdcWaffleChart'
+import legacyCountExampleConfig from '../../examples/private/waffle-chart-example-count.json'
 
 vi.mock('resize-observer-polyfill', () => ({
   default: vi.fn(() => ({
@@ -40,6 +41,7 @@ const extractMarkedExampleConfig = (content, label) => {
 describe('Waffle Chart', () => {
   const createBaseConfig = overrides => ({
     type: 'waffle-chart',
+    version: '4.26.4-1',
     title: 'Test Waffle',
     showTitle: true,
     visualizationType: 'Waffle',
@@ -121,6 +123,19 @@ describe('Waffle Chart', () => {
 
     expect(readmeBlock).toEqual(minimalExample)
     expect(minimalExample.version).toBeTruthy()
+  })
+
+  it('renders the legacy count example through the direct config prop path', async () => {
+    const config = JSON.parse(JSON.stringify(legacyCountExampleConfig))
+
+    const { container } = render(<CdcWaffleChart config={config} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('.cove-waffle-chart')).toBeInTheDocument()
+    })
+
+    expect(getPrimaryValueText(container)).toBeTruthy()
+    expect(getPrimaryValueText(container)).not.toContain('out of')
   })
 
   it('moves the trend indicator below the value when a trend label is configured', async () => {

--- a/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
+++ b/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
@@ -6,7 +6,7 @@ import { render, waitFor } from '@testing-library/react'
 import { testStandaloneBuild } from '@cdc/core/helpers/tests/testStandaloneBuild.ts'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import CdcWaffleChart from '../CdcWaffleChart'
-import legacyCountExampleConfig from '../../examples/private/waffle-chart-example-count.json'
+import legacyCountExampleConfig from '../../tests/fixtures/legacy-count-config.json'
 
 vi.mock('resize-observer-polyfill', () => ({
   default: vi.fn(() => ({

--- a/packages/waffle-chart/tests/fixtures/legacy-count-config.json
+++ b/packages/waffle-chart/tests/fixtures/legacy-count-config.json
@@ -1,0 +1,95 @@
+{
+  "title": "Legacy Count Waffle",
+  "showTitle": true,
+  "visualizationType": "Waffle",
+  "visualizationSubType": "linear",
+  "showPercent": true,
+  "showDenominator": true,
+  "valueDescription": "out of",
+  "content": "Of all inputs are from Federal sources",
+  "subtext": "",
+  "orientation": "horizontal",
+  "data": [
+    {
+      "Location": "Alaska",
+      "Year": "2021",
+      "Type": "Federal",
+      "Amount": "1436"
+    },
+    {
+      "Location": "Alaska",
+      "Year": "2021",
+      "Type": "Local",
+      "Amount": "1672"
+    },
+    {
+      "Location": "Alaska",
+      "Year": "2021",
+      "Type": "State",
+      "Amount": "1554"
+    },
+    {
+      "Location": "Alabama",
+      "Year": "2021",
+      "Type": "Federal",
+      "Amount": "1434"
+    },
+    {
+      "Location": "Alabama",
+      "Year": "2021",
+      "Type": "Local",
+      "Amount": "1670"
+    },
+    {
+      "Location": "Alabama",
+      "Year": "2021",
+      "Type": "State",
+      "Amount": "1552"
+    }
+  ],
+  "filters": [],
+  "fontSize": "",
+  "overallFontSize": "medium",
+  "dataColumn": "Amount",
+  "dataFunction": "Count",
+  "dataConditionalColumn": "Type",
+  "dataConditionalOperator": "=",
+  "dataConditionalComparate": "Federal",
+  "invalidComparate": false,
+  "customDenom": true,
+  "dataDenom": "100",
+  "dataDenomColumn": "Amount",
+  "dataDenomFunction": "Count",
+  "suffix": "%",
+  "roundToPlace": "0",
+  "shape": "square",
+  "nodeWidth": "13",
+  "nodeSpacer": "2",
+  "theme": "theme-green",
+  "type": "waffle-chart",
+  "gauge": {
+    "height": 35,
+    "width": "100%"
+  },
+  "visual": {
+    "border": true,
+    "accent": false,
+    "background": false,
+    "hideBackgroundColor": false,
+    "borderColorTheme": false,
+    "colors": {
+      "theme-blue": "#005eaa",
+      "theme-purple": "#712177",
+      "theme-brown": "#705043",
+      "theme-teal": "#00695c",
+      "theme-pink": "#af4448",
+      "theme-orange": "#bb4d00",
+      "theme-slate": "#29434e",
+      "theme-indigo": "#26418f",
+      "theme-cyan": "#006778",
+      "theme-green": "#4b830d",
+      "theme-amber": "#fbab18"
+    }
+  },
+  "version": "4.24.9"
+}


### PR DESCRIPTION
## Summary

Ensure migrations always run on waffle charts.

This fixes a bug introduced in https://github.com/CDCgov/cdc-open-viz/commit/a7e6c4f08bf47aaef26f7c115ea9b9e8ed92d1fe. The bug affected waffle charts loaded through the direct config prop path (which WCMS does) without a dataUrl, where incoming prop data updates caused the component to overwrite migrated state with the raw unmigrated config.

## Testing Steps

The [new story](http://localhost:6006/?path=/story/components-templates-wafflechart--legacy-count-config-prop-path) should not display "out of" in the waffle chart.