### PR TITLE
Enhancement [DEV-11976] TP5 waffle subtext improvements

### DIFF
--- a/packages/data-bite/src/CdcDataBite.tsx
+++ b/packages/data-bite/src/CdcDataBite.tsx
@@ -767,7 +767,7 @@ const CdcDataBite = (props: CdcDataBiteProps) => {
                 <div className='cdc-callout__content cove-prose cdc-callout__content-slot flex-grow-1 d-flex flex-column min-w-0'>
                   <p className='mb-0'>{parse(processContentWithMarkup(biteBody))}</p>
                   {subtext && !isCompactStyle && (
-                    <p className='bite-subtext fst-italic flex-shrink-0'>{parse(processContentWithMarkup(subtext))}</p>
+                    <p className='bite-subtext flex-shrink-0'>{parse(processContentWithMarkup(subtext))}</p>
                   )}
                 </div>
               </div>

--- a/packages/data-bite/src/scss/bite.scss
+++ b/packages/data-bite/src/scss/bite.scss
@@ -294,7 +294,6 @@
     }
 
     .bite-subtext {
-      font-style: italic;
       line-height: var(--visualization-body-line-height);
     }
 

--- a/packages/data-bite/src/test/CdcDataBite.test.jsx
+++ b/packages/data-bite/src/test/CdcDataBite.test.jsx
@@ -232,6 +232,41 @@ describe('Data Bite', () => {
     expect(container.querySelector('.mock-trend-arrow-wrap.cove-trend-arrow__wrap--inline')).toBeInTheDocument()
   })
 
+  it('renders TP5 subtext without forcing italics', () => {
+    const { container } = render(
+      <CdcDataBite
+        config={{
+          type: 'data-bite',
+          theme: 'theme-blue',
+          title: 'Test title',
+          biteStyle: 'tp5',
+          biteBody: 'Test body',
+          subtext: 'Source: example data',
+          dataColumn: 'value',
+          dataFunction: 'Pass Through',
+          dataFormat: {
+            prefix: '',
+            suffix: '',
+            commas: false,
+            roundToPlace: 0
+          },
+          visual: {
+            showTitle: true,
+            useWrap: false,
+            whiteBackground: false,
+            border: true
+          },
+          data: [{ value: '42' }]
+        }}
+      />
+    )
+
+    const subtext = container.querySelector('.bite__style--tp5 .bite-subtext')
+
+    expect(subtext).toHaveTextContent('Source: example data')
+    expect(subtext).not.toHaveClass('fst-italic')
+  })
+
   it('renders a no-change trend label when numeric no-change arrows are enabled', () => {
     const { container } = render(
       <CdcDataBite

--- a/packages/waffle-chart/src/CdcWaffleChart.tsx
+++ b/packages/waffle-chart/src/CdcWaffleChart.tsx
@@ -165,6 +165,7 @@ const WaffleChart = ({ config, isEditor, link = '', showConfigConfirm, updateCon
   const processedDownLabel = processedTextFields.downLabel
   const processedNoChangeLabel = processedTextFields.noChangeLabel
   const processedTrendLabel = processedTextFields.trendLabel
+  const isTp5Waffle = config.visualizationType === 'TP5 Waffle'
   const supportsTrendIndicator = config.visualizationType === 'TP5 Waffle' || config.visualizationType === 'TP5 Gauge'
 
   const gaugeColor = config.visual.colors[config.theme]
@@ -712,9 +713,7 @@ const WaffleChart = ({ config, isEditor, link = '', showConfigConfirm, updateCon
                   </Group>
                 </svg>
                 {processedSubtext && (
-                  <div className='cove-waffle-chart__subtext subtext cove-prose fst-italic mt-2'>
-                    {parse(processedSubtext)}
-                  </div>
+                  <div className='cove-waffle-chart__subtext subtext cove-prose mt-2'>{parse(processedSubtext)}</div>
                 )}
               </>
             ) : (
@@ -775,11 +774,16 @@ const WaffleChart = ({ config, isEditor, link = '', showConfigConfirm, updateCon
                 <div className='cove-waffle-chart__data--text cove-prose'>{parse(processedContent)}</div>
               )}
 
-              {processedSubtext && (
+              {processedSubtext && !isTp5Waffle && (
                 <div className='cove-waffle-chart__subtext subtext cove-prose fst-italic'>
                   {parse(processedSubtext)}
                 </div>
               )}
+            </div>
+          )}
+          {processedSubtext && isTp5Waffle && (
+            <div className='cove-waffle-chart__subtext cove-waffle-chart__subtext--below subtext cove-prose'>
+              {parse(processedSubtext)}
             </div>
           )}
         </div>

--- a/packages/waffle-chart/src/scss/waffle-chart.scss
+++ b/packages/waffle-chart/src/scss/waffle-chart.scss
@@ -3,8 +3,7 @@
 // Let core styles handle color palette
 
 .cove-visualization.type-waffle-chart {
-  .cove-waffle-chart__subtext.subtext,
-  .cove-waffle-chart__subtext.subtext.fst-italic {
+  .cove-waffle-chart__subtext.subtext {
     line-height: var(--visualization-body-line-height);
   }
 
@@ -74,7 +73,6 @@
     }
 
     &__subtext {
-      font-style: italic;
       line-height: var(--visualization-body-line-height);
     }
 
@@ -82,6 +80,10 @@
       line-height: 1.25em;
       font-weight: 400;
     }
+  }
+
+  &:not(.gauge__style--tp5) .cove-gauge-chart__subtext {
+    font-style: italic;
   }
 
   .cove-waffle-chart {
@@ -123,6 +125,10 @@
     .cove-waffle-chart__data--text {
       line-height: 1.25em;
       width: 100%;
+    }
+
+    > .cove-waffle-chart__subtext {
+      margin-top: 1em;
     }
   }
 
@@ -225,7 +231,7 @@
       align-items: flex-start;
       padding: 0;
       row-gap: 1rem;
-      flex-wrap: nowrap;
+      flex-wrap: wrap;
     }
 
     // Container query: wrap when width is less than 576px
@@ -268,6 +274,13 @@
 
     .cove-waffle-chart__subtext {
       margin-top: 1rem;
+    }
+
+    .cove-waffle-chart__subtext--below {
+      flex: 0 0 100%;
+      width: 100%;
+      margin-top: 0;
+      text-align: left;
     }
 
     // White background variant (when "Use White Background Style" is checked)

--- a/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
+++ b/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
@@ -287,6 +287,56 @@ describe('Waffle Chart', () => {
     expect(container.querySelector('.mock-trend-arrow-wrap.cove-trend-arrow__wrap--inline')).toBeInTheDocument()
   })
 
+  it('places TP5 waffle subtext below the chart row without forcing italics', async () => {
+    const { container } = render(
+      <CdcWaffleChart
+        config={createBaseConfig({
+          visualizationType: 'TP5 Waffle',
+          shape: 'square',
+          subtext: 'Source: example data'
+        })}
+      />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.cove-waffle-chart__subtext--below')).toBeInTheDocument()
+    })
+
+    const waffle = container.querySelector('.cove-waffle-chart')
+    const data = container.querySelector('.cove-waffle-chart__data')
+    const subtext = container.querySelector('.cove-waffle-chart__subtext--below')
+
+    expect(subtext).toHaveTextContent('Source: example data')
+    expect(subtext).not.toHaveClass('fst-italic')
+    expect(subtext?.parentElement).toBe(waffle)
+    expect(data?.contains(subtext)).toBe(false)
+    expect(Array.from(waffle?.children || []).at(-1)).toBe(subtext)
+  })
+
+  it('renders TP5 gauge subtext without forcing italics', async () => {
+    const { container } = render(
+      <CdcWaffleChart
+        config={createBaseConfig({
+          visualizationType: 'TP5 Gauge',
+          subtext: 'Source: example data',
+          gauge: {
+            height: 20,
+            width: 200
+          }
+        })}
+      />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.gauge__style--tp5 .cove-waffle-chart__subtext')).toBeInTheDocument()
+    })
+
+    const subtext = container.querySelector('.gauge__style--tp5 .cove-waffle-chart__subtext')
+
+    expect(subtext).toHaveTextContent('Source: example data')
+    expect(subtext).not.toHaveClass('fst-italic')
+  })
+
   it('renders a no-change trend label when numeric no-change arrows are enabled', async () => {
     const { container } = render(
       <CdcWaffleChart


### PR DESCRIPTION
## Summary

A few minor updates to the new TP waffle chart subtext.

## Testing Steps

Open or create a TP5 waffle, check that subtext appears below the waffle on all screen sizes and is not italicized by default.