### PR TITLE
fix: remove axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@visx/legend": "^3.12.0",
     "@visx/pattern": "^3.12.0",
     "@visx/responsive": "^3.12.0",
-    "axios": "^1.13.2",
     "chroma-js": "^3.1.2",
     "d3-format": "^3.1.2",
     "dompurify": "^3.4.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -12,7 +12,6 @@
     "@cdc/map": "^4.26.2",
     "@cdc/markup-include": "^4.26.2",
     "@cdc/waffle-chart": "^4.26.2",
-    "axios": "^1.13.2",
     "d3": "^7.9.0",
     "react-dropzone": "^14.3.8",
     "use-debounce": "^10.1.0"

--- a/packages/editor/src/components/DataImport/components/DataImport.tsx
+++ b/packages/editor/src/components/DataImport/components/DataImport.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useContext, useEffect } from 'react'
 import { useDropzone } from 'react-dropzone'
-import axios from 'axios'
 import { csvFormat } from 'd3'
 
 import { DataTransform } from '@cdc/core/helpers/DataTransform'
@@ -102,25 +101,20 @@ const DataImport = () => {
 
     try {
       // eslint-disable-next-line no-unused-vars
-      await axios
-        .get(dataURL.toString(), {
-          responseType: 'blob'
-        })
-        .then(response => {
-          responseBlob = response.data
+      const response = await fetch(dataURL.toString())
+      responseBlob = await response.blob()
 
-          // Sometimes the files are coming in as plain text types... Maybe when saved from Macs
-          const csvTypes = ['text/csv', 'text/plain']
-          if ((fileExtension === '.csv' && csvTypes.includes(responseBlob.type)) || isSolrCsv(externalURL)) {
-            responseBlob = responseBlob.slice(0, responseBlob.size, 'text/csv')
-          } else if (
-            responseBlob.type === 'application/json' ||
-            (fileExtension === '.json' && responseBlob.type === 'text/plain') ||
-            isSolrJson(externalURL)
-          ) {
-            responseBlob = responseBlob.slice(0, responseBlob.size, 'application/json')
-          }
-        })
+      // Sometimes the files are coming in as plain text types... Maybe when saved from Macs
+      const csvTypes = ['text/csv', 'text/plain']
+      if ((fileExtension === '.csv' && csvTypes.includes(responseBlob.type)) || isSolrCsv(externalURL)) {
+        responseBlob = responseBlob.slice(0, responseBlob.size, 'text/csv')
+      } else if (
+        responseBlob.type === 'application/json' ||
+        (fileExtension === '.json' && responseBlob.type === 'text/plain') ||
+        isSolrJson(externalURL)
+      ) {
+        responseBlob = responseBlob.slice(0, responseBlob.size, 'application/json')
+      }
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('Error in loadExternal', err)

--- a/packages/editor/src/components/DataImport/components/DataImport.tsx
+++ b/packages/editor/src/components/DataImport/components/DataImport.tsx
@@ -102,6 +102,9 @@ const DataImport = () => {
     try {
       // eslint-disable-next-line no-unused-vars
       const response = await fetch(dataURL.toString())
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`)
+      }
       responseBlob = await response.blob()
 
       // Sometimes the files are coming in as plain text types... Maybe when saved from Macs

--- a/packages/markup-include/package.json
+++ b/packages/markup-include/package.json
@@ -7,7 +7,6 @@
   "bugs": "https://github.com/CDCgov/cdc-open-viz/issues",
   "dependencies": {
     "@cdc/core": "^4.26.2",
-    "axios": "^1.13.2",
     "dompurify": "^3.4.0",
     "lodash": "^4.17.23",
     "react-accessible-accordion": "^5.0.1"

--- a/packages/markup-include/src/CdcMarkupInclude.tsx
+++ b/packages/markup-include/src/CdcMarkupInclude.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useCallback, useRef, useReducer, useMemo } from 'react'
 // external
 import DOMPurify from 'dompurify'
-import axios from 'axios'
 import parse from 'html-react-parser'
 
 // cdc
@@ -201,20 +200,18 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({
         dispatch({ type: 'SET_URL_MARKUP', payload })
       } else {
         try {
-          await axios.get(srcUrl).then(res => {
-            if (res.data) {
-              dispatch({ type: 'SET_URL_MARKUP', payload: res.data })
+          const res = await fetch(srcUrl)
+          if (!res.ok) {
+            dispatch({ type: 'SET_MARKUP_ERROR', payload: res.status })
+            dispatch({ type: 'SET_URL_MARKUP', payload: '' })
+          } else {
+            const data = await res.text()
+            if (data) {
+              dispatch({ type: 'SET_URL_MARKUP', payload: data })
             }
-          })
-        } catch (err) {
-          if (err.response) {
-            // Response with error
-            dispatch({ type: 'SET_MARKUP_ERROR', payload: err.response.status })
-          } else if (err.request) {
-            // No response received
-            dispatch({ type: 'SET_MARKUP_ERROR', payload: 200 })
           }
-
+        } catch {
+          dispatch({ type: 'SET_MARKUP_ERROR', payload: 200 })
           dispatch({ type: 'SET_URL_MARKUP', payload: '' })
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4369,7 +4369,7 @@ axe-core@^4.10.0, axe-core@^4.2.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.1.tgz#052ff9b2cbf543f5595028b583e4763b40c78ea7"
   integrity sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==
 
-axios@^1.13.2, axios@^1.6.0, axios@^1.8.3:
+axios@^1.6.0, axios@^1.8.3:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
   integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==


### PR DESCRIPTION
This pull request removes the `axios` dependency from multiple packages and replaces its usage with the native `fetch` API. This change simplifies the codebase by reducing external dependencies and streamlining HTTP request handling.

**Dependency removal:**

* Removed `axios` from the dependencies in `package.json`, `packages/editor/package.json`, and `packages/markup-include/package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12) [[2]](diffhunk://#diff-f4eedd0a8aaf55cc64de9e66438e075fb5c0c992b6fd2039bf5863b06cea99a0L15) [[3]](diffhunk://#diff-2ffc7984c7b47fd7c7f75cf23450b6ff4c4dccbad23b2a15ebfc8808009f2eceL10)

**Code refactoring:**

* Replaced all instances of `axios` with the native `fetch` API in `DataImport.tsx` and `CdcMarkupInclude.tsx`, updating the logic for HTTP requests and error handling accordingly. [[1]](diffhunk://#diff-862aed1b4418f413867cc10ce3c7832b7069d3134b6f96dea5be950313c39d33L3) [[2]](diffhunk://#diff-862aed1b4418f413867cc10ce3c7832b7069d3134b6f96dea5be950313c39d33L105-R105) [[3]](diffhunk://#diff-862aed1b4418f413867cc10ce3c7832b7069d3134b6f96dea5be950313c39d33L123) [[4]](diffhunk://#diff-7da8fb18a78d77d50577ff6833395b34ed9f904d16ca1a9c18cad6473a1f0221L4) [[5]](diffhunk://#diff-7da8fb18a78d77d50577ff6833395b34ed9f904d16ca1a9c18cad6473a1f0221L204-R214)