### PR TITLE
DEV-12107 State Zoom failsafe when unexpected state column name used, and add "jurisdiction" as column name

### DIFF
--- a/packages/map/src/helpers/dataTableHelpers.ts
+++ b/packages/map/src/helpers/dataTableHelpers.ts
@@ -23,8 +23,8 @@ export const filterCountyTableRuntimeDataByStateCode = (runtimeData: any, stateC
   const runtimeKeys = Object.keys(runtimeData)
   if (runtimeKeys.length === 0) return runtimeData
 
-  const stateName = supportedStateFipsCodes[stateCode]
-  const stateAbbreviation = stateFipsToAbbreviation[stateCode]
+  const stateName = supportedStateFipsCodes?.[stateCode]
+  const stateAbbreviation = stateFipsToAbbreviation?.[stateCode]
   const normalizedSelectedStateCode = String(stateCode).replace(/^0+/, '')
   const paddedSelectedStateCode = normalizedSelectedStateCode.padStart(2, '0')
   const stateColumnNames = Object.values(config?.columns || {})

--- a/packages/map/src/helpers/dataTableHelpers.ts
+++ b/packages/map/src/helpers/dataTableHelpers.ts
@@ -1,5 +1,5 @@
 import {
-  stateFipsToTwoDigit as stateFipsToAbbreviation,
+  stateFipsToTwoDigit as stateCodeToAbbreviation,
   supportedStatesFipsCodes as supportedStateCodes
 } from '../data/supported-geos'
 
@@ -13,18 +13,47 @@ export const shouldShowDataTable = (config: any, table: any, general: any, loadi
 /**
  * Filters county runtime data to a selected state code for data table display.
  * Keeps the original non-enumerable fromHash metadata when present.
+ * Fail-safe: if no recognizable state columns exist in the data, returns original
+ * data unfiltered (avoids breaking misconfigured datasets). If valid state columns
+ * exist but a state has no data, returns empty result as expected.
  */
 export const filterCountyTableRuntimeDataByStateCode = (runtimeData: any, stateCode: string, config?: any) => {
   if (!runtimeData || runtimeData.init || !stateCode) return runtimeData
 
-  const filtered = {}
+  const runtimeKeys = Object.keys(runtimeData)
+  if (runtimeKeys.length === 0) return runtimeData
+
   const stateName = supportedStateCodes[stateCode]
-  const stateAbbreviation = stateFipsToAbbreviation[stateCode]
+  const stateAbbreviation = stateCodeToAbbreviation[stateCode]
   const normalizedSelectedStateCode = String(stateCode).replace(/^0+/, '')
   const paddedSelectedStateCode = normalizedSelectedStateCode.padStart(2, '0')
   const stateColumnNames = Object.values(config?.columns || {})
     .map((column: any) => column?.name)
-    .filter((name: string) => !!name && /(state|territory|fips)/i.test(name))
+    .filter((name: string) => !!name && /(state|territory|fips|jurisdiction)/i.test(name))
+
+  // Also check common state field names directly in the data rows
+  const commonStateFieldNames = [
+    'jurisdiction',
+    'state',
+    'State',
+    'state_name',
+    'stateName',
+    'State/Territory',
+    'state_territory_name'
+  ]
+  const allStateColumns = [...new Set([...stateColumnNames, ...commonStateFieldNames])]
+
+  // Fail-safe: check if UIDs look like FIPS codes OR if any state column exists in the data
+  const sampleRow = runtimeData[runtimeKeys[0]]
+  const uidLooksFips = runtimeKeys.some(uid => /^\d{2}/.test(String(uid)))
+  const hasStateColumn = allStateColumns.some(col => sampleRow?.[col] !== undefined)
+
+  // If data has neither FIPS-style UIDs nor any recognizable state columns, don't filter
+  if (!uidLooksFips && !hasStateColumn) {
+    return runtimeData
+  }
+
+  const filtered = {}
 
   if (runtimeData.fromHash !== undefined) {
     Object.defineProperty(filtered, 'fromHash', {
@@ -38,7 +67,8 @@ export const filterCountyTableRuntimeDataByStateCode = (runtimeData: any, stateC
     const normalizedUidPrefix = uidPrefix.startsWith('0') ? uidPrefix.slice(1) : uidPrefix
     const matchesUidPrefix =
       uidPrefix === paddedSelectedStateCode || normalizedUidPrefix === normalizedSelectedStateCode
-    const matchesStateColumn = stateColumnNames.some((columnName: string) => {
+
+    const matchesStateColumn = allStateColumns.some((columnName: string) => {
       const rawValue = row?.[columnName]
       if (rawValue === undefined || rawValue === null) return false
 

--- a/packages/map/src/helpers/dataTableHelpers.ts
+++ b/packages/map/src/helpers/dataTableHelpers.ts
@@ -1,6 +1,6 @@
 import {
-  stateFipsToTwoDigit as stateCodeToAbbreviation,
-  supportedStatesFipsCodes as supportedStateCodes
+  stateFipsToTwoDigit as stateFipsToAbbreviation,
+  supportedStatesFipsCodes as supportedStateFipsCodes
 } from '../data/supported-geos'
 
 /**
@@ -23,8 +23,8 @@ export const filterCountyTableRuntimeDataByStateCode = (runtimeData: any, stateC
   const runtimeKeys = Object.keys(runtimeData)
   if (runtimeKeys.length === 0) return runtimeData
 
-  const stateName = supportedStateCodes[stateCode]
-  const stateAbbreviation = stateCodeToAbbreviation[stateCode]
+  const stateName = supportedStateFipsCodes[stateCode]
+  const stateAbbreviation = stateFipsToAbbreviation[stateCode]
   const normalizedSelectedStateCode = String(stateCode).replace(/^0+/, '')
   const paddedSelectedStateCode = normalizedSelectedStateCode.padStart(2, '0')
   const stateColumnNames = Object.values(config?.columns || {})
@@ -43,13 +43,12 @@ export const filterCountyTableRuntimeDataByStateCode = (runtimeData: any, stateC
   ]
   const allStateColumns = [...new Set([...stateColumnNames, ...commonStateFieldNames])]
 
-  // Fail-safe: check if UIDs look like FIPS codes OR if any state column exists in the data
-  const sampleRow = runtimeData[runtimeKeys[0]]
-  const uidLooksFips = runtimeKeys.some(uid => /^\d{2}/.test(String(uid)))
-  const hasStateColumn = allStateColumns.some(col => sampleRow?.[col] !== undefined)
+  // Fail-safe: check if UIDs look like county FIPS codes (5 digits) OR if any state column exists in the data
+  const hasCountyFipsUids = runtimeKeys.some(uid => /^\d{5}$/.test(String(uid)))
+  const hasStateColumn = runtimeKeys.some(uid => allStateColumns.some(col => runtimeData[uid]?.[col] !== undefined))
 
-  // If data has neither FIPS-style UIDs nor any recognizable state columns, don't filter
-  if (!uidLooksFips && !hasStateColumn) {
+  // If data has neither county FIPS UIDs nor any recognizable state columns, don't filter
+  if (!hasCountyFipsUids && !hasStateColumn) {
     return runtimeData
   }
 


### PR DESCRIPTION
## Summary
Had a case where a dataset was using an unexpected column name for the state names that caused the data table to filter to nothing when zoomed in. This change makes it so the data table remains unchanged in such cases so it at least shows something. Also added the new new column name used, "jurisdiction".

Some of this might be improved more in the future, but this is a more minimal fix.

## Testing Steps
Load a county-level us map states under an unexpected column name.

## Optional
### Storybook Links
n/a

### Screenshots
n/a