### PR TITLE
Date parsing xtra formats

### DIFF
--- a/packages/core/helpers/cove/date.ts
+++ b/packages/core/helpers/cove/date.ts
@@ -17,15 +17,9 @@ const AUTO_DETECT_DATE_FORMATS = [
 
 export type AutoDetectDateFormat = (typeof AUTO_DETECT_DATE_FORMATS)[number]
 
-type DateSampleShape = {
-  separator: '' | '/' | '-'
-  partCount: number
-  parts: string[]
-}
-
 type AutoDetectDateFormatDefinition = {
   detectedFormat: AutoDetectDateFormat
-  separator: DateSampleShape['separator']
+  separator: '' | '/' | '-'
   partCount: number
   parseFormats: readonly string[]
 }
@@ -215,32 +209,28 @@ const normalizeDateSample = (value: unknown) => {
   return String(value).trim()
 }
 
-const detectDateSampleShape = (value: string): DateSampleShape | undefined => {
+const getNumericDateParts = (value: string) => {
   const separatorMatches = value.match(/[/-]/g) || []
   const uniqueSeparators = [...new Set(separatorMatches)]
 
   if (uniqueSeparators.length > 1) {
-    return undefined
+    return null
   }
 
-  const separator = (uniqueSeparators[0] || '') as DateSampleShape['separator']
+  const separator = (uniqueSeparators[0] || '') as '' | '/' | '-'
   const parts = separator ? value.split(separator) : [value]
 
   if (!parts.every(part => /^\d+$/.test(part))) {
-    return undefined
+    return null
   }
 
-  return {
-    separator,
-    partCount: parts.length,
-    parts
-  }
+  return { separator, parts }
 }
 
 const sampleMatchesFormatShape = (sample: string, detectedFormat: AutoDetectDateFormat) => {
-  const shape = detectDateSampleShape(sample)
+  const numericDateParts = getNumericDateParts(sample)
 
-  if (!shape) {
+  if (!numericDateParts) {
     return false
   }
 
@@ -252,20 +242,23 @@ const sampleMatchesFormatShape = (sample: string, detectedFormat: AutoDetectDate
     return false
   }
 
-  if (shape.separator !== formatDefinition.separator || shape.partCount !== formatDefinition.partCount) {
+  if (
+    numericDateParts.separator !== formatDefinition.separator ||
+    numericDateParts.parts.length !== formatDefinition.partCount
+  ) {
     return false
   }
 
   if (detectedFormat === '%Y') {
-    return shape.parts[0].length === 4
+    return numericDateParts.parts[0].length === 4
   }
 
   if (detectedFormat === '%Y-%m' || detectedFormat === '%Y/%m') {
-    return shape.parts[0].length === 4
+    return numericDateParts.parts[0].length === 4
   }
 
   if (detectedFormat === '%Y-%m-%d' || detectedFormat === '%Y/%m/%d') {
-    return shape.parts[0].length === 4
+    return numericDateParts.parts[0].length === 4
   }
 
   if (
@@ -274,7 +267,7 @@ const sampleMatchesFormatShape = (sample: string, detectedFormat: AutoDetectDate
     detectedFormat === '%m-%d-%Y' ||
     detectedFormat === '%d-%m-%Y'
   ) {
-    return shape.parts[2].length === 4
+    return numericDateParts.parts[2].length === 4
   }
 
   return true

--- a/packages/core/helpers/cove/date.ts
+++ b/packages/core/helpers/cove/date.ts
@@ -14,17 +14,94 @@ const AUTO_DETECT_DATE_FORMATS = [
   '%Y-%m',
   '%Y/%m'
 ] as const
-const AUTO_DETECT_DATE_FORMATTERS = Object.fromEntries(
-  AUTO_DETECT_DATE_FORMATS.map(format => [
-    format,
-    {
-      parser: timeParse(format),
-      formatter: timeFormat(format)
-    }
-  ])
-) as Record<AutoDetectDateFormat, { parser: ReturnType<typeof timeParse>; formatter: ReturnType<typeof timeFormat> }>
 
 export type AutoDetectDateFormat = (typeof AUTO_DETECT_DATE_FORMATS)[number]
+
+type DateSampleShape = {
+  separator: '' | '/' | '-'
+  partCount: number
+  parts: string[]
+}
+
+type AutoDetectDateFormatDefinition = {
+  detectedFormat: AutoDetectDateFormat
+  separator: DateSampleShape['separator']
+  partCount: number
+  parseFormats: readonly string[]
+}
+
+const AUTO_DETECT_DATE_FORMAT_DEFINITIONS: readonly AutoDetectDateFormatDefinition[] = [
+  {
+    detectedFormat: '%Y-%m-%d',
+    separator: '-',
+    partCount: 3,
+    parseFormats: ['%Y-%m-%d', '%Y-%m-%-d', '%Y-%-m-%d', '%Y-%-m-%-d']
+  },
+  {
+    detectedFormat: '%Y/%m/%d',
+    separator: '/',
+    partCount: 3,
+    parseFormats: ['%Y/%m/%d', '%Y/%m/%-d', '%Y/%-m/%d', '%Y/%-m/%-d']
+  },
+  {
+    detectedFormat: '%m/%d/%Y',
+    separator: '/',
+    partCount: 3,
+    parseFormats: ['%m/%d/%Y', '%m/%-d/%Y', '%-m/%d/%Y', '%-m/%-d/%Y']
+  },
+  {
+    detectedFormat: '%d/%m/%Y',
+    separator: '/',
+    partCount: 3,
+    parseFormats: ['%d/%m/%Y', '%d/%-m/%Y', '%-d/%m/%Y', '%-d/%-m/%Y']
+  },
+  {
+    detectedFormat: '%m-%d-%Y',
+    separator: '-',
+    partCount: 3,
+    parseFormats: ['%m-%d-%Y', '%m-%-d-%Y', '%-m-%d-%Y', '%-m-%-d-%Y']
+  },
+  {
+    detectedFormat: '%d-%m-%Y',
+    separator: '-',
+    partCount: 3,
+    parseFormats: ['%d-%m-%Y', '%d-%-m-%Y', '%-d-%m-%Y', '%-d-%-m-%Y']
+  },
+  {
+    detectedFormat: '%Y',
+    separator: '',
+    partCount: 1,
+    parseFormats: ['%Y']
+  },
+  {
+    detectedFormat: '%Y-%m',
+    separator: '-',
+    partCount: 2,
+    parseFormats: ['%Y-%m', '%Y-%-m']
+  },
+  {
+    detectedFormat: '%Y/%m',
+    separator: '/',
+    partCount: 2,
+    parseFormats: ['%Y/%m', '%Y/%-m']
+  }
+] as const
+
+const AUTO_DETECT_DATE_FORMATTERS = Object.fromEntries(
+  AUTO_DETECT_DATE_FORMAT_DEFINITIONS.map(({ detectedFormat, parseFormats }) => [
+    detectedFormat,
+    parseFormats.map(parseFormat => ({
+      parser: timeParse(parseFormat),
+      formatter: timeFormat(parseFormat)
+    }))
+  ])
+) as Record<
+  AutoDetectDateFormat,
+  {
+    parser: ReturnType<typeof timeParse>
+    formatter: ReturnType<typeof timeFormat>
+  }[]
+>
 
 export type DateFormatDetectionResult = {
   detectedFormat?: AutoDetectDateFormat
@@ -138,13 +215,83 @@ const normalizeDateSample = (value: unknown) => {
   return String(value).trim()
 }
 
+const detectDateSampleShape = (value: string): DateSampleShape | undefined => {
+  const separatorMatches = value.match(/[/-]/g) || []
+  const uniqueSeparators = [...new Set(separatorMatches)]
+
+  if (uniqueSeparators.length > 1) {
+    return undefined
+  }
+
+  const separator = (uniqueSeparators[0] || '') as DateSampleShape['separator']
+  const parts = separator ? value.split(separator) : [value]
+
+  if (!parts.every(part => /^\d+$/.test(part))) {
+    return undefined
+  }
+
+  return {
+    separator,
+    partCount: parts.length,
+    parts
+  }
+}
+
+const sampleMatchesFormatShape = (sample: string, detectedFormat: AutoDetectDateFormat) => {
+  const shape = detectDateSampleShape(sample)
+
+  if (!shape) {
+    return false
+  }
+
+  const formatDefinition = AUTO_DETECT_DATE_FORMAT_DEFINITIONS.find(
+    definition => definition.detectedFormat === detectedFormat
+  )
+
+  if (!formatDefinition) {
+    return false
+  }
+
+  if (shape.separator !== formatDefinition.separator || shape.partCount !== formatDefinition.partCount) {
+    return false
+  }
+
+  if (detectedFormat === '%Y') {
+    return shape.parts[0].length === 4
+  }
+
+  if (detectedFormat === '%Y-%m' || detectedFormat === '%Y/%m') {
+    return shape.parts[0].length === 4
+  }
+
+  if (detectedFormat === '%Y-%m-%d' || detectedFormat === '%Y/%m/%d') {
+    return shape.parts[0].length === 4
+  }
+
+  if (
+    detectedFormat === '%m/%d/%Y' ||
+    detectedFormat === '%d/%m/%Y' ||
+    detectedFormat === '%m-%d-%Y' ||
+    detectedFormat === '%d-%m-%Y'
+  ) {
+    return shape.parts[2].length === 4
+  }
+
+  return true
+}
+
 const matchesDateFormatExactly = (format: AutoDetectDateFormat, value: string) => {
-  const { parser, formatter } = AUTO_DETECT_DATE_FORMATTERS[format]
-  const parsedValue = parser(value)
+  if (!sampleMatchesFormatShape(value, format)) {
+    return false
+  }
 
-  if (!parsedValue) return false
+  return AUTO_DETECT_DATE_FORMATTERS[format].some(({ parser, formatter }) => {
+    const parsedValue = parser(value)
 
-  return formatter(parsedValue) === value
+    if (!parsedValue) return false
+
+    return formatter(parsedValue) === value
+  })
 }
 
 export function detectDateParseFormat(values: unknown[]): DateFormatDetectionResult {
@@ -170,9 +317,13 @@ export function detectDateParseFormat(values: unknown[]): DateFormatDetectionRes
     }
   }
 
-  const matchingFormats = AUTO_DETECT_DATE_FORMATS.filter(format =>
-    samples.every(sample => matchesDateFormatExactly(format, sample))
-  )
+  let candidateFormats = AUTO_DETECT_DATE_FORMATS.filter(format => sampleMatchesFormatShape(samples[0], format))
+
+  for (const sample of samples.slice(1)) {
+    candidateFormats = candidateFormats.filter(format => sampleMatchesFormatShape(sample, format))
+  }
+
+  const matchingFormats = candidateFormats.filter(format => samples.every(sample => matchesDateFormatExactly(format, sample)))
 
   if (matchingFormats.length === 1) {
     return {

--- a/packages/core/helpers/tests/date.test.ts
+++ b/packages/core/helpers/tests/date.test.ts
@@ -138,6 +138,35 @@ describe('detectDateParseFormat', () => {
     })
   })
 
+  it('detects canonical formats when samples omit leading zeroes', () => {
+    expect(detectDateParseFormat(['2024/3/5', '2025/11/9'])).toMatchObject({
+      detectedFormat: '%Y/%m/%d',
+      isReliable: true
+    })
+
+    expect(detectDateParseFormat(['3/15/2024', '11/9/2025'])).toMatchObject({
+      detectedFormat: '%m/%d/%Y',
+      isReliable: true
+    })
+
+    expect(detectDateParseFormat(['15/3/2024', '9/11/2025'])).toMatchObject({
+      detectedFormat: '%d/%m/%Y',
+      isReliable: true
+    })
+  })
+
+  it('detects canonical formats when padded and unpadded samples are mixed', () => {
+    expect(detectDateParseFormat(['2024/03/5', '2025/11/09'])).toMatchObject({
+      detectedFormat: '%Y/%m/%d',
+      isReliable: true
+    })
+
+    expect(detectDateParseFormat(['03/5/2024', '11/13/2025'])).toMatchObject({
+      detectedFormat: '%m/%d/%Y',
+      isReliable: true
+    })
+  })
+
   it('detects year-only and year-month formats', () => {
     expect(detectDateParseFormat(['2024', '2025'])).toMatchObject({
       detectedFormat: '%Y',
@@ -172,8 +201,42 @@ describe('detectDateParseFormat', () => {
     })
   })
 
+  it('rejects samples with unsupported separators or non-numeric parts', () => {
+    expect(detectDateParseFormat(['2024.03.15'])).toMatchObject({
+      isReliable: false,
+      failureReason: 'no_matching_format'
+    })
+
+    expect(detectDateParseFormat(['Mar 15 2024'])).toMatchObject({
+      isReliable: false,
+      failureReason: 'no_matching_format'
+    })
+  })
+
+  it('uses sample shape to narrow candidates before exact parsing', () => {
+    expect(detectDateParseFormat(['2024/03/15', '2025/11/09'])).toMatchObject({
+      detectedFormat: '%Y/%m/%d',
+      isReliable: true,
+      ambiguous: false
+    })
+
+    expect(detectDateParseFormat(['2024-03', '2025-11'])).toMatchObject({
+      detectedFormat: '%Y-%m',
+      isReliable: true,
+      ambiguous: false
+    })
+  })
+
   it('treats dual-valid samples as ambiguous', () => {
     expect(detectDateParseFormat(['01/02/2024', '02/03/2024'])).toMatchObject({
+      isReliable: false,
+      ambiguous: true,
+      failureReason: 'ambiguous'
+    })
+  })
+
+  it('still treats unpadded dual-valid samples as ambiguous', () => {
+    expect(detectDateParseFormat(['1/2/2024', '2/3/2024'])).toMatchObject({
       isReliable: false,
       ambiguous: true,
       failureReason: 'ambiguous'
@@ -206,6 +269,18 @@ describe('getAutoDetectedDateParseFormat', () => {
         [
           { date: '2024/03/15', value: 10 },
           { date: '2025/11/09', value: 12 }
+        ],
+        'date'
+      )
+    ).toBe('%Y/%m/%d')
+  })
+
+  it('detects a reliable format from a selected data key when month/day zeroes are omitted', () => {
+    expect(
+      getAutoDetectedDateParseFormat(
+        [
+          { date: '2024/3/5', value: 10 },
+          { date: '2025/11/9', value: 12 }
         ],
         'date'
       )


### PR DESCRIPTION
## Summary
Added support for non-zero padded dates (Ex. 3/5/2026 or 10/4/2025). 

This isnt the most elegant solution but we are thinking most dates from CSVs that users will upload wont have leading zeroes most of the time which was the primary point of failure.
