### PR TITLE
Fix data-bite & waffle empty data column

### DIFF
--- a/packages/data-bite/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/data-bite/src/components/EditorPanel/EditorPanel.tsx
@@ -40,16 +40,17 @@ const EditorPanel: React.FC<DataBiteEditorPanelProps> = () => {
   const { config, updateConfig, loading, data, editorData, setParentConfig, isDashboard } = useContext(Context)
 
   const updateField = updateFieldFactory(config, updateConfig, true)
+  const columnSourceData = Array.isArray(editorData) && editorData.length ? editorData : data
 
   // Filters -----------------------------------------------
   const { addNewFilter, removeFilter, updateFilterProp, getFilterColumnValues } = useFilterManagement(
     config,
     updateConfig,
-    data
+    columnSourceData
   )
 
   // Extract column names from data with memoization (replaces getColumns)
-  const columns = useDataColumns(data)
+  const columns = useDataColumns(columnSourceData)
 
   // Dynamic Images ----------------------------------------
   // Use standardized list management hook (Phase 2 improvement)

--- a/packages/data-bite/src/test/CdcDataBite.test.jsx
+++ b/packages/data-bite/src/test/CdcDataBite.test.jsx
@@ -2,7 +2,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import vm from 'node:vm'
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { testStandaloneBuild } from '@cdc/core/helpers/tests/testStandaloneBuild.ts'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import CdcDataBite from '../CdcDataBite'
@@ -21,6 +21,14 @@ vi.mock('@cdc/core/components/ui/TrendArrow', () => ({
       <span className='mock-trend-arrow'>{label || 'Trend'}</span>
     </span>
   )
+}))
+
+vi.mock('@cdc/core/components/ui/Icon', () => ({
+  default: ({ display }) => <span data-testid='mock-icon'>{display}</span>
+}))
+
+vi.mock('@cdc/core/components/AdvancedEditor', () => ({
+  default: () => null
 }))
 
 afterEach(() => {
@@ -60,6 +68,30 @@ describe('Data Bite', () => {
 
     expect(await screen.findByText('Test body')).toBeInTheDocument()
     expect(screen.getByText('Test subtext')).toBeInTheDocument()
+  })
+
+  it('uses dashboard raw data for editor column options when rendered data is empty', async () => {
+    render(
+      <CdcDataBite
+        isDashboard={true}
+        isEditor={true}
+        rawData={[{ metric: 42, region: 'East' }]}
+        config={{
+          type: 'data-bite',
+          theme: 'theme-blue',
+          title: 'Test title',
+          biteBody: 'Test body',
+          data: []
+        }}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Data' }))
+
+    const dataColumnSelect = screen.getByLabelText('Data Column')
+    const options = Array.from(dataColumnSelect.options).map(option => option.value)
+
+    expect(options).toEqual(expect.arrayContaining(['metric', 'region']))
   })
 
   it('keeps the minimal example in sync with the README docs', () => {

--- a/packages/waffle-chart/src/components/EditorPanel.jsx
+++ b/packages/waffle-chart/src/components/EditorPanel.jsx
@@ -29,12 +29,13 @@ const EditorPanel = memo(props => {
   const inputSelectStyle = condition => (condition ? { backgroundColor: '#ffd2d2', color: '#d8000c' } : {})
 
   const updateField = updateFieldFactory(config, updateConfig, true)
+  const columnSourceData = Array.isArray(editorData) && editorData.length ? editorData : data
 
   // Filters
   const { addNewFilter, removeFilter, updateFilterProp, getFilterColumnValues } = useFilterManagement(
     config,
     updateConfig,
-    data
+    columnSourceData
   )
 
   useEffect(() => {
@@ -54,7 +55,7 @@ const EditorPanel = memo(props => {
   }, [config.dataConditionalOperator, config.dataConditionalComparate])
 
   // Extract column names from data with memoization (replaces getColumns)
-  const columns = useDataColumns(data)
+  const columns = useDataColumns(columnSourceData)
   //visualizationType
 
   const approvedWaffleChartOptions = [

--- a/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
+++ b/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
@@ -2,7 +2,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import vm from 'node:vm'
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { testStandaloneBuild } from '@cdc/core/helpers/tests/testStandaloneBuild.ts'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import CdcWaffleChart from '../CdcWaffleChart'
@@ -22,6 +22,18 @@ vi.mock('@cdc/core/components/ui/TrendArrow', () => ({
       <span className='mock-trend-arrow'>{label || 'Trend'}</span>
     </span>
   )
+}))
+
+vi.mock('@cdc/core/components/ui/Icon', () => ({
+  default: ({ display }) => <span data-testid='mock-icon'>{display}</span>
+}))
+
+vi.mock('@cdc/core/components/AdvancedEditor', () => ({
+  default: () => null
+}))
+
+vi.mock('../images/warning.svg', () => ({
+  default: props => <span data-testid='mock-warning-icon' {...props} />
 }))
 
 afterEach(() => {
@@ -123,6 +135,28 @@ describe('Waffle Chart', () => {
 
     expect(readmeBlock).toEqual(minimalExample)
     expect(minimalExample.version).toBeTruthy()
+  })
+
+  it('uses dashboard raw data for editor column options when rendered data is empty', async () => {
+    render(
+      <CdcWaffleChart
+        isDashboard={true}
+        isEditor={true}
+        rawData={[{ numerator: 42, denominator: 100, region: 'East' }]}
+        config={createBaseConfig({
+          data: [],
+          dataColumn: '',
+          dataFunction: ''
+        })}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Data' }))
+
+    const dataColumnSelect = screen.getByLabelText('Data Column')
+    const options = Array.from(dataColumnSelect.options).map(option => option.value)
+
+    expect(options).toEqual(expect.arrayContaining(['denominator', 'numerator', 'region']))
   })
 
   it('renders the legacy count example through the direct config prop path', async () => {


### PR DESCRIPTION
## Summary

Fixes a regression/bug for data bites and waffle charts where the data column dropdown was empty in the editor.