### PR TITLE
DEV-12107 State Zoom failsafe when unexpected state column name used, and add "jurisdiction" as column name

### DIFF
--- a/packages/chart/src/components/Annotations/components/AnnotationDraggable.tsx
+++ b/packages/chart/src/components/Annotations/components/AnnotationDraggable.tsx
@@ -218,7 +218,7 @@ const Annotations = ({
               return (
                 <HtmlLabel
                   className='annotation__desktop-label'
-                  containerStyle={{ width: `${labelWidth}px` }}
+                  containerStyle={{ width: 'fit-content', maxWidth: `${labelWidth}px` }}
                   horizontalAnchor={horizontalAnchor}
                   verticalAnchor={verticalAnchor}
                   showAnchorLine={false}

--- a/packages/chart/src/components/Axis/BottomAxis.tsx
+++ b/packages/chart/src/components/Axis/BottomAxis.tsx
@@ -205,7 +205,7 @@ const BottomAxis: React.FC<BottomAxisProps> = ({
               const tickLength = showTick === 'block' ? MAJOR_TICK_LENGTH : DEFAULT_TICK_LENGTH
               const to = { x: tick.to.x, y: tickLength }
               const tickSlotWidth = filteredTicks.length > 0 ? xMax / filteredTicks.length : xMax
-              const limitedWidth = Math.max(Math.min(maxLengthOfTick, tickSlotWidth), 0)
+              const limitedWidth = Math.max(Math.min(maxLengthOfTick, tickSlotWidth), 1)
 
               // Configure rotation using effective values (computed above without mutations)
               const tickRotation =

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, memo, useContext, useMemo } from 'react'
 import { Draggable } from '@hello-pangea/dnd'
 import chroma from 'chroma-js'
-import { isDateScale } from '@cdc/core/helpers/cove/date'
+import { getAutoDetectedDateParseFormat, isDateScale } from '@cdc/core/helpers/cove/date'
 import {
   Accordion,
   AccordionItem,
@@ -967,6 +967,17 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
   }
 
   const updateField = updateFieldFactory(config, updateConfig)
+  const getAutoDetectedXAxisDateParseFormat = (dataKey = config.xAxis.dataKey, axisType = config.xAxis.type) => {
+    const hasExistingDateParseFormat =
+      typeof config.xAxis.dateParseFormat === 'string' && config.xAxis.dateParseFormat.trim() !== ''
+
+    if (hasExistingDateParseFormat || !['date', 'date-time'].includes(axisType)) {
+      return undefined
+    }
+
+    return getAutoDetectedDateParseFormat(config.data, dataKey)
+  }
+
   const updateFieldDeprecated = (section, subsection, fieldName, newValue) => {
     if (isDebug)
       console.error(
@@ -1009,6 +1020,23 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
       })
       return
     }
+
+    if (section === 'xAxis' && !truthy(subsection) && fieldName === 'dataKey') {
+      const autoDetectedDateParseFormat = getAutoDetectedXAxisDateParseFormat(newValue)
+      const updatedConfig = {
+        ...config,
+        xAxis: {
+          ...config.xAxis,
+          dataKey: newValue,
+          ...(autoDetectedDateParseFormat ? { dateParseFormat: autoDetectedDateParseFormat } : {})
+        }
+      }
+
+      enforceRestrictions(updatedConfig)
+      updateConfig(updatedConfig)
+      return
+    }
+
     if (null === section && null === subsection) {
       // special case that allows for updating the config object directly
       if (!truthy(fieldName)) console.error('fieldName is required')
@@ -2903,11 +2931,19 @@ const EditorPanel: React.FC<ChartEditorPanelProps> = ({ datasets }) => {
                                 section='xAxis'
                                 fieldName='type'
                                 updateField={(_section, _subsection, _fieldName, value) => {
+                                  const autoDetectedDateParseFormat = getAutoDetectedXAxisDateParseFormat(
+                                    config.xAxis.dataKey,
+                                    value
+                                  )
+
                                   updateConfig({
                                     ...config,
                                     xAxis: {
                                       ...config.xAxis,
-                                      type: value
+                                      type: value,
+                                      ...(autoDetectedDateParseFormat
+                                        ? { dateParseFormat: autoDetectedDateParseFormat }
+                                        : {})
                                     }
                                   })
                                 }}

--- a/packages/chart/src/components/Legend/LegendGroup/LegendGroup.styles.css
+++ b/packages/chart/src/components/Legend/LegendGroup/LegendGroup.styles.css
@@ -17,6 +17,11 @@
     }
   }
 
+  .legend-group-grid {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
   .legend-group.top,
   .legend-group.bottom {
     grid-gap: 10px;

--- a/packages/chart/src/components/Legend/LegendGroup/LegendGroup.tsx
+++ b/packages/chart/src/components/Legend/LegendGroup/LegendGroup.tsx
@@ -32,7 +32,7 @@ const LegendGroup = ({ formatLabels }) => {
 
   const groups: string[] = getSubGroups(data, config.legend.groupBy)
 
-  const classNames = ['legend-group', 'container', config.legend.position, currentViewport, 'row']
+  const classNames = ['legend-group', 'legend-group-grid', 'container', config.legend.position, currentViewport]
 
   const gridCol =
     currentViewport === 'xs'
@@ -46,6 +46,8 @@ const LegendGroup = ({ formatLabels }) => {
   const isSigleCol = config.legend.position === 'bottom' || config.legend.position === 'top' ? gridCol : 'col-12'
 
   let classNameItem = ['legend-group group-item', isSigleCol]
+
+  if (groups.length === 0) return null
 
   return (
     <div className={classNames.join(' ')}>

--- a/packages/chart/src/components/Legend/helpers/index.ts
+++ b/packages/chart/src/components/Legend/helpers/index.ts
@@ -40,8 +40,6 @@ export const getMarginBottom = (isLegendBottom, config) => {
 
   if (isLegendTop) marginBottom = 27
 
-  if (isLegendTop && config.yAxis?.inlineLabel) marginBottom += 9
-
   if (isLegendBottom) marginBottom += 9
 
   if (hasSuppression) marginBottom += 40

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -451,6 +451,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
   const internalSvgRef = useProgrammaticTooltip({
     svgRef,
     getCoordinateFromXValue,
+    getXValueFromCoordinate,
     config,
     yAxisWidth,
     setPoint,

--- a/packages/chart/src/hooks/useProgrammaticTooltip.ts
+++ b/packages/chart/src/hooks/useProgrammaticTooltip.ts
@@ -3,6 +3,7 @@ import { useRef, useImperativeHandle, ForwardedRef } from 'react'
 interface UseProgrammaticTooltipProps {
   svgRef: ForwardedRef<SVGAElement>
   getCoordinateFromXValue: (xAxisValue: any) => number
+  getXValueFromCoordinate: (xCoordinate: number) => any
   config: any
   yAxisWidth: number
   setPoint: (point: { x: number; y: number }) => void
@@ -19,6 +20,7 @@ interface UseProgrammaticTooltipProps {
 export const useProgrammaticTooltip = ({
   svgRef,
   getCoordinateFromXValue,
+  getXValueFromCoordinate,
   config,
   yAxisWidth,
   setPoint,
@@ -64,6 +66,15 @@ export const useProgrammaticTooltip = ({
           }
 
           const pixelX = getCoordinateFromXValue(xAxisValue)
+          const resolvedXValue = Number.isFinite(pixelX) ? getXValueFromCoordinate(pixelX) : null
+
+          if (!Number.isFinite(pixelX) || resolvedXValue !== xAxisValue) {
+            hideTooltip()
+            setShowHoverLine(false)
+            setSynchronizedXValue?.(null)
+            return
+          }
+
           const adjustedX = pixelX + yAxisWidth
 
           const svgRect = internalSvgRef.current!.getBoundingClientRect()
@@ -105,6 +116,7 @@ export const useProgrammaticTooltip = ({
     },
     [
       getCoordinateFromXValue,
+      getXValueFromCoordinate,
       yAxisWidth,
       config.visualizationType,
       setPoint,

--- a/packages/core/CONFIG.md
+++ b/packages/core/CONFIG.md
@@ -42,9 +42,9 @@ Use these values anywhere a package accepts a shared theme token.
 
 | Type | Description | Format |
 | --- | --- | --- |
-| `string` | Semantic version string used to record the COVE version associated with a saved config. | `<major>.<minor>.<patch>` or `<major>.<minor>.<patch>-<label>` |
+| `string` | Semantic version string used to record the COVE version associated with a saved config. Plain three-part versions are the normal case. Config migration ordering is guaranteed for `<major>.<minor>.<patch>` and versions with a numeric suffix, where a missing suffix is treated as `0`. | `<major>.<minor>.<patch>` or `<major>.<minor>.<patch>-<numeric-suffix>` |
 
-Examples: `4.26.4`, `4.26.4-beta.1`
+Examples: `4.26.4`, `4.26.4-1`
 
 ### `FilterBehavior`
 

--- a/packages/core/components/DataTable/data-table.css
+++ b/packages/core/components/DataTable/data-table.css
@@ -108,6 +108,9 @@
         background-size: 10px 5px;
         color: #fff !important;
         cursor: pointer;
+        a{
+          color: inherit;
+        }
       }
 
       th:last-child,

--- a/packages/core/helpers/cove/date.ts
+++ b/packages/core/helpers/cove/date.ts
@@ -34,6 +34,38 @@ export type DateFormatDetectionResult = {
   failureReason?: 'no_non_empty_values' | 'no_matching_format' | 'ambiguous'
 }
 
+export function getAutoDetectedDateParseFormat(
+  rows: readonly unknown[] | undefined,
+  dataKey: string | undefined
+): AutoDetectDateFormat | undefined {
+  if (!dataKey || !rows?.length) {
+    return undefined
+  }
+
+  const dateDetectionSamples: unknown[] = []
+
+  for (const row of rows) {
+    if (!row || typeof row !== 'object' || !Object.prototype.hasOwnProperty.call(row, dataKey)) {
+      continue
+    }
+
+    const value = (row as Record<string, unknown>)[dataKey]
+    const normalizedValue = typeof value === 'string' ? value.trim() : value
+
+    if (normalizedValue !== null && normalizedValue !== undefined && normalizedValue !== '') {
+      dateDetectionSamples.push(value)
+
+      if (dateDetectionSamples.length >= MAX_AUTO_DETECT_DATE_SAMPLES) {
+        break
+      }
+    }
+  }
+
+  const detection = detectDateParseFormat(dateDetectionSamples)
+
+  return detection.isReliable ? detection.detectedFormat : undefined
+}
+
 /** Locale definitions for d3-time-format. Add new locales here as needed. */
 const localeDefinitions: Record<string, TimeLocaleDefinition> = {
   'es-MX': {

--- a/packages/core/helpers/coveUpdateWorker.ts
+++ b/packages/core/helpers/coveUpdateWorker.ts
@@ -24,6 +24,7 @@ import update_4_26_1 from './ver/4.26.1'
 import update_4_26_2 from './ver/4.26.2'
 import update_4_26_3 from './ver/4.26.3'
 import update_4_26_4 from './ver/4.26.4'
+import update_4_26_4_1 from './ver/4.26.4-1'
 
 import { stripDataFromConfig, restoreDataToConfig } from './configDataHelpers'
 
@@ -54,7 +55,8 @@ export const coveUpdateWorker = (config, multiDashboardVersion?) => {
     ['4.26.1', update_4_26_1],
     ['4.26.2', update_4_26_2],
     ['4.26.3', update_4_26_3],
-    ['4.26.4', update_4_26_4]
+    ['4.26.4', update_4_26_4],
+    ['4.26.4-1', update_4_26_4_1]
   ]
 
   const initialVersion = genConfig.version

--- a/packages/core/helpers/isOlderVersion.ts
+++ b/packages/core/helpers/isOlderVersion.ts
@@ -1,7 +1,10 @@
+import { compareMigrationVersions } from './ver/compareMigrationVersions'
+
 /**
  * Determines if the previous version is older than the current version.
  *
- * This function compares two version strings in the format "major.minor.patch".
+ * This function compares config migration version strings in the format
+ * "major.minor.patch" or "major.minor.patch-numeric-suffix".
  * It returns `true` if the `previousVersion` is older than the `currentVersion`,
  * otherwise it returns `false`.
  *
@@ -11,10 +14,5 @@
  */
 export default function isOlderVersion(previousVersion: string, currentVersion: string): boolean {
   if (!previousVersion) return true
-  const [prevMajor, prevMinor, prevPatch] = previousVersion.split('.').map(Number)
-  const [currMajor, currMinor, currPatch] = currentVersion.split('.').map(Number)
-  if (currMajor > prevMajor) return false
-  if (currMajor === prevMajor && currMinor > prevMinor) return false
-  if (currMajor === prevMajor && currMinor === prevMinor && currPatch > prevPatch) return false
-  return true
+  return compareMigrationVersions(previousVersion, currentVersion) < 0
 }

--- a/packages/core/helpers/tests/date.test.ts
+++ b/packages/core/helpers/tests/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectDateParseFormat, formatDate, getDateRenderFormat } from '../cove/date'
+import { detectDateParseFormat, formatDate, getAutoDetectedDateParseFormat, getDateRenderFormat } from '../cove/date'
 
 const NBSP = '\u00A0'
 
@@ -196,5 +196,70 @@ describe('detectDateParseFormat', () => {
       isReliable: true,
       sampleSize: 50
     })
+  })
+})
+
+describe('getAutoDetectedDateParseFormat', () => {
+  it('detects a reliable format from a selected data key', () => {
+    expect(
+      getAutoDetectedDateParseFormat(
+        [
+          { date: '2024/03/15', value: 10 },
+          { date: '2025/11/09', value: 12 }
+        ],
+        'date'
+      )
+    ).toBe('%Y/%m/%d')
+  })
+
+  it('ignores rows that do not include the selected data key', () => {
+    expect(
+      getAutoDetectedDateParseFormat(
+        [
+          { otherDate: 'ignore-me', value: 8 },
+          { date: '2024/03/15', value: 10 },
+          { date: '2025/11/09', value: 12 }
+        ],
+        'date'
+      )
+    ).toBe('%Y/%m/%d')
+  })
+
+  it('ignores non-row values before sampling matching records', () => {
+    expect(
+      getAutoDetectedDateParseFormat(
+        [null, 'not-a-row', 42, ['2024/03/01'], { date: '2024/03/15' }, { date: '2025/11/09' }],
+        'date'
+      )
+    ).toBe('%Y/%m/%d')
+  })
+
+  it('returns undefined when the sample is ambiguous', () => {
+    expect(
+      getAutoDetectedDateParseFormat(
+        [
+          { date: '01/02/2024', value: 10 },
+          { date: '02/03/2024', value: 12 }
+        ],
+        'date'
+      )
+    ).toBeUndefined()
+  })
+
+  it('stops scanning rows once the auto-detect sample limit is reached', () => {
+    const requiredSamples = Array.from({ length: 50 }, (_, index) => ({
+      date: `2024/03/${String((index % 28) + 1).padStart(2, '0')}`,
+      value: index
+    }))
+
+    const rowAfterSampleLimit: Record<string, unknown> = {}
+    Object.defineProperty(rowAfterSampleLimit, 'date', {
+      enumerable: true,
+      get() {
+        throw new Error('should not read rows after reaching the sample limit')
+      }
+    })
+
+    expect(getAutoDetectedDateParseFormat([...requiredSamples, rowAfterSampleLimit], 'date')).toBe('%Y/%m/%d')
   })
 })

--- a/packages/core/helpers/ver/4.26.4-1.ts
+++ b/packages/core/helpers/ver/4.26.4-1.ts
@@ -1,0 +1,88 @@
+import cloneConfig from '../cloneConfig'
+import { DashboardConfig } from '@cdc/dashboard/src/types/DashboardConfig'
+import { getMarkupVariableSourceType } from '../../types/MarkupVariable'
+
+const addMarkupIncludeStyle = config => {
+  if (config.type === 'markup-include') {
+    if (!config.contentEditor) {
+      config.contentEditor = {}
+    }
+
+    if (!config.contentEditor.style) {
+      config.contentEditor.style = 'default'
+    }
+  }
+}
+
+const fixWaffleType = config => {
+  if (config.type === 'waffle-chart' && config.visualizationType === 'waffle-chart') {
+    config.visualizationType = 'Waffle'
+  }
+}
+
+const applyWaffleValueDescriptorDefaults = config => {
+  if (
+    config.type === 'waffle-chart' &&
+    (config.visualizationType === 'Waffle' || config.visualizationType === 'TP5 Waffle')
+  ) {
+    config.valueDescription = ''
+    config.showPercent = true
+    config.showDenominator = false
+  }
+}
+
+const applyTerritoryMapDefaults = config => {
+  if (config.type !== 'map' || !config.general) return
+  if (config.general.territoriesAlwaysShow === undefined) {
+    config.general.territoriesAlwaysShow = true
+  }
+}
+
+const applyMarkupVariableSourceTypes = config => {
+  if (!Array.isArray(config.markupVariables)) {
+    return
+  }
+
+  config.markupVariables = config.markupVariables.map(variable => {
+    if (!variable) {
+      return variable
+    }
+
+    return {
+      ...variable,
+      sourceType: getMarkupVariableSourceType(variable)
+    }
+  })
+}
+
+const enableFullGeoNameCsvOnLegacyCountyMaps = config => {
+  if (config.type === 'map' && config.general?.geoType === 'us-county') {
+    config.table = config.table || {}
+    config.table.showFullGeoNameInCSV = true
+  }
+}
+
+const run_4_26_4_1_migrations = config => {
+  fixWaffleType(config)
+  addMarkupIncludeStyle(config)
+  applyWaffleValueDescriptorDefaults(config)
+  applyMarkupVariableSourceTypes(config)
+  enableFullGeoNameCsvOnLegacyCountyMaps(config)
+  applyTerritoryMapDefaults(config)
+
+  if (config.type === 'dashboard' && config.visualizations) {
+    Object.values((config as DashboardConfig).visualizations).forEach(visualization => {
+      run_4_26_4_1_migrations(visualization)
+    })
+  }
+}
+
+const update_4_26_4_1 = config => {
+  const ver = '4.26.4-1'
+  const newConfig = cloneConfig(config)
+  run_4_26_4_1_migrations(newConfig)
+  newConfig.version = ver
+  return newConfig
+}
+
+export default update_4_26_4_1

--- a/packages/core/helpers/ver/4.26.4.ts
+++ b/packages/core/helpers/ver/4.26.4.ts
@@ -45,6 +45,7 @@ const applyWaffleValueDescriptorDefaults = config => {
 }
 
 const applyTerritoryMapDefaults = config => {
+  if (config.type !== 'map' || !config.general) return
   if (config.general.territoriesAlwaysShow === undefined) {
     config.general.territoriesAlwaysShow = true
   }

--- a/packages/core/helpers/ver/4.26.4.ts
+++ b/packages/core/helpers/ver/4.26.4.ts
@@ -1,6 +1,5 @@
 import cloneConfig from '../cloneConfig'
 import { DashboardConfig } from '@cdc/dashboard/src/types/DashboardConfig'
-import { getMarkupVariableSourceType } from '../../types/MarkupVariable'
 
 const disableExtraChartVisualSettings = config => {
   if (config.type === 'chart') {
@@ -15,73 +14,8 @@ const disableExtraChartVisualSettings = config => {
   }
 }
 
-const addMarkupIncludeStyle = config => {
-  if (config.type === 'markup-include') {
-    if (!config.contentEditor) {
-      config.contentEditor = {}
-    }
-
-    if (!config.contentEditor.style) {
-      config.contentEditor.style = 'default'
-    }
-  }
-}
-
-const applyWaffleValueDescriptorDefaults = config => {
-  if (
-    config.type === 'waffle-chart' &&
-    (config.visualizationType === 'Waffle' || config.visualizationType === 'TP5 Waffle')
-  ) {
-    config.valueDescription = ''
-    config.showPercent = true
-    config.showDenominator = false
-  }
-
-  if (config.type === 'dashboard' && config.visualizations) {
-    Object.values((config as DashboardConfig).visualizations).forEach(visualization => {
-      applyWaffleValueDescriptorDefaults(visualization)
-    })
-  }
-}
-
-const applyTerritoryMapDefaults = config => {
-  if (config.type !== 'map' || !config.general) return
-  if (config.general.territoriesAlwaysShow === undefined) {
-    config.general.territoriesAlwaysShow = true
-  }
-}
-
-const applyMarkupVariableSourceTypes = config => {
-  if (!Array.isArray(config.markupVariables)) {
-    return
-  }
-
-  config.markupVariables = config.markupVariables.map(variable => {
-    if (!variable) {
-      return variable
-    }
-
-    return {
-      ...variable,
-      sourceType: getMarkupVariableSourceType(variable)
-    }
-  })
-}
-
-const enableFullGeoNameCsvOnLegacyCountyMaps = config => {
-  if (config.type === 'map' && config.general?.geoType === 'us-county') {
-    config.table = config.table || {}
-    config.table.showFullGeoNameInCSV = true
-  }
-}
-
 const run_4_26_4_migrations = config => {
   disableExtraChartVisualSettings(config)
-  addMarkupIncludeStyle(config)
-  applyWaffleValueDescriptorDefaults(config)
-  applyMarkupVariableSourceTypes(config)
-  enableFullGeoNameCsvOnLegacyCountyMaps(config)
-  applyTerritoryMapDefaults(config)
 
   if (config.type === 'dashboard' && config.visualizations) {
     Object.values((config as DashboardConfig).visualizations).forEach(visualization => {

--- a/packages/core/helpers/ver/4.26.4.ts
+++ b/packages/core/helpers/ver/4.26.4.ts
@@ -44,6 +44,12 @@ const applyWaffleValueDescriptorDefaults = config => {
   }
 }
 
+const applyTerritoryMapDefaults = config => {
+  if (config.general.territoriesAlwaysShow === undefined) {
+    config.general.territoriesAlwaysShow = true
+  }
+}
+
 const applyMarkupVariableSourceTypes = config => {
   if (!Array.isArray(config.markupVariables)) {
     return
@@ -74,6 +80,7 @@ const run_4_26_4_migrations = config => {
   applyWaffleValueDescriptorDefaults(config)
   applyMarkupVariableSourceTypes(config)
   enableFullGeoNameCsvOnLegacyCountyMaps(config)
+  applyTerritoryMapDefaults(config)
 
   if (config.type === 'dashboard' && config.visualizations) {
     Object.values((config as DashboardConfig).visualizations).forEach(visualization => {

--- a/packages/core/helpers/ver/compareMigrationVersions.ts
+++ b/packages/core/helpers/ver/compareMigrationVersions.ts
@@ -1,0 +1,34 @@
+type ParsedMigrationVersion = {
+  major: number
+  minor: number
+  patch: number
+  suffix: number
+}
+
+const parseMigrationVersion = (version: string): ParsedMigrationVersion => {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-(\d+))?$/)
+
+  if (!match) {
+    throw new Error(
+      `Invalid migration version "${version}". Expected format "major.minor.patch" or "major.minor.patch-suffix".`
+    )
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    suffix: Number(match[4] ?? 0)
+  }
+}
+
+export const compareMigrationVersions = (leftVersion: string, rightVersion: string): number => {
+  const left = parseMigrationVersion(leftVersion)
+  const right = parseMigrationVersion(rightVersion)
+
+  if (left.major !== right.major) return left.major - right.major
+  if (left.minor !== right.minor) return left.minor - right.minor
+  if (left.patch !== right.patch) return left.patch - right.patch
+  return left.suffix - right.suffix
+}
+

--- a/packages/core/helpers/ver/tests/4.26.4-1.test.ts
+++ b/packages/core/helpers/ver/tests/4.26.4-1.test.ts
@@ -1,0 +1,232 @@
+import update_4_26_4_1 from '../4.26.4-1'
+import { describe, expect, it } from 'vitest'
+
+describe('update_4_26_4_1', () => {
+  it('sets markup-include contentEditor.style to default when missing', () => {
+    const config: any = {
+      type: 'markup-include',
+      version: '4.26.4',
+      contentEditor: {
+        title: 'Title'
+      }
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(result.contentEditor.style).toBe('default')
+    expect(result.version).toBe('4.26.4-1')
+  })
+
+  it('creates contentEditor object when missing on markup-include', () => {
+    const config: any = {
+      type: 'markup-include',
+      version: '4.26.4'
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(result.contentEditor).toBeTruthy()
+    expect(result.contentEditor.style).toBe('default')
+  })
+
+  it('does not overwrite existing markup-include contentEditor.style', () => {
+    const config: any = {
+      type: 'markup-include',
+      version: '4.26.4',
+      contentEditor: {
+        title: 'Title',
+        style: 'tp5'
+      }
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(result.contentEditor.style).toBe('tp5')
+  })
+
+  it('backfills sourceType for standalone markup variables', () => {
+    const config: any = {
+      type: 'chart',
+      version: '4.26.4',
+      markupVariables: [
+        {
+          name: 'State',
+          tag: '{{state}}',
+          columnName: 'state',
+          conditions: []
+        },
+        {
+          name: 'Last Updated',
+          tag: '{{lastUpdated}}',
+          metadataKey: 'lastUpdated',
+          conditions: []
+        }
+      ]
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(result.markupVariables[0].sourceType).toBe('column')
+    expect(result.markupVariables[1].sourceType).toBe('metadata')
+    expect(config.markupVariables[0].sourceType).toBeUndefined()
+  })
+
+  it('preserves existing markup variable source types', () => {
+    const config: any = {
+      type: 'chart',
+      version: '4.26.4',
+      markupVariables: [
+        {
+          sourceType: 'icon',
+          name: 'Trend Up',
+          tag: '{{trend-arrow-up}}',
+          iconId: 'trend-arrow-up',
+          conditions: []
+        }
+      ]
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(result.markupVariables[0].sourceType).toBe('icon')
+  })
+
+  it('leaves null and undefined markup variables unchanged during sourceType backfill', () => {
+    const config: any = {
+      type: 'chart',
+      version: '4.26.4',
+      markupVariables: [
+        null,
+        undefined,
+        {
+          name: 'State',
+          tag: '{{state}}',
+          columnName: 'state',
+          conditions: []
+        }
+      ]
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(result.markupVariables[0]).toBeNull()
+    expect(result.markupVariables[1]).toBeUndefined()
+    expect(result.markupVariables[2].sourceType).toBe('column')
+  })
+
+  it('does not mutate original markup-include config', () => {
+    const config: any = {
+      type: 'markup-include',
+      version: '4.26.4',
+      contentEditor: {
+        title: 'Title'
+      }
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(config.contentEditor.style).toBeUndefined()
+    expect(result.contentEditor.style).toBe('default')
+  })
+
+  it('overrides waffle mode configs with new value descriptor defaults', () => {
+    const config: any = {
+      type: 'waffle-chart',
+      visualizationType: 'Waffle',
+      valueDescription: 'out of',
+      showPercent: false,
+      showDenominator: true
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(result.valueDescription).toBe('')
+    expect(result.showPercent).toBe(true)
+    expect(result.showDenominator).toBe(false)
+    expect(result.version).toBe('4.26.4-1')
+  })
+
+  it('does not modify gauge mode waffle-chart configs', () => {
+    const config: any = {
+      type: 'waffle-chart',
+      visualizationType: 'Gauge',
+      valueDescription: 'out of',
+      showPercent: false,
+      showDenominator: true
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(result.valueDescription).toBe('out of')
+    expect(result.showPercent).toBe(false)
+    expect(result.showDenominator).toBe(true)
+  })
+
+  it('updates moved behaviors recursively inside nested dashboards', () => {
+    const config: any = {
+      type: 'dashboard',
+      version: '4.26.4',
+      visualizations: {
+        nestedDashboard: {
+          type: 'dashboard',
+          visualizations: {
+            nestedMarkup: {
+              type: 'markup-include'
+            },
+            nestedWaffle: {
+              type: 'waffle-chart',
+              visualizationType: 'TP5 Waffle',
+              valueDescription: 'legacy',
+              showPercent: false,
+              showDenominator: true
+            },
+            nestedChart: {
+              type: 'chart',
+              markupVariables: [
+                {
+                  name: 'State',
+                  tag: '{{state}}',
+                  columnName: 'state',
+                  conditions: []
+                }
+              ]
+            },
+            nestedCountyMap: {
+              type: 'map',
+              general: { geoType: 'us-county' },
+              table: { showFullGeoNameInCSV: false }
+            },
+            nestedTerritoryMap: {
+              type: 'map',
+              general: {}
+            }
+          }
+        }
+      }
+    }
+
+    const result = update_4_26_4_1(config)
+    const nested = result.visualizations.nestedDashboard.visualizations
+
+    expect(nested.nestedMarkup.contentEditor.style).toBe('default')
+    expect(nested.nestedWaffle.valueDescription).toBe('')
+    expect(nested.nestedWaffle.showPercent).toBe(true)
+    expect(nested.nestedWaffle.showDenominator).toBe(false)
+    expect(nested.nestedChart.markupVariables[0].sourceType).toBe('column')
+    expect(nested.nestedCountyMap.table.showFullGeoNameInCSV).toBe(true)
+    expect(nested.nestedTerritoryMap.general.territoriesAlwaysShow).toBe(true)
+  })
+
+  it('does not change non-county map CSV full geo name settings', () => {
+    const config: any = {
+      type: 'map',
+      version: '4.26.4',
+      general: { geoType: 'us' },
+      table: { showFullGeoNameInCSV: false }
+    }
+
+    const result = update_4_26_4_1(config)
+
+    expect(result.table.showFullGeoNameInCSV).toBe(false)
+  })
+})

--- a/packages/core/helpers/ver/tests/4.26.4.test.ts
+++ b/packages/core/helpers/ver/tests/4.26.4.test.ts
@@ -27,36 +27,6 @@ describe('update_4_26_4', () => {
     expect(result.version).toBe('4.26.4')
   })
 
-  it('should set markup-include contentEditor.style to default when missing', () => {
-    const config: any = {
-      type: 'markup-include',
-      version: '4.26.3',
-      contentEditor: {
-        title: 'Title'
-      }
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.contentEditor.style).toBe('default')
-    expect(result.version).toBe('4.26.4')
-  })
-
-  it('does not overwrite existing markup-include contentEditor.style', () => {
-    const config: any = {
-      type: 'markup-include',
-      version: '4.26.3',
-      contentEditor: {
-        title: 'Title',
-        style: 'tp5'
-      }
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.contentEditor.style).toBe('tp5')
-  })
-
   it('turns off extra visual settings for chart visualizations inside dashboards only', () => {
     const config: any = {
       type: 'dashboard',
@@ -80,19 +50,6 @@ describe('update_4_26_4', () => {
             background: true,
             hideBackgroundColor: true
           }
-        },
-        markup1: {
-          type: 'markup-include',
-          contentEditor: {
-            title: 'Markup 1'
-          }
-        },
-        markup2: {
-          type: 'markup-include',
-          contentEditor: {
-            title: 'Markup 2',
-            style: 'tp5'
-          }
         }
       }
     }
@@ -112,90 +69,6 @@ describe('update_4_26_4', () => {
       background: true,
       hideBackgroundColor: true
     })
-    expect(result.visualizations.markup1.contentEditor.style).toBe('default')
-    expect(result.visualizations.markup2.contentEditor.style).toBe('tp5')
-  })
-
-  it('creates contentEditor object when missing on markup-include', () => {
-    const config: any = {
-      type: 'markup-include',
-      version: '4.26.3'
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.contentEditor).toBeTruthy()
-    expect(result.contentEditor.style).toBe('default')
-  })
-
-  it('backfills sourceType for standalone markup variables', () => {
-    const config: any = {
-      type: 'chart',
-      version: '4.26.3',
-      markupVariables: [
-        {
-          name: 'State',
-          tag: '{{state}}',
-          columnName: 'state',
-          conditions: []
-        },
-        {
-          name: 'Last Updated',
-          tag: '{{lastUpdated}}',
-          metadataKey: 'lastUpdated',
-          conditions: []
-        }
-      ]
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.markupVariables[0].sourceType).toBe('column')
-    expect(result.markupVariables[1].sourceType).toBe('metadata')
-    expect(config.markupVariables[0].sourceType).toBeUndefined()
-  })
-
-  it('preserves existing markup variable source types', () => {
-    const config: any = {
-      type: 'chart',
-      version: '4.26.3',
-      markupVariables: [
-        {
-          sourceType: 'icon',
-          name: 'Trend Up',
-          tag: '{{trend-arrow-up}}',
-          iconId: 'trend-arrow-up',
-          conditions: []
-        }
-      ]
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.markupVariables[0].sourceType).toBe('icon')
-  })
-
-  it('leaves null and undefined markup variables unchanged during sourceType backfill', () => {
-    const config: any = {
-      type: 'chart',
-      version: '4.26.3',
-      markupVariables: [
-        null,
-        undefined,
-        {
-          name: 'State',
-          tag: '{{state}}',
-          columnName: 'state',
-          conditions: []
-        }
-      ]
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.markupVariables[0]).toBeNull()
-    expect(result.markupVariables[1]).toBeUndefined()
-    expect(result.markupVariables[2].sourceType).toBe('column')
   })
 
   it('does not mutate original chart config', () => {
@@ -213,127 +86,28 @@ describe('update_4_26_4', () => {
     expect(result.visual.accent).toBe(false)
   })
 
-  it('does not mutate original markup-include config', () => {
-    const config: any = {
-      type: 'markup-include',
-      version: '4.26.3',
-      contentEditor: {
-        title: 'Title'
-      }
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(config.contentEditor.style).toBeUndefined()
-    expect(result.contentEditor.style).toBe('default')
-  })
-
-  it('overrides waffle mode configs with new value descriptor defaults', () => {
-    const config: any = {
-      type: 'waffle-chart',
-      visualizationType: 'Waffle',
-      valueDescription: 'out of',
-      showPercent: false,
-      showDenominator: true
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.valueDescription).toBe('')
-    expect(result.showPercent).toBe(true)
-    expect(result.showDenominator).toBe(false)
-    expect(result.version).toBe('4.26.4')
-  })
-
-  it('does not modify gauge mode waffle-chart configs', () => {
-    const config: any = {
-      type: 'waffle-chart',
-      visualizationType: 'Gauge',
-      valueDescription: 'out of',
-      showPercent: false,
-      showDenominator: true
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.valueDescription).toBe('out of')
-    expect(result.showPercent).toBe(false)
-    expect(result.showDenominator).toBe(true)
-  })
-
-  it('updates waffle visualizations but not gauge visualizations in mixed dashboards', () => {
-    const config: any = {
-      type: 'dashboard',
-      visualizations: {
-        waffle: {
-          type: 'waffle-chart',
-          visualizationType: 'Waffle',
-          valueDescription: 'legacy',
-          showPercent: false,
-          showDenominator: true
-        },
-        gauge: {
-          type: 'waffle-chart',
-          visualizationType: 'TP5 Gauge',
-          valueDescription: 'keep',
-          showPercent: false,
-          showDenominator: true
-        }
-      }
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.visualizations.waffle.valueDescription).toBe('')
-    expect(result.visualizations.waffle.showPercent).toBe(true)
-    expect(result.visualizations.waffle.showDenominator).toBe(false)
-
-    expect(result.visualizations.gauge.valueDescription).toBe('keep')
-    expect(result.visualizations.gauge.showPercent).toBe(false)
-    expect(result.visualizations.gauge.showDenominator).toBe(true)
-  })
-
-  it('leaves configs with missing or unexpected visualizationType unchanged', () => {
-    const missingTypeConfig: any = {
-      type: 'waffle-chart',
-      valueDescription: 'legacy',
-      showPercent: false,
-      showDenominator: true
-    }
-
-    const unexpectedTypeConfig: any = {
-      type: 'waffle-chart',
-      visualizationType: 'Unknown Mode',
-      valueDescription: 'legacy',
-      showPercent: false,
-      showDenominator: true
-    }
-
-    const missingTypeResult = update_4_26_4(missingTypeConfig)
-    const unexpectedTypeResult = update_4_26_4(unexpectedTypeConfig)
-
-    expect(missingTypeResult.valueDescription).toBe('legacy')
-    expect(missingTypeResult.showPercent).toBe(false)
-    expect(missingTypeResult.showDenominator).toBe(true)
-
-    expect(unexpectedTypeResult.valueDescription).toBe('legacy')
-    expect(unexpectedTypeResult.showPercent).toBe(false)
-    expect(unexpectedTypeResult.showDenominator).toBe(true)
-  })
-
-  it('recursively updates nested dashboard visualizations', () => {
+  it('recursively updates only chart visualizations inside nested dashboards', () => {
     const config: any = {
       type: 'dashboard',
       visualizations: {
         nestedDashboard: {
           type: 'dashboard',
           visualizations: {
-            nestedWaffle: {
-              type: 'waffle-chart',
-              visualizationType: 'TP5 Waffle',
-              valueDescription: 'legacy',
-              showPercent: false,
-              showDenominator: true
+            nestedChart: {
+              type: 'chart',
+              visual: {
+                border: true,
+                borderColorTheme: true,
+                accent: true,
+                background: true,
+                hideBackgroundColor: true
+              }
+            },
+            nestedMarkup: {
+              type: 'markup-include',
+              contentEditor: {
+                title: 'Legacy'
+              }
             }
           }
         }
@@ -342,91 +116,32 @@ describe('update_4_26_4', () => {
 
     const result = update_4_26_4(config)
 
-    expect(result.visualizations.nestedDashboard.visualizations.nestedWaffle.valueDescription).toBe('')
-    expect(result.visualizations.nestedDashboard.visualizations.nestedWaffle.showPercent).toBe(true)
-    expect(result.visualizations.nestedDashboard.visualizations.nestedWaffle.showDenominator).toBe(false)
+    expect(result.visualizations.nestedDashboard.visualizations.nestedChart.visual).toEqual({
+      border: false,
+      borderColorTheme: false,
+      accent: false,
+      background: false,
+      hideBackgroundColor: false
+    })
+    expect(result.visualizations.nestedDashboard.visualizations.nestedMarkup.contentEditor.style).toBeUndefined()
   })
 
-  it('recursively backfills markup variable source types inside dashboards', () => {
+  it('does not apply moved repair logic before 4.26.4-1', () => {
     const config: any = {
-      type: 'dashboard',
+      type: 'chart',
       version: '4.26.3',
-      visualizations: {
-        nestedChart: {
-          type: 'chart',
-          markupVariables: [
-            {
-              name: 'State',
-              tag: '{{state}}',
-              columnName: 'state',
-              conditions: []
-            },
-            {
-              name: 'Source',
-              tag: '{{source}}',
-              metadataKey: 'source',
-              conditions: []
-            }
-          ]
+      markupVariables: [
+        {
+          name: 'State',
+          tag: '{{state}}',
+          columnName: 'state',
+          conditions: []
         }
-      }
+      ]
     }
 
     const result = update_4_26_4(config)
 
-    expect(result.visualizations.nestedChart.markupVariables[0].sourceType).toBe('column')
-    expect(result.visualizations.nestedChart.markupVariables[1].sourceType).toBe('metadata')
-  })
-
-  it('enables full geo name CSV export for legacy county maps', () => {
-    const config: any = {
-      type: 'map',
-      version: '4.26.3',
-      general: { geoType: 'us-county' },
-      table: { showFullGeoNameInCSV: false }
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.table.showFullGeoNameInCSV).toBe(true)
-    expect(result.version).toBe('4.26.4')
-    expect(config.table.showFullGeoNameInCSV).toBe(false)
-  })
-
-  it('does not change non-county map CSV full geo name settings', () => {
-    const config: any = {
-      type: 'map',
-      version: '4.26.3',
-      general: { geoType: 'us' },
-      table: { showFullGeoNameInCSV: false }
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.table.showFullGeoNameInCSV).toBe(false)
-  })
-
-  it('enables full geo name CSV export for county maps inside dashboards', () => {
-    const config: any = {
-      type: 'dashboard',
-      version: '4.26.3',
-      visualizations: {
-        countyMap: {
-          type: 'map',
-          general: { geoType: 'us-county' },
-          table: { showFullGeoNameInCSV: false }
-        },
-        usMap: {
-          type: 'map',
-          general: { geoType: 'us' },
-          table: { showFullGeoNameInCSV: false }
-        }
-      }
-    }
-
-    const result = update_4_26_4(config)
-
-    expect(result.visualizations.countyMap.table.showFullGeoNameInCSV).toBe(true)
-    expect(result.visualizations.usMap.table.showFullGeoNameInCSV).toBe(false)
+    expect(result.markupVariables[0].sourceType).toBeUndefined()
   })
 })

--- a/packages/core/helpers/ver/tests/coveUpdateWorker.test.ts
+++ b/packages/core/helpers/ver/tests/coveUpdateWorker.test.ts
@@ -83,5 +83,91 @@ describe('coveUpdateWorker', () => {
 
       expect(subDash.visualizations.mi1.contentEditor.style).toBe('default')
     })
+
+    it('runs 4.26.4 and then 4.26.4-1 for configs starting at 4.26.3', () => {
+      const config: any = {
+        type: 'dashboard',
+        version: '4.26.3',
+        rows: [],
+        visualizations: {
+          chart1: {
+            type: 'chart',
+            visual: {
+              border: true,
+              borderColorTheme: true,
+              accent: true,
+              background: true,
+              hideBackgroundColor: true
+            }
+          },
+          markup1: {
+            type: 'markup-include'
+          }
+        }
+      }
+
+      const result = coveUpdateWorker(config)
+
+      expect(result.visualizations.chart1.visual).toEqual({
+        border: false,
+        borderColorTheme: false,
+        accent: false,
+        background: false,
+        hideBackgroundColor: false
+      })
+      expect(result.visualizations.markup1.contentEditor.style).toBe('default')
+      expect(result.version).toBe('4.26.4-1')
+    })
+
+    it('applies the 4.26.4-1 repair logic to configs already stamped 4.26.4', () => {
+      const config: any = {
+        type: 'dashboard',
+        version: '4.26.4',
+        rows: [],
+        visualizations: {
+          nestedDashboard: {
+            type: 'dashboard',
+            rows: [],
+            visualizations: {
+              markup1: {
+                type: 'markup-include'
+              },
+              territoryMap: {
+                type: 'map',
+                general: {}
+              }
+            }
+          }
+        }
+      }
+
+      const result = coveUpdateWorker(config)
+      const nested = result.visualizations.nestedDashboard.visualizations
+
+      expect(nested.markup1.contentEditor.style).toBe('default')
+      expect(nested.territoryMap.general.territoriesAlwaysShow).toBe(true)
+      expect(result.version).toBe('4.26.4-1')
+    })
+
+    it('does not rerun 4.26.4-1 when config is already at 4.26.4-1', () => {
+      const config: any = {
+        type: 'dashboard',
+        version: '4.26.4-1',
+        rows: [],
+        visualizations: {
+          territoryMap: {
+            type: 'map',
+            general: {
+              territoriesAlwaysShow: false
+            }
+          }
+        }
+      }
+
+      const result = coveUpdateWorker(config)
+
+      expect(result.visualizations.territoryMap.general.territoriesAlwaysShow).toBe(false)
+      expect(result.version).toBe('4.26.4-1')
+    })
   })
 })

--- a/packages/core/helpers/ver/tests/versionNeedsUpdate.test.ts
+++ b/packages/core/helpers/ver/tests/versionNeedsUpdate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import versionNeedsUpdate from '../versionNeedsUpdate'
+import isOlderVersion from '../../isOlderVersion'
 
 describe('versionNeedsUpdate', () => {
   it('should return true if previousVersion is empty', () => {
@@ -24,5 +25,31 @@ describe('versionNeedsUpdate', () => {
 
   it('should return false if currentVersion is an older version', () => {
     expect(versionNeedsUpdate('2.0.0', '1.0.0')).toBe(false)
+  })
+
+  it('treats a missing numeric suffix as zero', () => {
+    expect(versionNeedsUpdate('4.26.4', '4.26.4-0')).toBe(false)
+    expect(versionNeedsUpdate('4.26.4-0', '4.26.4')).toBe(false)
+  })
+
+  it('orders numeric suffix follow-up migration versions after the base patch', () => {
+    expect(versionNeedsUpdate('4.26.4', '4.26.4-1')).toBe(true)
+  })
+
+  it('orders later numeric suffix follow-up migration versions correctly', () => {
+    expect(versionNeedsUpdate('4.26.4-1', '4.26.4-2')).toBe(true)
+  })
+
+  it('keeps the next patch ahead of any numeric suffix follow-up migration version', () => {
+    expect(versionNeedsUpdate('4.26.4-9', '4.26.5')).toBe(true)
+  })
+})
+
+describe('isOlderVersion', () => {
+  it('uses the same numeric suffix ordering rules', () => {
+    expect(isOlderVersion('4.26.4', '4.26.4-1')).toBe(true)
+    expect(isOlderVersion('4.26.4-1', '4.26.4-2')).toBe(true)
+    expect(isOlderVersion('4.26.4-9', '4.26.5')).toBe(true)
+    expect(isOlderVersion('4.26.4', '4.26.4-0')).toBe(false)
   })
 })

--- a/packages/core/helpers/ver/versionNeedsUpdate.ts
+++ b/packages/core/helpers/ver/versionNeedsUpdate.ts
@@ -1,11 +1,8 @@
+import { compareMigrationVersions } from './compareMigrationVersions'
+
 export default function versionNeedsUpdate(previousVersion: string, currentVersion: string): boolean {
   if (!previousVersion) return true
-  const [prevMajor, prevMinor, prevPatch] = previousVersion.split('.').map(Number)
-  const [currMajor, currMinor, currPatch] = currentVersion.split('.').map(Number)
-  if (currMajor > prevMajor) return true
-  if (currMajor === prevMajor && currMinor > prevMinor) return true
-  if (currMajor === prevMajor && currMinor === prevMinor && currPatch > prevPatch) return true
-  return false
+  return compareMigrationVersions(previousVersion, currentVersion) < 0
 }
 
 export const isOlderVersion = versionNeedsUpdate

--- a/packages/dashboard/src/components/VisualizationsPanel/VisualizationsPanel.tsx
+++ b/packages/dashboard/src/components/VisualizationsPanel/VisualizationsPanel.tsx
@@ -43,7 +43,7 @@ const VisualizationsPanel = () => {
       <span className='subheading-3'>Misc.</span>
       <div className='drag-grid'>
         <Widget addVisualization={() => addVisualization('data-bite', '')} type='data-bite' />
-        <Widget addVisualization={() => addVisualization('waffle-chart', '')} type='waffle-chart' />
+        <Widget addVisualization={() => addVisualization('waffle-chart', 'Waffle')} type='waffle-chart' />
         <Widget addVisualization={() => addVisualization('markup-include', '')} type='markup-include' />
         <Widget addVisualization={() => addVisualization('filtered-text', '')} type='filtered-text' />
         <Widget addVisualization={() => addVisualization('dashboardFilters', '')} type='dashboardFilters' />

--- a/packages/dashboard/src/helpers/addVisualization.ts
+++ b/packages/dashboard/src/helpers/addVisualization.ts
@@ -35,9 +35,11 @@ export const addVisualization = (type, subType) => {
       }
       break
     case 'data-bite':
-    case 'waffle-chart':
     case 'filtered-text':
       newVisualizationConfig.visualizationType = type
+      break
+    case 'waffle-chart':
+      newVisualizationConfig.visualizationType = subType
       break
     case 'table': {
       const tableConfig: Table = {

--- a/packages/dashboard/src/helpers/tests/addVisualization.test.ts
+++ b/packages/dashboard/src/helpers/tests/addVisualization.test.ts
@@ -46,7 +46,7 @@ describe('addVisualization', () => {
     vi.spyOn(Date, 'now').mockReturnValue(12345)
 
     expect(addVisualization('data-bite')).toMatchObject({ visualizationType: 'data-bite' })
-    expect(addVisualization('waffle-chart')).toMatchObject({ visualizationType: 'waffle-chart' })
+    expect(addVisualization('waffle-chart', 'Waffle')).toMatchObject({ visualizationType: 'Waffle' })
     expect(addVisualization('filtered-text')).toMatchObject({ visualizationType: 'filtered-text' })
   })
 })

--- a/packages/editor/src/components/DataImport/helpers/applyAutoDetectedDateParseFormat.ts
+++ b/packages/editor/src/components/DataImport/helpers/applyAutoDetectedDateParseFormat.ts
@@ -1,4 +1,4 @@
-import { detectDateParseFormat, isDateScale } from '@cdc/core/helpers/cove/date'
+import { getAutoDetectedDateParseFormat, isDateScale } from '@cdc/core/helpers/cove/date'
 import { type Visualization } from '@cdc/core/types/Visualization'
 
 const isChartWithDateAxis = (config: Visualization) =>
@@ -14,35 +14,14 @@ export const applyAutoDetectedDateParseFormat = (
 
   const existingDateParseFormat = config.xAxis.dateParseFormat
 
-  if (
-    typeof existingDateParseFormat === 'string' &&
-    existingDateParseFormat.trim() !== ''
-  ) {
+  if (typeof existingDateParseFormat === 'string' && existingDateParseFormat.trim() !== '') {
     return config
   }
   const xAxisKey = config.xAxis.dataKey
 
-  const hasXAxisKeyInImportedData = importedData.some(
-    row => row && Object.prototype.hasOwnProperty.call(row, xAxisKey)
-  )
+  const autoDetectedDateParseFormat = getAutoDetectedDateParseFormat(importedData, xAxisKey)
 
-  if (!hasXAxisKeyInImportedData) {
-    return config
-  }
-
-  const dateDetectionSamples: unknown[] = []
-
-  for (const row of importedData) {
-    const value = row?.[xAxisKey]
-    const normalizedValue = typeof value === 'string' ? value.trim() : value
-
-    if (normalizedValue !== null && normalizedValue !== undefined && normalizedValue !== '') {
-      dateDetectionSamples.push(value)
-    }
-  }
-
-  const detection = detectDateParseFormat(dateDetectionSamples)
-  if (!detection.isReliable || !detection.detectedFormat) {
+  if (!autoDetectedDateParseFormat) {
     return config
   }
 
@@ -50,7 +29,7 @@ export const applyAutoDetectedDateParseFormat = (
     ...config,
     xAxis: {
       ...config.xAxis,
-      dateParseFormat: detection.detectedFormat
+      dateParseFormat: autoDetectedDateParseFormat
     }
   }
 }

--- a/packages/editor/src/components/DataImport/tests/applyAutoDetectedDateParseFormat.test.ts
+++ b/packages/editor/src/components/DataImport/tests/applyAutoDetectedDateParseFormat.test.ts
@@ -42,6 +42,23 @@ describe('applyAutoDetectedDateParseFormat', () => {
     expect(result.table.dateDisplayFormat).toBe('%b %-d %Y')
   })
 
+  it('auto-fills the chart xAxis date parse format for date-time axes when detection is reliable', () => {
+    const result: any = applyAutoDetectedDateParseFormat(
+      {
+        ...baseChartConfig,
+        xAxis: {
+          ...baseChartConfig.xAxis,
+          type: 'date-time'
+        }
+      },
+      reliableSlashDateRows
+    )
+
+    expect(result.xAxis.dateParseFormat).toBe('%Y/%m/%d')
+    expect(result.tooltips.dateDisplayFormat).toBe('%B %-d, %Y')
+    expect(result.table.dateDisplayFormat).toBe('%b %-d %Y')
+  })
+
   it('leaves the config unchanged when the sample is ambiguous', () => {
     const result: any = applyAutoDetectedDateParseFormat(baseChartConfig, ambiguousUsOrEuDateRows)
 
@@ -57,10 +74,7 @@ describe('applyAutoDetectedDateParseFormat', () => {
       }
     }
 
-    const result: any = applyAutoDetectedDateParseFormat(
-      preconfiguredChartConfig,
-      reliableSlashDateRows
-    )
+    const result: any = applyAutoDetectedDateParseFormat(preconfiguredChartConfig, reliableSlashDateRows)
 
     expect(result).toEqual(preconfiguredChartConfig)
   })

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -85,7 +85,7 @@ The following data-loading fields are shared and documented in core: `data`, `da
 | `general.statesPicked` | `object[]` | No | `[]` | Selected states for single-state maps. | Each item has `fipsCode` and `stateName`. |
 | `general.countriesPicked` | `object[]` | No | `[]` | Selected countries for world maps. | Each item has `iso` and `name`. |
 | `general.hideUnselectedCountries` | `boolean` | No | `false` | Controls whether unselected countries are hidden or grayed out. | Only meaningful when `countriesPicked` is populated. |
-| `general.territoriesAlwaysShow` | `boolean` | No | `true` | Keeps US territories visible even when they would normally be hidden. | `true`, `false`. When omitted, the runtime/editor treat it as `true`; legacy county maps are backfilled to `true` during migration unless they already set an explicit value. |
+| `general.territoriesAlwaysShow` | `boolean` | No | `true` | Controls how U.S. territories are rendered on U.S. maps. | `true`, `false`. On county maps, `false` hides all territory counties; `true` renders only territory counties with matching runtime data. On state maps, `false` renders only territories with matching runtime data; `true` renders all supported territories whether data exists or not. When omitted, the editor/runtime treat it as `true`, and legacy configs are backfilled to `true` during migration. |
 | `general.territoriesLabel` | `string` | No | `Territories` | Label used for territories in US maps. | Often left at the default. |
 | `general.hasRegions` | `boolean` | No | `false` | Marks the map as region-aware for some data-loading and editor flows. | Mainly used by US regional map flows. |
 

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -85,7 +85,7 @@ The following data-loading fields are shared and documented in core: `data`, `da
 | `general.statesPicked` | `object[]` | No | `[]` | Selected states for single-state maps. | Each item has `fipsCode` and `stateName`. |
 | `general.countriesPicked` | `object[]` | No | `[]` | Selected countries for world maps. | Each item has `iso` and `name`. |
 | `general.hideUnselectedCountries` | `boolean` | No | `false` | Controls whether unselected countries are hidden or grayed out. | Only meaningful when `countriesPicked` is populated. |
-| `general.territoriesAlwaysShow` | `boolean` | No | `true` | Keeps US territories visible even when they would normally be hidden. | `true`, `false` |
+| `general.territoriesAlwaysShow` | `boolean` | No | `true` | Keeps US territories visible even when they would normally be hidden. | `true`, `false`. When omitted, the runtime/editor treat it as `true`; legacy county maps are backfilled to `true` during migration unless they already set an explicit value. |
 | `general.territoriesLabel` | `string` | No | `Territories` | Label used for territories in US maps. | Often left at the default. |
 | `general.hasRegions` | `boolean` | No | `false` | Marks the map as region-aware for some data-loading and editor flows. | Mainly used by US regional map flows. |
 
@@ -230,5 +230,6 @@ These fields may appear in saved configs, editor exports, or runtime state, but 
 | `newViz` | Editor-only preview/confirmation flag. |
 | `columns.additionalColumnN` | Editor-generated extra columns for data-table and tooltip workflows. |
 | `general.countyCensusYear`, `general.filterControlsCountyYear`, `general.filterControlsStatesPicked` | Editor-only controls that are surfaced for some county and single-state flows. |
+| `general.territoriesAlwayShow` | Misspelled legacy artifact from an older migration bug. The runtime repairs this to `general.territoriesAlwaysShow`; do not author it manually. |
 | `statePicked` | Legacy saved-config artifact from older editor flows. |
 | `showDownloadButton`, `expandDataTable` | Legacy editor state from older configs. |

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -85,7 +85,7 @@ The following data-loading fields are shared and documented in core: `data`, `da
 | `general.statesPicked` | `object[]` | No | `[]` | Selected states for single-state maps. | Each item has `fipsCode` and `stateName`. |
 | `general.countriesPicked` | `object[]` | No | `[]` | Selected countries for world maps. | Each item has `iso` and `name`. |
 | `general.hideUnselectedCountries` | `boolean` | No | `false` | Controls whether unselected countries are hidden or grayed out. | Only meaningful when `countriesPicked` is populated. |
-| `general.territoriesAlwaysShow` | `boolean` | No | `false` | Keeps US territories visible even when they would normally be hidden. | `true`, `false` |
+| `general.territoriesAlwaysShow` | `boolean` | No | `true` | Keeps US territories visible even when they would normally be hidden. | `true`, `false` |
 | `general.territoriesLabel` | `string` | No | `Territories` | Label used for territories in US maps. | Often left at the default. |
 | `general.hasRegions` | `boolean` | No | `false` | Marks the map as region-aware for some data-loading and editor flows. | Mainly used by US regional map flows. |
 

--- a/packages/map/src/_stories/CdcMap.Editor.TypeSectionTests.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Editor.TypeSectionTests.stories.tsx
@@ -106,7 +106,7 @@ export const TypeSectionTests: Story = {
       },
       (before, after) => !before.classes.includes('us-county') && after.classes.includes('us-county'),
       () => {
-        const territoriesCheckbox = canvas.getByLabelText(/Show All Territories/i) as HTMLInputElement
+        const territoriesCheckbox = canvas.getByLabelText(/Show Available Territories/i) as HTMLInputElement
         expect(territoriesCheckbox).toBeTruthy()
         expect(territoriesCheckbox.disabled).toBe(false)
       }
@@ -273,11 +273,11 @@ export const TypeSectionTests: Story = {
     )
 
     // ==========================================================================
-    // TEST: Show All Territories checkbox
+    // TEST: Show Available Territories checkbox
     // Verifies: Territory SVG elements appear/disappear in visualization
     // ==========================================================================
     const territoriesLabel = Array.from(canvasElement.querySelectorAll('label')).find(label =>
-      label.textContent?.includes('Show All Territories')
+      label.textContent?.includes('Show Available Territories')
     )
     const territoriesCheckbox = territoriesLabel?.querySelector('input[type="checkbox"]') as HTMLInputElement
     expect(territoriesCheckbox).toBeTruthy()
@@ -292,7 +292,7 @@ export const TypeSectionTests: Story = {
     }
 
     await performAndAssert(
-      'Show All Territories → Enable',
+      'Show Available Territories → Enable',
       getTerritoriesVisual,
       async () => {
         await userEvent.click(territoriesCheckbox)
@@ -301,7 +301,7 @@ export const TypeSectionTests: Story = {
     )
 
     await performAndAssert(
-      'Show All Territories → Disable',
+      'Show Available Territories → Disable',
       getTerritoriesVisual,
       async () => {
         await userEvent.click(territoriesCheckbox)

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -1647,7 +1647,7 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                         section='general'
                         subsection={null}
                         fieldName='territoriesAlwaysShow'
-                        label='Show All Territories'
+                        label='Show Available Territories'
                         updateField={updateField}
                       />
                     )}

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -1643,7 +1643,7 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
 
                     {['us', 'us-county'].includes(config.general.geoType) && (
                       <CheckBox
-                        value={general.territoriesAlwaysShow || false}
+                        value={general.territoriesAlwaysShow ?? true}
                         section='general'
                         subsection={null}
                         fieldName='territoriesAlwaysShow'

--- a/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
@@ -24,6 +24,11 @@ import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
 import { createCanvasPattern, PatternType } from '../../../helpers/createCanvasPattern'
 import { getPatternForRow } from '../../../helpers/getPatternForRow'
+import {
+  getCountyTerritoryVisibility,
+  type CountyTerritoryVisibility,
+  US_TERRITORY_STATE_FIPS_PREFIXES
+} from '../../../helpers/countyTerritories'
 
 type Geometry = GeoGeometryObjects & { id?: string; properties: { name: string } }
 type Focus = {
@@ -42,16 +47,6 @@ type TopoData = {
   projection: any
   hsaMapping: Record<string, string>
 }
-
-const US_TERRITORY_FIPS_PREFIXES = {
-  AMERICAN_SAMOA: '60',
-  GUAM: '66',
-  NORTHERN_MARIANA_ISLANDS: '69',
-  PUERTO_RICO: '72',
-  US_VIRGIN_ISLANDS: '78'
-} as const
-
-const US_TERRITORY_STATE_FIPS_PREFIXES = new Set<string>(Object.values(US_TERRITORY_FIPS_PREFIXES))
 
 const dedupeFeaturesById = <T extends { id?: string }>(features: T[]): T[] => {
   const seenIds = new Set<string>()
@@ -74,8 +69,7 @@ const sortById = (a, b) => {
   return 0
 }
 
-const getTopoData = (year, showHSABoundaries, territoriesAlwaysShow: boolean) => {
-  const showTerritories = territoriesAlwaysShow
+const getTopoData = (year, showHSABoundaries, territoryVisibility: CountyTerritoryVisibility) => {
   return new Promise(resolve => {
     const resolveWithTopo = async response => {
       if (response.status !== 200) {
@@ -96,7 +90,7 @@ const getTopoData = (year, showHSABoundaries, territoriesAlwaysShow: boolean) =>
       }
 
       topoData.year = year || 'default'
-      const topoSources = showTerritories ? [response, usExtendedGeography] : [response]
+      const topoSources = territoryVisibility.showTerritories ? [response, usExtendedGeography] : [response]
       topoData.counties = dedupeFeaturesById(
         topoSources
           .flatMap(topo => feature(topo, topo.objects.counties).features)
@@ -104,7 +98,7 @@ const getTopoData = (year, showHSABoundaries, territoriesAlwaysShow: boolean) =>
       )
       topoData.states = dedupeFeaturesById(topoSources.flatMap(topo => feature(topo, topo.objects.states).features))
       // Additional filtering removes territory features that may still be present in the topology data when territories are hidden.
-      if (!showTerritories) {
+      if (!territoryVisibility.showTerritories) {
         topoData.states = topoData.states.filter(state => {
           const statePrefix = state.id?.substring(0, 2)
           return !statePrefix || !US_TERRITORY_STATE_FIPS_PREFIXES.has(statePrefix)
@@ -112,6 +106,23 @@ const getTopoData = (year, showHSABoundaries, territoriesAlwaysShow: boolean) =>
         topoData.counties = topoData.counties.filter(county => {
           const countyPrefix = county.id?.substring(0, 2)
           return !countyPrefix || !US_TERRITORY_STATE_FIPS_PREFIXES.has(countyPrefix)
+        })
+      } else {
+        topoData.states = topoData.states.filter(state => {
+          const statePrefix = state.id?.substring(0, 2)
+          return (
+            !statePrefix ||
+            !US_TERRITORY_STATE_FIPS_PREFIXES.has(statePrefix) ||
+            territoryVisibility.statePrefixes.has(statePrefix)
+          )
+        })
+        topoData.counties = topoData.counties.filter(county => {
+          const countyPrefix = county.id?.substring(0, 2)
+          return (
+            !countyPrefix ||
+            !US_TERRITORY_STATE_FIPS_PREFIXES.has(countyPrefix) ||
+            territoryVisibility.countyIds.has(county.id)
+          )
         })
       }
       if (showHSABoundaries) {
@@ -254,6 +265,10 @@ const CountyMap = () => {
   const pathGenerator = geoPath().projection(geoAlbersUsaTerritories())
 
   const { featureArray } = useMapLayers(config, setConfig, pathGenerator, tooltipId)
+  const territoryVisibility = useMemo(
+    () => getCountyTerritoryVisibility(config.general.territoriesAlwaysShow, runtimeData),
+    [config.general.territoriesAlwaysShow, runtimeData]
+  )
 
   useEffect(() => {
     if (containerEl) {
@@ -264,7 +279,7 @@ const CountyMap = () => {
   })
 
   const getAndSetTopoData = currentYear => {
-    getTopoData(currentYear, config.general.showHSABoundaries, config.general.territoriesAlwaysShow).then(response => {
+    getTopoData(currentYear, config.general.showHSABoundaries, territoryVisibility).then(response => {
       if (canvasRef.current) {
         const context = canvasRef.current.getContext('2d') as CanvasRenderingContext2D
         context.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height)
@@ -279,7 +294,12 @@ const CountyMap = () => {
     if (currentYear !== topoData.year) {
       getAndSetTopoData(currentYear)
     }
-  }, [config.general.countyCensusYear, config.general.filterControlsCountyYear, JSON.stringify(runtimeFilters)])
+  }, [
+    config.general.countyCensusYear,
+    config.general.filterControlsCountyYear,
+    JSON.stringify(runtimeFilters),
+    territoryVisibility.key
+  ])
 
   const prevShowHSABoundariesRef = useRef(config.general.showHSABoundaries)
   useEffect(() => {
@@ -289,13 +309,13 @@ const CountyMap = () => {
     prevShowHSABoundariesRef.current = config.general.showHSABoundaries
   }, [config.general.showHSABoundaries])
 
-  const prevTerritoriesAlwaysShowRef = useRef(config.general.territoriesAlwaysShow)
+  const prevTerritoryVisibilityRef = useRef(territoryVisibility.key)
   useEffect(() => {
-    if (prevTerritoriesAlwaysShowRef.current === config.general.territoriesAlwaysShow) return
+    if (prevTerritoryVisibilityRef.current === territoryVisibility.key) return
     const currentYear = getCurrentTopoYear(config, runtimeFilters)
     getAndSetTopoData(currentYear)
-    prevTerritoriesAlwaysShowRef.current = config.general.territoriesAlwaysShow
-  }, [config.general.territoriesAlwaysShow])
+    prevTerritoryVisibilityRef.current = territoryVisibility.key
+  }, [territoryVisibility.key])
 
   // Whenever the memo at the top is triggered and the map is called to re-render, call drawCanvas and update
   // The resize function so it includes the latest state variables

--- a/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
@@ -1112,7 +1112,7 @@ const CountyMap = () => {
     }
 
     drawCanvas()
-  }, [isLoading, topoData, focus, runtimeLegend, runtimeData, featureArray, config])
+  }, [isLoading, topoData, focus, runtimeLegend, runtimeData, featureArray, config, filteredCountyCode])
 
   const showManualZoomControls = config.general.allowMapZoom
   const showResetControl = (hasMoved || focus.id) && (showManualZoomControls || config.general.type === 'us-geocode')

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -161,7 +161,7 @@ const UsaMap = () => {
 
   useEffect(() => {
     if (general.territoriesAlwaysShow) {
-      // show all Territories whether in the data or not
+      // Show Available Territories whether in the data or not
       setTerritoriesData(territoriesKeys)
     } else {
       // Territories need to show up if they're in the data at all, not just if they're "active". That's why this is different from Cities

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -29,7 +29,7 @@ const createInitialState = () => {
       showDownloadMediaButton: false,
       displayAsHex: false,
       displayStateLabels: true,
-      territoriesAlwaysShow: false,
+      territoriesAlwaysShow: true,
       language: 'en',
       geoType: 'single-state',
       geoLabelOverride: '',

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -29,7 +29,7 @@ const createInitialState = () => {
       showDownloadMediaButton: false,
       displayAsHex: false,
       displayStateLabels: true,
-      territoriesAlwaysShow: true,
+      territoriesAlwaysShow: undefined, // Will be set to true by default for US County maps in the migration helper
       language: 'en',
       geoType: 'single-state',
       geoLabelOverride: '',

--- a/packages/map/src/helpers/countyTerritories.ts
+++ b/packages/map/src/helpers/countyTerritories.ts
@@ -1,0 +1,38 @@
+export const US_TERRITORY_STATE_FIPS_PREFIXES = new Set(['60', '66', '69', '72', '78'])
+
+export type CountyTerritoryVisibility = {
+  showTerritories: boolean
+  statePrefixes: Set<string>
+  countyIds: Set<string>
+  key: string
+}
+
+export const getCountyTerritoryVisibility = (
+  territoriesAlwaysShow: boolean | undefined,
+  runtimeData?: Record<string, any>
+): CountyTerritoryVisibility => {
+  const countyIds = new Set<string>()
+  const statePrefixes = new Set<string>()
+
+  if (runtimeData) {
+    Object.keys(runtimeData).forEach(key => {
+      if (key.length <= 2) return
+
+      const statePrefix = key.slice(0, 2)
+      if (!US_TERRITORY_STATE_FIPS_PREFIXES.has(statePrefix)) return
+
+      countyIds.add(key)
+      statePrefixes.add(statePrefix)
+    })
+  }
+
+  const showTerritories = territoriesAlwaysShow !== false && countyIds.size > 0
+  const key = `${showTerritories}:${showTerritories ? Array.from(countyIds).sort().join(',') : ''}`
+
+  return {
+    showTerritories,
+    statePrefixes,
+    countyIds,
+    key
+  }
+}

--- a/packages/map/src/helpers/dataTableHelpers.ts
+++ b/packages/map/src/helpers/dataTableHelpers.ts
@@ -1,5 +1,5 @@
 import {
-  stateFipsToTwoDigit as stateFipsToAbbreviation,
+  stateFipsToTwoDigit as stateCodeToAbbreviation,
   supportedStatesFipsCodes as supportedStateCodes
 } from '../data/supported-geos'
 
@@ -13,18 +13,47 @@ export const shouldShowDataTable = (config: any, table: any, general: any, loadi
 /**
  * Filters county runtime data to a selected state code for data table display.
  * Keeps the original non-enumerable fromHash metadata when present.
+ * Fail-safe: if no recognizable state columns exist in the data, returns original
+ * data unfiltered (avoids breaking misconfigured datasets). If valid state columns
+ * exist but a state has no data, returns empty result as expected.
  */
 export const filterCountyTableRuntimeDataByStateCode = (runtimeData: any, stateCode: string, config?: any) => {
   if (!runtimeData || runtimeData.init || !stateCode) return runtimeData
 
-  const filtered = {}
+  const runtimeKeys = Object.keys(runtimeData)
+  if (runtimeKeys.length === 0) return runtimeData
+
   const stateName = supportedStateCodes[stateCode]
-  const stateAbbreviation = stateFipsToAbbreviation[stateCode]
+  const stateAbbreviation = stateCodeToAbbreviation[stateCode]
   const normalizedSelectedStateCode = String(stateCode).replace(/^0+/, '')
   const paddedSelectedStateCode = normalizedSelectedStateCode.padStart(2, '0')
   const stateColumnNames = Object.values(config?.columns || {})
     .map((column: any) => column?.name)
-    .filter((name: string) => !!name && /(state|territory|fips)/i.test(name))
+    .filter((name: string) => !!name && /(state|territory|fips|jurisdiction)/i.test(name))
+
+  // Also check common state field names directly in the data rows
+  const commonStateFieldNames = [
+    'jurisdiction',
+    'state',
+    'State',
+    'state_name',
+    'stateName',
+    'State/Territory',
+    'state_territory_name'
+  ]
+  const allStateColumns = [...new Set([...stateColumnNames, ...commonStateFieldNames])]
+
+  // Fail-safe: check if UIDs look like FIPS codes OR if any state column exists in the data
+  const sampleRow = runtimeData[runtimeKeys[0]]
+  const uidLooksFips = runtimeKeys.some(uid => /^\d{2}/.test(String(uid)))
+  const hasStateColumn = allStateColumns.some(col => sampleRow?.[col] !== undefined)
+
+  // If data has neither FIPS-style UIDs nor any recognizable state columns, don't filter
+  if (!uidLooksFips && !hasStateColumn) {
+    return runtimeData
+  }
+
+  const filtered = {}
 
   if (runtimeData.fromHash !== undefined) {
     Object.defineProperty(filtered, 'fromHash', {
@@ -38,7 +67,8 @@ export const filterCountyTableRuntimeDataByStateCode = (runtimeData: any, stateC
     const normalizedUidPrefix = uidPrefix.startsWith('0') ? uidPrefix.slice(1) : uidPrefix
     const matchesUidPrefix =
       uidPrefix === paddedSelectedStateCode || normalizedUidPrefix === normalizedSelectedStateCode
-    const matchesStateColumn = stateColumnNames.some((columnName: string) => {
+
+    const matchesStateColumn = allStateColumns.some((columnName: string) => {
       const rawValue = row?.[columnName]
       if (rawValue === undefined || rawValue === null) return false
 

--- a/packages/map/src/helpers/tests/countyTerritories.test.ts
+++ b/packages/map/src/helpers/tests/countyTerritories.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { getCountyTerritoryVisibility } from '../countyTerritories'
+
+describe('countyTerritories', () => {
+  it('collects visible territory prefixes and county ids from runtime data', () => {
+    const runtimeData = {
+      '06001': { uid: '06001', value: 1 },
+      '72001': { uid: '72001', value: 2 }
+    }
+
+    const visibility = getCountyTerritoryVisibility(true, runtimeData)
+
+    expect(visibility.showTerritories).toBe(true)
+    expect(Array.from(visibility.statePrefixes).sort()).toEqual(['72'])
+    expect(Array.from(visibility.countyIds).sort()).toEqual(['72001'])
+    expect(visibility.key).toBe('true:72001')
+  })
+
+  it('collects multiple territory prefixes and ignores non-territory counties', () => {
+    const runtimeData = {
+      '72001': { uid: '72001', value: 1 },
+      '72003': { uid: '72003', value: 2 },
+      '78010': { uid: '78010', value: 3 },
+      '06001': { uid: '06001', value: 4 }
+    }
+
+    const visibility = getCountyTerritoryVisibility(true, runtimeData)
+
+    expect(Array.from(visibility.statePrefixes).sort()).toEqual(['72', '78'])
+    expect(Array.from(visibility.countyIds).sort()).toEqual(['72001', '72003', '78010'])
+    expect(visibility.key).toBe('true:72001,72003,78010')
+  })
+
+  it('hides county territories when the config flag is disabled even if territory data exists', () => {
+    const runtimeData = {
+      '72001': { uid: '72001', value: 1 }
+    }
+
+    const visibility = getCountyTerritoryVisibility(false, runtimeData)
+
+    expect(visibility.showTerritories).toBe(false)
+    expect(Array.from(visibility.statePrefixes).sort()).toEqual(['72'])
+    expect(Array.from(visibility.countyIds).sort()).toEqual(['72001'])
+    expect(visibility.key).toBe('false:')
+  })
+
+  it('hides county territories when the config flag is enabled but no territory data exists', () => {
+    const runtimeData = {
+      '06001': { uid: '06001', value: 1 }
+    }
+
+    const visibility = getCountyTerritoryVisibility(true, runtimeData)
+
+    expect(visibility.showTerritories).toBe(false)
+    expect(Array.from(visibility.statePrefixes).sort()).toEqual([])
+    expect(Array.from(visibility.countyIds).sort()).toEqual([])
+    expect(visibility.key).toBe('false:')
+  })
+
+  it('treats an omitted config flag as enabled by default but still hides territories when no territory data exists', () => {
+    const runtimeData = {
+      '06001': { uid: '06001', value: 1 }
+    }
+
+    const visibility = getCountyTerritoryVisibility(undefined, runtimeData)
+
+    expect(visibility.showTerritories).toBe(false)
+    expect(Array.from(visibility.statePrefixes)).toEqual([])
+    expect(Array.from(visibility.countyIds)).toEqual([])
+    expect(visibility.key).toBe('false:')
+  })
+
+  it('changes the key when visible territory county ids change within the same territory prefix', () => {
+    const firstVisibility = getCountyTerritoryVisibility(true, {
+      '72001': { uid: '72001', value: 1 }
+    })
+    const secondVisibility = getCountyTerritoryVisibility(true, {
+      '72003': { uid: '72003', value: 1 }
+    })
+
+    expect(Array.from(firstVisibility.statePrefixes)).toEqual(['72'])
+    expect(Array.from(secondVisibility.statePrefixes)).toEqual(['72'])
+    expect(firstVisibility.key).toBe('true:72001')
+    expect(secondVisibility.key).toBe('true:72003')
+    expect(firstVisibility.key).not.toBe(secondVisibility.key)
+  })
+})

--- a/packages/waffle-chart/src/CdcWaffleChart.tsx
+++ b/packages/waffle-chart/src/CdcWaffleChart.tsx
@@ -912,10 +912,11 @@ const CdcWaffleChart = ({
     }
   }, [config, container])
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+  // Keep direct config-prop usage in sync with parent data updates
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (!configObj?.dataUrl) {
-      updateConfig({ ...defaults, ...configObj })
+    if (configObj && config && JSON.stringify(configObj.data) !== JSON.stringify(config.data)) {
+      loadConfig().catch(err => console.warn(err))
     }
   }, [configObj?.data])
 

--- a/packages/waffle-chart/src/_stories/WaffleChart.smoke.stories.tsx
+++ b/packages/waffle-chart/src/_stories/WaffleChart.smoke.stories.tsx
@@ -5,6 +5,7 @@ import { expect } from 'storybook/test'
 import WaffleChart from '../CdcWaffleChart'
 import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
 import MinimalExampleConfig from '../../examples/minimal-example.json'
+import LegacyCountExampleConfig from '../../tests/fixtures/legacy-count-config.json'
 
 const meta: Meta<typeof WaffleChart> = {
   title: 'Components/Templates/WaffleChart',
@@ -195,6 +196,26 @@ export const Gauge: Story = {
   ),
   play: async ({ canvasElement }) => {
     await assertVisualizationRendered(canvasElement)
+  }
+}
+
+export const Legacy_Count_Config_Prop_Path: Story = {
+  args: {
+    config: JSON.parse(JSON.stringify(LegacyCountExampleConfig))
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Loads the legacy count example through the direct config prop path used by dashboard/editor-style renderers. Useful for reproducing config-object initialization behavior without going through configUrl.'
+      }
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    const primaryValue = canvasElement.querySelector('.cove-waffle-chart__data--primary') as HTMLElement | null
+    expect(primaryValue).toBeTruthy()
   }
 }
 

--- a/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
+++ b/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
@@ -6,6 +6,7 @@ import { render, waitFor } from '@testing-library/react'
 import { testStandaloneBuild } from '@cdc/core/helpers/tests/testStandaloneBuild.ts'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import CdcWaffleChart from '../CdcWaffleChart'
+import legacyCountExampleConfig from '../../tests/fixtures/legacy-count-config.json'
 
 vi.mock('resize-observer-polyfill', () => ({
   default: vi.fn(() => ({
@@ -40,6 +41,7 @@ const extractMarkedExampleConfig = (content, label) => {
 describe('Waffle Chart', () => {
   const createBaseConfig = overrides => ({
     type: 'waffle-chart',
+    version: '4.26.4-1',
     title: 'Test Waffle',
     showTitle: true,
     visualizationType: 'Waffle',
@@ -121,6 +123,19 @@ describe('Waffle Chart', () => {
 
     expect(readmeBlock).toEqual(minimalExample)
     expect(minimalExample.version).toBeTruthy()
+  })
+
+  it('renders the legacy count example through the direct config prop path', async () => {
+    const config = JSON.parse(JSON.stringify(legacyCountExampleConfig))
+
+    const { container } = render(<CdcWaffleChart config={config} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('.cove-waffle-chart')).toBeInTheDocument()
+    })
+
+    expect(getPrimaryValueText(container)).toBeTruthy()
+    expect(getPrimaryValueText(container)).not.toContain('out of')
   })
 
   it('moves the trend indicator below the value when a trend label is configured', async () => {

--- a/packages/waffle-chart/tests/fixtures/legacy-count-config.json
+++ b/packages/waffle-chart/tests/fixtures/legacy-count-config.json
@@ -1,0 +1,95 @@
+{
+  "title": "Legacy Count Waffle",
+  "showTitle": true,
+  "visualizationType": "Waffle",
+  "visualizationSubType": "linear",
+  "showPercent": true,
+  "showDenominator": true,
+  "valueDescription": "out of",
+  "content": "Of all inputs are from Federal sources",
+  "subtext": "",
+  "orientation": "horizontal",
+  "data": [
+    {
+      "Location": "Alaska",
+      "Year": "2021",
+      "Type": "Federal",
+      "Amount": "1436"
+    },
+    {
+      "Location": "Alaska",
+      "Year": "2021",
+      "Type": "Local",
+      "Amount": "1672"
+    },
+    {
+      "Location": "Alaska",
+      "Year": "2021",
+      "Type": "State",
+      "Amount": "1554"
+    },
+    {
+      "Location": "Alabama",
+      "Year": "2021",
+      "Type": "Federal",
+      "Amount": "1434"
+    },
+    {
+      "Location": "Alabama",
+      "Year": "2021",
+      "Type": "Local",
+      "Amount": "1670"
+    },
+    {
+      "Location": "Alabama",
+      "Year": "2021",
+      "Type": "State",
+      "Amount": "1552"
+    }
+  ],
+  "filters": [],
+  "fontSize": "",
+  "overallFontSize": "medium",
+  "dataColumn": "Amount",
+  "dataFunction": "Count",
+  "dataConditionalColumn": "Type",
+  "dataConditionalOperator": "=",
+  "dataConditionalComparate": "Federal",
+  "invalidComparate": false,
+  "customDenom": true,
+  "dataDenom": "100",
+  "dataDenomColumn": "Amount",
+  "dataDenomFunction": "Count",
+  "suffix": "%",
+  "roundToPlace": "0",
+  "shape": "square",
+  "nodeWidth": "13",
+  "nodeSpacer": "2",
+  "theme": "theme-green",
+  "type": "waffle-chart",
+  "gauge": {
+    "height": 35,
+    "width": "100%"
+  },
+  "visual": {
+    "border": true,
+    "accent": false,
+    "background": false,
+    "hideBackgroundColor": false,
+    "borderColorTheme": false,
+    "colors": {
+      "theme-blue": "#005eaa",
+      "theme-purple": "#712177",
+      "theme-brown": "#705043",
+      "theme-teal": "#00695c",
+      "theme-pink": "#af4448",
+      "theme-orange": "#bb4d00",
+      "theme-slate": "#29434e",
+      "theme-indigo": "#26418f",
+      "theme-cyan": "#006778",
+      "theme-green": "#4b830d",
+      "theme-amber": "#fbab18"
+    }
+  },
+  "version": "4.24.9"
+}


### PR DESCRIPTION
*Do not merge yet, confirming whether this release or not*

## Summary
Had a case where a dataset was using an unexpected column name for the state names that caused the data table to filter to nothing when zoomed in. This change makes it so the data table remains unchanged in such cases so it at least shows something. Also added the new new column name used, "jurisdiction".

Some of this might be improved more in the future, but this is a more minimal fix.

## Testing Steps
Load a county-level us map states under an unexpected column name.

## Optional
### Storybook Links
n/a

### Screenshots
n/a