### PR TITLE
FIX: [dev-12991] County Map Memory issues

### DIFF
--- a/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.County.tsx
@@ -295,6 +295,8 @@ const CountyMap = () => {
         const context = canvasRef.current.getContext('2d') as CanvasRenderingContext2D
         context.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height)
       }
+      geoPathCacheRef.current.clear()
+      geoPathCacheKeyRef.current = ''
       setTopoData(response)
     })
   }
@@ -350,6 +352,7 @@ const CountyMap = () => {
   const zoomBehaviorRef = useRef()
   const zoomFrameRef = useRef<number | null>(null)
   const geoPathCacheRef = useRef<Map<string, Path2D>>(new Map())
+  const geoPathCacheKeyRef = useRef('')
 
   // Clear pattern cache when pattern configuration changes
   useEffect(() => {
@@ -359,8 +362,20 @@ const CountyMap = () => {
   const runtimeKeys = runtimeData ? Object.keys(runtimeData) : []
   const lineWidth = 1
 
+  const getPathCacheKey = (canvas: HTMLCanvasElement) =>
+    [
+      topoData.year,
+      topoData.mapData?.length || 0,
+      topoData.states?.length || 0,
+      topoData.hsas?.length || 0,
+      focus.id || '',
+      canvas.clientWidth,
+      config.general.showHSABoundaries ? 'hsa' : 'county',
+      territoryVisibility.key
+    ].join('|')
+
   // Pre-compute Path2D objects for all geo features — avoids expensive geoPath projection on every zoom frame
-  const buildPathCache = () => {
+  const buildPathCache = (cacheKey: string) => {
     const pathGen = geoPath(topoData.projection)
     const cache = new Map<string, Path2D>()
     topoData.mapData.forEach(geo => {
@@ -378,7 +393,9 @@ const CountyMap = () => {
       const d = pathGen(hsa.feature as any)
       if (d) cache.set('hsa_border_' + hsa.groupId, new Path2D(d))
     })
+    geoPathCacheRef.current.clear()
     geoPathCacheRef.current = cache
+    geoPathCacheKeyRef.current = cacheKey
   }
 
   const resetZoomTransform = () => {
@@ -862,14 +879,17 @@ const CountyMap = () => {
     context.restore()
   }
 
-  // Sets up canvas dimensions, projection, and Path2D cache, then renders.
+  // Sets up canvas dimensions and projection, rebuilds the Path2D cache only when geometry changes, then renders.
   // Called on data change, resize, focus change — NOT during zoom/pan.
   const drawCanvas = () => {
     if (canvasRef.current && runtimeLegend.items.length > 0) {
       const canvas = canvasRef.current
 
-      canvas.width = canvas.clientWidth
-      canvas.height = canvas.width * 0.6
+      const canvasWidth = canvas.clientWidth
+      const canvasHeight = canvasWidth * 0.6
+
+      if (canvas.width !== canvasWidth) canvas.width = canvasWidth
+      if (canvas.height !== canvasHeight) canvas.height = canvasHeight
 
       topoData.projection.scale(canvas.width * 1.25).translate([canvas.width / 2, canvas.height / 2])
 
@@ -883,8 +903,10 @@ const CountyMap = () => {
         topoData.projection.fitExtent(fitExtent, focus.feature)
       }
 
-      // Pre-compute Path2D objects with the current projection
-      buildPathCache()
+      const pathCacheKey = getPathCacheKey(canvas)
+      if (geoPathCacheKeyRef.current !== pathCacheKey || geoPathCacheRef.current.size === 0) {
+        buildPathCache(pathCacheKey)
+      }
 
       // Render the map
       renderFrame()


### PR DESCRIPTION
## Summary
<!-- Provide a brief explanation of the changes -->
Explanation from Codex: 
The likely memory issue is in UsaMap.County.tsx (line 362): buildPathCache() creates thousands of new native Path2D objects every time drawCanvas() runs.

That becomes dangerous because drawCanvas() is called from an effect with very broad dependencies:

UsaMap.County.tsx (line 1121)
```
useEffect(() => {
  if (isLoading) return
  drawCanvas()
}, [isLoading, topoData, focus, runtimeLegend, runtimeData, featureArray, config, filteredCountyCode])
```

So any new config, runtimeData, runtimeLegend, focus, or filteredCountyCode reference can rebuild the entire path cache. With HSA boundaries enabled, that includes roughly:

- 3,200 county/state paths
- plus about 949 merged HSA boundary paths
- each as a browser-native Path2D

Those old native objects may not be collected immediately, so repeated renders can balloon browser memory until it crashes.

The fix is to separate “projection/layout changed, rebuild Path2D cache” from “data/legend/selection changed, repaint using existing cache.” In other words: don’t call buildPathCache() when only colors, legend data, runtime data, or selected county changes.

## Testing Steps
<!-- Provide testing steps -->
<!-- Add applicable configs to JIRA ticket for testers-->

## Optional
### Storybook Links
<!-- Add links to Storybook components if relevant -->
<!-- E.g., "Storybook URL: [Link to component]" -->

### Screenshots
<!-- Add any relevant screenshots for UI changes -->
