### PR TITLE
Fix [DEV-12963] Deprecate filtered text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Before working on a specific area, read the relevant context document from the `
 
 | Document                             | When to Use                                                                                                                                                                      |
 | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `docs/FILTERED_TEXT_DEPRECATION.md`  | Working on the `filtered-text` deprecation. Phase 1 was implemented in `4.26.5`; Phase 2 is planned for `4.26.6`. Covers the two-phase rollout, migration contract, and cleanup/removal expectations. |
 | `docs/TESTING_BEST_PRACTICES.md`     | Writing or reviewing editor interaction tests. Covers the `performAndAssert` pattern, testing helpers, and common pitfalls to avoid.                                             |
 | `docs/CONFIG_DOCUMENTATION_GUIDE.md` | Maintaining or creating package `CONFIG.md` files. Covers maintenance triggers, ownership rules, README example workflow, shared `@cdc/core` references, and new-package setup.  |
 | `docs/DASHBOARD_CONDITIONS.md`     | Working on dashboard-condition visibility logic. Covers condition config, target scoping, precomputed condition data, unresolved-vs-empty behavior, and v1 exclusions. |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Project Description
 
-COVE is a collection of React-based visualization packages used to build charts, maps, dashboards, data callouts, filtered text, markup includes, and related authoring experiences. The repository also contains shared core utilities, Storybook stories, a local development portal, and an embed package for partner-facing iframe integrations.
+COVE is a collection of React-based visualization packages used to build charts, maps, dashboards, data callouts, markup includes, and related authoring experiences. The repository also contains shared core utilities, Storybook stories, a local development portal, and an embed package for partner-facing iframe integrations.
 
 - **What does it do?** Builds and tests reusable CDC visualization packages such as `@cdc/chart`, `@cdc/map`, `@cdc/dashboard`, `@cdc/editor`, and supporting packages under `packages/`.
 - **What problem does it solve?** Centralizes shared visualization logic, styling, testing, and package release workflows in one monorepo so CDC visualization components can evolve consistently.
@@ -60,7 +60,7 @@ This project is currently in **Production**.
 | `@cdc/data-table` | React standalone data table component |
 | `@cdc/editor` | React component for generating a new component entry |
 | `@cdc/embed` | Embeddable COVE visualizations for partner websites |
-| `@cdc/filtered-text` | React component for adding filtered text on dashboards |
+| `@cdc/filtered-text` | Deprecated legacy component for existing saved configs; author new dynamic text with `@cdc/markup-include` |
 | `@cdc/map` | React component for visualizing tabular data on a map of the United States or the world |
 | `@cdc/markup-include` | React component for displaying HTML content from an outside link |
 | `@cdc/waffle-chart` | React component for displaying a single piece of data in a card module |

--- a/docs/FILTERED_TEXT_DEPRECATION.md
+++ b/docs/FILTERED_TEXT_DEPRECATION.md
@@ -1,0 +1,147 @@
+# Filtered Text Deprecation
+
+This document tracks the two-phase deprecation of `@cdc/filtered-text` in favor of `@cdc/markup-include`.
+
+- Phase 1 was implemented in `4.26.5`.
+- Phase 2 is planned for `4.26.6`.
+
+## Summary
+
+Deprecation happens in two explicit phases.
+
+Phase 1 is the operational deprecation phase. It makes `markup-include` the supported replacement, adds `selectionMode: 'first'` to markup variables, migrates legacy `filtered-text` configs to `markup-include`, removes `filtered-text` from new authoring surfaces, and intentionally surfaces remaining standalone/runtime migration issues during Phase 1 rather than delaying them to package deletion.
+
+Phase 2 is a cleanup/removal phase. It deletes the legacy package and remaining runtime/editor references while preserving automatic config migration through the shared versioned migration pipeline.
+
+Important implementation rule: do not implement Phase 1 and Phase 2 together. Phase 1 is the user-visible deprecation and migration phase; Phase 2 should be mostly removal and cleanup.
+
+## Phase 1
+
+### Markup Variable Enhancement
+
+- Extend the shared `MarkupVariable` type in `@cdc/core` with `selectionMode?: 'all' | 'first'`.
+- Keep the default unchanged: omitted `selectionMode` preserves current multi-match list behavior.
+- Update `processMarkupVariables(...)` so column-based variables:
+  - use existing dashboard/shared filtering behavior
+  - apply variable `conditions`
+  - then resolve output using `selectionMode`
+- For `selectionMode: 'first'`, return the first matching row’s cell value only, with no list formatting or comma-joining.
+- Do not change metadata or icon variable behavior in this phase.
+
+### Markup Variable Editor Behavior
+
+- Expose the new control only for column-based value variables.
+- Place the control inside the existing `Conditions` accordion, not in `Basic Settings`.
+- Treat it as a match-resolution choice that appears below the condition controls.
+- Keep the current default behavior visible in authoring so comma-joined output still signals under-filtered variables.
+- Use editor wording equivalent to `Display all matching rows` with an explicit way to switch to first-match behavior.
+
+### Filtered-Text To Markup-Include Migration Contract
+
+- Define migration as a pure config transformation in the shared migration/version pipeline, not in the legacy package.
+- Migrate:
+  - `type: 'filtered-text'` -> `type: 'markup-include'`
+  - `visualizationType: 'filtered-text'` -> `visualizationType: 'markup-include'`
+  - `title` -> `contentEditor.title`
+  - `textColumn` -> one markup variable targeting that column
+  - rendered body -> `contentEditor.inlineHTML` containing only that variable tag
+  - local `filters[{ columnName, columnValue }]` -> markup-variable `conditions[{ columnName, isOrIsNotEqualTo: 'is', value }]`
+  - variable processing -> `enableMarkupVariables: true`
+  - first-row semantics -> `selectionMode: 'first'`
+- Preserve `dataKey`, `dataDescription`, `formattedData`/`data`, `theme`, and shell `visual` settings where they map cleanly.
+- Preserve dashboard/shared filters as-is; do not convert them into local markup-include widget filters.
+- Do not preserve `filtered-text`’s buggy local filter loop behavior. Migration should produce correct combined condition matching.
+- If `textColumn` is missing or unusable, migrate conservatively to `markup-include` with a clear inline fallback message rather than guessing.
+
+### Runtime And Authoring Deprecation Behavior
+
+- Remove `filtered-text` from all editor/dashboard creation surfaces so no new `filtered-text` visualizations can be authored.
+- Remove `filtered-text` from picker/add-visualization flows and reject programmatic creation of new `filtered-text` configs.
+- Keep legacy dashboard/runtime branches present during Phase 1 so old saved configs can still enter the system.
+- Intentionally stop standalone `@cdc/filtered-text` from rendering once its config has been migrated to `markup-include`; show a clear migrated/deprecated message instead of silently handing off.
+- Treat Phase 1 as the moment when remaining standalone `filtered-text` usage surfaces and must be migrated. This is deliberate so Phase 2 can be mostly file deletion.
+
+### Documentation And Messaging
+
+- Update shared config docs to describe `filtered-text` as a legacy saved-config format that migrates to `markup-include`.
+- Update package/repo docs so new authored dynamic text points to `markup-include`, not `filtered-text`.
+- Document `selectionMode: 'first'` as primarily introduced for filtered-text migration and single-row text resolution, while preserving default multi-match behavior for authoring visibility.
+
+### Phase 1 Tests
+
+- Add unit tests for `processMarkupVariables(...)` covering:
+  - default multi-match behavior unchanged
+  - `selectionMode: 'first'` returns only the first matching row
+  - `selectionMode: 'first'` works with dashboard filtering and variable `conditions`
+  - empty-match behavior remains predictable
+- Add markup variable editor tests confirming:
+  - the new control lives in the `Conditions` area
+  - default UI state preserves current behavior
+  - selecting first-match updates the variable config correctly
+- Add migration tests covering:
+  - basic `filtered-text` config with only `textColumn`
+  - `filtered-text` config with one or more local filters
+  - dashboard-backed `filtered-text` configs preserving `dataKey` and shared-filter behavior
+  - migrated configs using `selectionMode: 'first'`
+  - migrated configs not inheriting the old broken multi-filter loop semantics
+  - conservative migration when `textColumn` is missing
+- Add authoring-surface tests confirming:
+  - `filtered-text` no longer appears in creation surfaces
+  - programmatic creation of new `filtered-text` configs is rejected
+- Add runtime tests confirming:
+  - legacy dashboard widgets still pass through the system during Phase 1
+  - standalone `@cdc/filtered-text` shows the migrated/deprecated message after config migration
+- Add one comparison fixture/story showing original `filtered-text` and migrated `markup-include` behavior for a representative single-row case.
+
+## Phase 2
+
+### Preconditions
+
+- Phase 2 is a later follow-up and must not be bundled into the Phase 1 implementation.
+- Only begin once Phase 1 has shipped and the shared migration pipeline is the accepted upgrade path for all supported config entrypoints.
+- Assume the operational breaking point for standalone `filtered-text` already happened in Phase 1 by design.
+
+### Removal Work
+
+- Delete the `@cdc/filtered-text` package and its tests, examples, and package metadata.
+- Remove remaining imports/usages of `CdcFilteredText` from dashboard, editor, stories, and runtime code.
+- Remove legacy rendering/editing branches for `type === 'filtered-text'`.
+- Remove temporary Phase 1 migrated/deprecated-message behavior along with the package.
+- Remove stale helper/test references, wrapper behavior, and styling hooks that exist only for `filtered-text`.
+- Remove `filtered-text` from shared registries such as labels, icons, picker metadata, and type maps where Phase 2 intends full retirement.
+
+### Long-Term Compatibility Stance
+
+- Keep the `4.26.5` migration logic alive in the shared versioned migration pipeline after package deletion.
+- Treat that migration as the sole supported path for old `filtered-text` configs.
+- Ensure the migration code does not import from or depend on the `filtered-text` package.
+- After Phase 2, the supported legacy path is:
+  1. config enters the shared migration pipeline
+  2. config upgrades to `markup-include`
+  3. normal `markup-include` rendering proceeds
+- If a `filtered-text` config somehow bypasses migration and reaches runtime after Phase 2, fail clearly as unsupported legacy config rather than attempting fallback rendering.
+
+### Documentation Cleanup
+
+- Remove docs that present `filtered-text` as a supported component/package.
+- Keep only narrow migration-oriented references where needed, phrased as `legacy saved configs are upgraded automatically`.
+- Update repo/package descriptions so `filtered-text` is no longer listed as an active supported visualization package.
+
+### Phase 2 Tests
+
+- Verify legacy `filtered-text` configs still upgrade to `markup-include` through `coveUpdateWorker` after package removal.
+- Verify migrated configs still carry `selectionMode: 'first'` and converted local filter `conditions`.
+- Verify a representative old dashboard config renders through `markup-include` after migration with no dependency on the deleted package.
+- Remove or update tests that import `@cdc/filtered-text`.
+- Add checks confirming no remaining dashboard/editor/runtime branches reference `filtered-text`.
+- Add checks confirming no creation surfaces, helper factories, shared registries, docs, or package listings expose `filtered-text` as available.
+- Add one regression test proving a legacy saved config still loads successfully after package deletion because migration happens before render.
+
+## Assumptions
+
+- `selectionMode` belongs on the shared `MarkupVariable` model, with default behavior unchanged.
+- Concatenated multi-match output remains the default because it helps authors detect under-filtered variables; `first` is an explicit opt-in and is applied automatically for migrated `filtered-text`.
+- The editor control for this feature lives in the `Conditions` area for column variables, not in `Basic Settings`.
+- Phase 1 intentionally surfaces standalone/runtime migration issues rather than preserving full standalone compatibility through package deletion.
+- Phase 2 is a cleanup/removal pass only; it should not redesign the Phase 1 migration contract or revisit the `selectionMode` behavior.
+- The shared migration pipeline is expected to run before runtime rendering for supported legacy config entrypoints after Phase 2.

--- a/packages/core/CONFIG.md
+++ b/packages/core/CONFIG.md
@@ -104,7 +104,7 @@ Dashboards and dataset-driven packages use `DataSet` entries inside a `datasets`
 
 | Field | Type | Required | Description | Allowed values / Notes |
 | --- | --- | --- | --- | --- |
-| `type` | `string` | No | Visualization package type. | Common values include `chart`, `map`, `data-bite`, `waffle-chart`, `markup-include`, `filtered-text`, `table`, and `navigation`. |
+| `type` | `string` | No | Visualization package type. | Common values include `chart`, `map`, `data-bite`, `waffle-chart`, `markup-include`, `table`, and `navigation`. Legacy saved configs may still contain `filtered-text`; the migration pipeline upgrades those to `markup-include`. |
 | `title` | `string` | No | Shared title field used by multiple packages. | Package-specific title handling still varies. |
 | `theme` | `ComponentThemes \| string` | No | Shared shell theme token. | Most packages use the `theme-*` tokens listed above. |
 | `locale` | `string` | No | Locale used for formatting. | Any valid `Intl` locale is accepted. |
@@ -437,6 +437,7 @@ Use `Region` for shaded chart regions or range overlays.
 | `conditions` | `MarkupCondition[]` | Yes | Optional row-level conditions used to narrow which record supplies the replacement value. | Empty array means no extra conditions. |
 | `columnName` | `string` | No | Data column used when the variable pulls from a dataset column. | Most common source for dynamic values. |
 | `sourceType` | `'column' \| 'metadata' \| 'icon'` | No | Explicitly declares where the replacement comes from. | If omitted, COVE infers `metadata` when `metadataKey` is present; otherwise `column`. |
+| `selectionMode` | `'all' \| 'first'` | No | Chooses how a column value variable resolves multiple matching rows after shared filters and conditions are applied. | Omitted or `all` keeps the default multi-value list behavior. `first` uses only the first matching row's cell value. Metadata and icon variables ignore this field. |
 | `addCommas` | `boolean` | No | Adds locale-aware grouping separators when the resolved value is numeric. | `true`, `false` |
 | `hideOnNull` | `boolean` | No | Suppresses the variable output when the resolved value is nullish. | `true`, `false` |
 | `metadataKey` | `string` | No | Metadata key used when `sourceType` is `metadata`. | Reads from `config.dataMetadata`. |

--- a/packages/core/components/EditorPanel/EditorPanel.styles.css
+++ b/packages/core/components/EditorPanel/EditorPanel.styles.css
@@ -71,6 +71,11 @@
   fill: currentColor;
 }
 
+.editor-panel .markup-variables-editor .cove-accordion__panel {
+  padding-left: 0.3125em;
+  padding-right: 0.3125em;
+}
+
 .editor-panel .warning {
   background-color: #ffd2d2;
   border: #d8000c 1px solid;

--- a/packages/core/components/EditorPanel/components/MarkupVariablesEditor.test.tsx
+++ b/packages/core/components/EditorPanel/components/MarkupVariablesEditor.test.tsx
@@ -149,6 +149,52 @@ describe('MarkupVariablesEditor', () => {
     ])
   })
 
+  it('places column value display behavior below the condition controls', () => {
+    const { onChange } = renderEditor([
+      {
+        sourceType: 'column',
+        name: 'Category',
+        tag: '{{category}}',
+        columnName: 'category',
+        conditions: [],
+        outputType: 'value'
+      }
+    ])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    const basicSettingsButton = screen.getByRole('button', { name: 'Basic Settings' })
+    fireEvent.click(basicSettingsButton)
+    const basicSettingsItem = basicSettingsButton.closest('.cove-accordion__item') as HTMLElement
+    expect(within(basicSettingsItem).queryByRole('combobox', { name: 'Display all matching rows' })).not.toBeInTheDocument()
+
+    const conditionsButton = screen.getByRole('button', { name: 'Conditions' })
+    fireEvent.click(conditionsButton)
+    const conditionsItem = conditionsButton.closest('.cove-accordion__item') as HTMLElement
+    const displayAllMatchingRows = within(conditionsItem).getByRole('combobox', {
+      name: 'Display all matching rows'
+    })
+    const conditionLeadIn = within(conditionsItem).getByText(
+      'Add conditions to filter when this variable should display data.'
+    )
+    const addConditionButton = within(conditionsItem).getByRole('button', { name: /add condition/i })
+    const conditionsText = conditionsItem.textContent || ''
+
+    expect(displayAllMatchingRows).toHaveDisplayValue('Yes')
+    expect(conditionsText.indexOf('Add conditions to filter when this variable should display data.')).toBeLessThan(
+      conditionsText.indexOf('Display all matching rows')
+    )
+    expect(conditionLeadIn.compareDocumentPosition(addConditionButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(addConditionButton.compareDocumentPosition(displayAllMatchingRows) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    fireEvent.change(displayAllMatchingRows, { target: { value: 'no' } })
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        selectionMode: 'first'
+      })
+    ])
+  })
+
   it('preserves data-driven icon settings when switching to static icon mode', () => {
     const onChange = vi.fn()
 

--- a/packages/core/components/EditorPanel/components/MarkupVariablesEditor.test.tsx
+++ b/packages/core/components/EditorPanel/components/MarkupVariablesEditor.test.tsx
@@ -152,14 +152,14 @@ describe('MarkupVariablesEditor', () => {
   it('places column value display behavior below the condition controls', () => {
     const { onChange } = renderEditor([
       {
-        sourceType: 'column',
-        name: 'Category',
-        tag: '{{category}}',
-        columnName: 'category',
-        conditions: [],
-        outputType: 'value'
-      }
-    ])
+	        sourceType: 'column',
+	        name: 'Category',
+	        tag: '{{category}}',
+	        columnName: 'category',
+	        conditions: [{ columnName: 'category', isOrIsNotEqualTo: 'is', value: 'Up' }],
+	        outputType: 'value'
+	      }
+	    ])
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
     const basicSettingsButton = screen.getByRole('button', { name: 'Basic Settings' })
@@ -173,18 +173,22 @@ describe('MarkupVariablesEditor', () => {
     const displayAllMatchingRows = within(conditionsItem).getByRole('combobox', {
       name: 'Display all matching rows'
     })
-    const conditionLeadIn = within(conditionsItem).getByText(
-      'Add conditions to filter when this variable should display data.'
-    )
-    const addConditionButton = within(conditionsItem).getByRole('button', { name: /add condition/i })
-    const conditionsText = conditionsItem.textContent || ''
+	    const conditionLeadIn = within(conditionsItem).getByText(
+	      'Add conditions to filter when this variable should display data.'
+	    )
+	    const conditionItem = conditionsItem.querySelector('.condition-item') as HTMLElement
+	    const addConditionButton = within(conditionsItem).getByRole('button', { name: /add condition/i })
+	    const conditionsText = conditionsItem.textContent || ''
 
-    expect(displayAllMatchingRows).toHaveDisplayValue('Yes')
-    expect(conditionsText.indexOf('Add conditions to filter when this variable should display data.')).toBeLessThan(
-      conditionsText.indexOf('Display all matching rows')
-    )
-    expect(conditionLeadIn.compareDocumentPosition(addConditionButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-    expect(addConditionButton.compareDocumentPosition(displayAllMatchingRows) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+	    expect(displayAllMatchingRows).toHaveDisplayValue('Yes')
+	    expect(conditionItem).toBeTruthy()
+	    expect(conditionsText.indexOf('Add conditions to filter when this variable should display data.')).toBeLessThan(
+	      conditionsText.indexOf('Display all matching rows')
+	    )
+	    expect(conditionLeadIn.compareDocumentPosition(conditionItem) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+	    expect(conditionItem.compareDocumentPosition(addConditionButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+	    expect(conditionLeadIn.compareDocumentPosition(addConditionButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+	    expect(addConditionButton.compareDocumentPosition(displayAllMatchingRows) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
     fireEvent.change(displayAllMatchingRows, { target: { value: 'no' } })
 

--- a/packages/core/components/EditorPanel/components/MarkupVariablesEditor.test.tsx
+++ b/packages/core/components/EditorPanel/components/MarkupVariablesEditor.test.tsx
@@ -14,13 +14,19 @@ describe('MarkupVariablesEditor', () => {
     { category: 'Down', trend: 'down' }
   ]
 
-  const renderEditor = (markupVariables: MarkupVariable[], dataMetadata: Record<string, string> = {}) => {
+  const renderEditor = (
+    markupVariables: MarkupVariable[],
+    dataMetadata: Record<string, string> = {},
+    data = defaultData,
+    editorData?: Record<string, string>[]
+  ) => {
     const onChange = vi.fn()
     const onToggleEnable = vi.fn()
     const view = render(
       <MarkupVariablesEditor
         markupVariables={markupVariables}
-        data={defaultData}
+        data={data}
+        editorData={editorData}
         dataMetadata={dataMetadata}
         enableMarkupVariables={true}
         onChange={onChange}
@@ -152,14 +158,14 @@ describe('MarkupVariablesEditor', () => {
   it('places column value display behavior below the condition controls', () => {
     const { onChange } = renderEditor([
       {
-	        sourceType: 'column',
-	        name: 'Category',
-	        tag: '{{category}}',
-	        columnName: 'category',
-	        conditions: [{ columnName: 'category', isOrIsNotEqualTo: 'is', value: 'Up' }],
-	        outputType: 'value'
-	      }
-	    ])
+        sourceType: 'column',
+        name: 'Category',
+        tag: '{{category}}',
+        columnName: 'category',
+        conditions: [{ columnName: 'category', isOrIsNotEqualTo: 'is', value: 'Up' }],
+        outputType: 'value'
+      }
+    ])
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
     const basicSettingsButton = screen.getByRole('button', { name: 'Basic Settings' })
@@ -173,22 +179,22 @@ describe('MarkupVariablesEditor', () => {
     const displayAllMatchingRows = within(conditionsItem).getByRole('combobox', {
       name: 'Display all matching rows'
     })
-	    const conditionLeadIn = within(conditionsItem).getByText(
-	      'Add conditions to filter when this variable should display data.'
-	    )
-	    const conditionItem = conditionsItem.querySelector('.condition-item') as HTMLElement
-	    const addConditionButton = within(conditionsItem).getByRole('button', { name: /add condition/i })
-	    const conditionsText = conditionsItem.textContent || ''
+    const conditionLeadIn = within(conditionsItem).getByText(
+      'Add conditions to filter when this variable should display data.'
+    )
+    const conditionItem = conditionsItem.querySelector('.condition-item') as HTMLElement
+    const addConditionButton = within(conditionsItem).getByRole('button', { name: /add condition/i })
+    const conditionsText = conditionsItem.textContent || ''
 
-	    expect(displayAllMatchingRows).toHaveDisplayValue('Yes')
-	    expect(conditionItem).toBeTruthy()
-	    expect(conditionsText.indexOf('Add conditions to filter when this variable should display data.')).toBeLessThan(
-	      conditionsText.indexOf('Display all matching rows')
-	    )
-	    expect(conditionLeadIn.compareDocumentPosition(conditionItem) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-	    expect(conditionItem.compareDocumentPosition(addConditionButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-	    expect(conditionLeadIn.compareDocumentPosition(addConditionButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-	    expect(addConditionButton.compareDocumentPosition(displayAllMatchingRows) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(displayAllMatchingRows).toHaveDisplayValue('Yes')
+    expect(conditionItem).toBeTruthy()
+    expect(conditionsText.indexOf('Add conditions to filter when this variable should display data.')).toBeLessThan(
+      conditionsText.indexOf('Display all matching rows')
+    )
+    expect(conditionLeadIn.compareDocumentPosition(conditionItem) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(conditionItem.compareDocumentPosition(addConditionButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(conditionLeadIn.compareDocumentPosition(addConditionButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(addConditionButton.compareDocumentPosition(displayAllMatchingRows) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
     fireEvent.change(displayAllMatchingRows, { target: { value: 'no' } })
 
@@ -197,6 +203,150 @@ describe('MarkupVariablesEditor', () => {
         selectionMode: 'first'
       })
     ])
+  })
+
+  it('warns when first-row mode will choose from multiple distinct render-data values', () => {
+    renderEditor(
+      [
+        {
+          sourceType: 'column',
+          name: 'Text',
+          tag: '{{text}}',
+          columnName: 'text',
+          conditions: [{ columnName: 'category', isOrIsNotEqualTo: 'is', value: 'Up' }],
+          outputType: 'value',
+          selectionMode: 'first'
+        }
+      ],
+      {},
+      [
+        { category: 'Up', text: 'Alpha' },
+        { category: 'Up', text: 'Beta' },
+        { category: 'Down', text: 'Ignore' }
+      ]
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Conditions' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'This variable matches multiple different values for "text". Because Display all matching rows is set to No, only the first matching value will display.'
+    )
+  })
+
+  it('does not warn in first-row mode when matching render-data rows share the selected value', () => {
+    renderEditor(
+      [
+        {
+          sourceType: 'column',
+          name: 'Text',
+          tag: '{{text}}',
+          columnName: 'text',
+          conditions: [{ columnName: 'category', isOrIsNotEqualTo: 'is', value: 'Up' }],
+          outputType: 'value',
+          selectionMode: 'first'
+        }
+      ],
+      {},
+      [
+        { category: 'Up', text: 'Alpha' },
+        { category: 'Up', text: 'Alpha' },
+        { category: 'Down', text: 'Beta' }
+      ]
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Conditions' }))
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('does not warn when all matching rows are displayed', () => {
+    renderEditor(
+      [
+        {
+          sourceType: 'column',
+          name: 'Text',
+          tag: '{{text}}',
+          columnName: 'text',
+          conditions: [{ columnName: 'category', isOrIsNotEqualTo: 'is', value: 'Up' }],
+          outputType: 'value'
+        }
+      ],
+      {},
+      [
+        { category: 'Up', text: 'Alpha' },
+        { category: 'Up', text: 'Beta' }
+      ]
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Conditions' }))
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('ignores incomplete conditions when checking first-row warning risk', () => {
+    renderEditor(
+      [
+        {
+          sourceType: 'column',
+          name: 'Text',
+          tag: '{{text}}',
+          columnName: 'text',
+          conditions: [{ columnName: '', isOrIsNotEqualTo: 'is', value: '' }],
+          outputType: 'value',
+          selectionMode: 'first'
+        }
+      ],
+      {},
+      [
+        { category: 'Up', text: 'Alpha' },
+        { category: 'Down', text: 'Beta' }
+      ]
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Conditions' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent('multiple different values for "text"')
+    expect(screen.getByText('Condition 1: Column is required')).toBeInTheDocument()
+    expect(screen.getByText('Condition 1: Value is required')).toBeInTheDocument()
+  })
+
+  it('uses editorData for authoring values while warning against render data', () => {
+    renderEditor(
+      [
+        {
+          sourceType: 'column',
+          name: 'Text',
+          tag: '{{text}}',
+          columnName: 'text',
+          conditions: [{ columnName: 'category', isOrIsNotEqualTo: 'is', value: 'Up' }],
+          outputType: 'value',
+          selectionMode: 'first'
+        }
+      ],
+      {},
+      [
+        { category: 'Up', text: 'Alpha' },
+        { category: 'Up', text: 'Beta' }
+      ],
+      [
+        { category: 'Up', text: 'Alpha' },
+        { category: 'Raw Only', text: 'Gamma' }
+      ]
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    const conditionsButton = screen.getByRole('button', { name: 'Conditions' })
+    fireEvent.click(conditionsButton)
+    const conditionsItem = conditionsButton.closest('.cove-accordion__item') as HTMLElement
+    const valueSelect = within(conditionsItem).getByRole('combobox', { name: 'Value' })
+    const valueOptions = Array.from(valueSelect.querySelectorAll('option')).map(option => option.textContent)
+
+    expect(valueOptions).toContain('Raw Only')
+    expect(screen.getByRole('alert')).toHaveTextContent('multiple different values for "text"')
   })
 
   it('preserves data-driven icon settings when switching to static icon mode', () => {

--- a/packages/core/components/EditorPanel/components/MarkupVariablesEditor.tsx
+++ b/packages/core/components/EditorPanel/components/MarkupVariablesEditor.tsx
@@ -13,6 +13,7 @@ import { TextField, Select, CheckBox } from '../Inputs'
 import SvgIconSelect from './SvgIconSelect'
 import Icon from '../../ui/Icon'
 import Accordion from '../../ui/Accordion'
+import Tooltip from '../../ui/Tooltip'
 import { Datasets } from '../../../types/DataSet'
 import _ from 'lodash'
 
@@ -840,6 +841,48 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                                 Add conditions to filter when this variable should display data.
                               </div>
 
+                              <Button className='btn-sm mb-3' onClick={() => addCondition(index)}>
+                                <Icon display='plus' size={14} className='mr-1' />
+                                Add Condition
+                              </Button>
+
+                              {editorSourceType !== 'icon' && (
+                                <>
+                                  <hr />
+
+                                  <div className='mb-3'>
+                                    <Select
+                                      value={variable.selectionMode === 'first' ? 'no' : 'yes'}
+                                      fieldName='selectionMode'
+                                      label='Display all matching rows'
+                                      tooltip={
+                                        <Tooltip style={{ textTransform: 'none' }}>
+                                          <Tooltip.Target>
+                                            <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                                          </Tooltip.Target>
+                                          <Tooltip.Content>
+                                            <p>
+                                              Choose whether this variable shows every row that matches dashboard filters
+                                              and conditions, or only the first matching row. Showing all rows keeps the
+                                              default list-style output.
+                                            </p>
+                                          </Tooltip.Content>
+                                        </Tooltip>
+                                      }
+                                      options={[
+                                        { value: 'yes', label: 'Yes' },
+                                        { value: 'no', label: 'No' }
+                                      ]}
+                                      updateField={(_section, _subsection, _fieldName, value) => {
+                                        updateVariable(index, {
+                                          selectionMode: value === 'no' ? 'first' : undefined
+                                        })
+                                      }}
+                                    />
+                                  </div>
+                                </>
+                              )}
+
                               {variable.conditions && variable.conditions.length > 0 && (
                                 <div className='conditions-list mb-2'>
                                   {variable.conditions.map((condition, conditionIndex) => (
@@ -910,11 +953,6 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                                   ))}
                                 </div>
                               )}
-
-                              <Button className='btn-sm' onClick={() => addCondition(index)}>
-                                <Icon display='plus' size={14} className='mr-1' />
-                                Add Condition
-                              </Button>
                             </Accordion.Section>
                           )}
 

--- a/packages/core/components/EditorPanel/components/MarkupVariablesEditor.tsx
+++ b/packages/core/components/EditorPanel/components/MarkupVariablesEditor.tsx
@@ -15,6 +15,7 @@ import Icon from '../../ui/Icon'
 import Accordion from '../../ui/Accordion'
 import Tooltip from '../../ui/Tooltip'
 import { Datasets } from '../../../types/DataSet'
+import { filterDataByConditions } from '../../../helpers/markupProcessor'
 import _ from 'lodash'
 
 type MarkupVariablesEditorProps = {
@@ -22,6 +23,8 @@ type MarkupVariablesEditorProps = {
   markupVariables: MarkupVariable[]
   /** Dataset to extract column names and values from (for backward compatibility) */
   data?: any[]
+  /** Optional broader data source for editor authoring controls */
+  editorData?: any[]
   /** Available datasets for multi-dataset support */
   datasets?: Datasets
   /** Configuration object containing dataKey for dataset assignment */
@@ -71,6 +74,7 @@ const getMarkupVariableIconMode = (variable: Partial<MarkupVariable>): MarkupVar
 const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
   markupVariables = [],
   data = [],
+  editorData,
   datasets,
   config,
   onChange,
@@ -84,9 +88,12 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
   // Ensure we always have a valid array (memoized with deep equality to prevent unnecessary re-renders)
   const safeMarkupVariables = useMemo(() => markupVariables || [], [JSON.stringify(markupVariables)])
 
-  // Get the target dataset with fallback logic (memoized for performance)
-  const getTargetData = useCallback((): any[] => {
-    // First try to use the data prop
+  // Get the target dataset for editor authoring controls with fallback logic.
+  const getEditorData = useCallback((): any[] => {
+    if (editorData && editorData.length > 0) {
+      return editorData
+    }
+
     if (data && data.length > 0) {
       return data
     }
@@ -100,21 +107,23 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
     }
 
     return []
-  }, [data, datasets, config?.dataKey])
+  }, [data, editorData, datasets, config?.dataKey])
+
+  const renderData = Array.isArray(data) ? data : []
 
   const metadataKeys = useMemo(() => Object.keys(dataMetadata || {}), [dataMetadata])
   const hasMetadataKeys = metadataKeys.length > 0
 
   // Get columns from the available data (memoized for performance)
   const getAvailableColumns = useMemo((): string[] => {
-    const targetData = getTargetData()
+    const targetData = getEditorData()
     return targetData.length > 0 ? Object.keys(targetData[0]) : []
-  }, [getTargetData])
+  }, [getEditorData])
 
   // Get column values for a specific column (memoized for performance)
   const getColumnValues = useCallback(
     (columnName: string): string[] => {
-      const targetData = getTargetData()
+      const targetData = getEditorData()
       if (targetData.length === 0) return []
 
       const uniqueValues = new Set<string>()
@@ -125,8 +134,36 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
       })
       return Array.from(uniqueValues).sort()
     },
-    [getTargetData]
+    [getEditorData]
   )
+
+  const getFirstRowSelectionWarning = (variable: MarkupVariable): string | null => {
+    if (getMarkupVariableSourceType(variable) !== 'column') return null
+    if (isDataDrivenIconsVariable(variable)) return null
+    if (variable.selectionMode !== 'first') return null
+    if (!variable.columnName) return null
+
+    const completeConditions = (variable.conditions || []).filter(condition => condition.columnName && condition.value)
+
+    if (renderData.length === 0) return null
+
+    const matchingRows = completeConditions.length ? filterDataByConditions(renderData, completeConditions) : renderData
+    const distinctValues = new Set<string>()
+
+    matchingRows.forEach(row => {
+      const value = row?.[variable.columnName]
+      if (value === undefined || value === null) return
+
+      const stringValue = String(value)
+      if (stringValue.trim() === '') return
+
+      distinctValues.add(stringValue)
+    })
+
+    if (distinctValues.size <= 1) return null
+
+    return `This variable matches multiple different values for "${variable.columnName}". Because Display all matching rows is set to No, only the first matching value will display.`
+  }
 
   const getIconDefaults = useCallback((iconId?: MarkupVariable['iconId']) => {
     const resolvedIconId = iconId || SVG_REGISTRY_OPTIONS[0]?.value
@@ -349,7 +386,10 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
 
   const addCustomSvgMapping = (variableIndex: number) => {
     const variable = safeMarkupVariables[variableIndex]
-    const nextMappings = [...(variable.svgMappings || []), { sourceValue: '', svgId: '' as MarkupVariableSvgMapping['svgId'] }]
+    const nextMappings = [
+      ...(variable.svgMappings || []),
+      { sourceValue: '', svgId: '' as MarkupVariableSvgMapping['svgId'] }
+    ]
     updateVariable(variableIndex, { svgMappings: nextMappings })
   }
 
@@ -488,6 +528,7 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                   return list
                 })()
                 const iconLabel = getSvgRegistryLabel(variable.iconId) || 'Not selected'
+                const firstRowSelectionWarning = getFirstRowSelectionWarning(variable)
 
                 return (
                   <div
@@ -646,11 +687,11 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                                                 ?.svgId || ''
 
                                             return (
-                                              <div
-                                                className='cove-accordion__panel-row align-center mb-2'
-                                                key={key}
-                                              >
-                                                <div className='cove-accordion__panel-col' style={{ flex: '1 1 0', minWidth: 0 }}>
+                                              <div className='cove-accordion__panel-row align-center mb-2' key={key}>
+                                                <div
+                                                  className='cove-accordion__panel-col'
+                                                  style={{ flex: '1 1 0', minWidth: 0 }}
+                                                >
                                                   {fromData ? (
                                                     sourceValue
                                                   ) : (
@@ -665,7 +706,10 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                                                     />
                                                   )}
                                                 </div>
-                                                <div className='cove-accordion__panel-col' style={{ flex: '1 1 0', minWidth: 0 }}>
+                                                <div
+                                                  className='cove-accordion__panel-col'
+                                                  style={{ flex: '1 1 0', minWidth: 0 }}
+                                                >
                                                   <SvgIconSelect
                                                     value={selectedSvgId}
                                                     options={[{ value: '', label: 'None' }, ...SVG_REGISTRY_OPTIONS]}
@@ -678,7 +722,10 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                                                     }
                                                   />
                                                 </div>
-                                                <div className='cove-accordion__panel-col' style={{ flex: '0 0 1.5rem' }}>
+                                                <div
+                                                  className='cove-accordion__panel-col'
+                                                  style={{ flex: '0 0 1.5rem' }}
+                                                >
                                                   {!fromData && (
                                                     <button
                                                       type='button'
@@ -837,85 +884,85 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
 
                           {sourceType === 'column' && (
                             <Accordion.Section title='Conditions'>
-	                              <div className='text-sm text-gray-500 mb-2'>
-	                                Add conditions to filter when this variable should display data.
-	                              </div>
+                              <div className='text-sm text-gray-500 mb-2'>
+                                Add conditions to filter when this variable should display data.
+                              </div>
 
-	                              {variable.conditions && variable.conditions.length > 0 && (
-	                                <div className='conditions-list mb-2'>
-	                                  {variable.conditions.map((condition, conditionIndex) => (
-	                                    <div
-	                                      key={`condition-${index}-${conditionIndex}`}
-	                                      className='condition-item p-2 border rounded mb-2'
-	                                      style={{ backgroundColor: '#f8f9fa' }}
-	                                    >
-	                                      <div className='mb-2'>
-	                                        <Select
-	                                          value={condition.columnName || ''}
-	                                          fieldName={`condition-column-${index}-${conditionIndex}`}
-	                                          label='Column'
-	                                          options={[
-	                                            { value: '', label: 'Select Column...' },
-	                                            ...getAvailableColumns.map(col => ({ value: col, label: col }))
-	                                          ]}
-	                                          updateField={(_section, _subsection, _fieldName, newColumnName) => {
-	                                            updateCondition(index, conditionIndex, {
-	                                              columnName: newColumnName,
-	                                              value: ''
-	                                            })
-	                                          }}
-	                                        />
-	                                      </div>
-	                                      <div className='mb-2'>
-	                                        <Select
-	                                          value={condition.isOrIsNotEqualTo || 'is'}
-	                                          fieldName={`condition-operator-${index}-${conditionIndex}`}
-	                                          label='Operator'
-	                                          options={[
-	                                            { value: 'is', label: 'is' },
-	                                            { value: 'is not', label: 'is not' }
-	                                          ]}
-	                                          updateField={(_section, _subsection, _fieldName, value) => {
-	                                            updateCondition(index, conditionIndex, {
-	                                              isOrIsNotEqualTo: value as 'is' | 'is not'
-	                                            })
-	                                          }}
-	                                        />
-	                                      </div>
-	                                      <div className='mb-2'>
-	                                        <Select
-	                                          value={condition.value || ''}
-	                                          fieldName={`condition-value-${index}-${conditionIndex}`}
-	                                          label='Value'
-	                                          options={[
-	                                            { value: '', label: 'Select Value...' },
-	                                            ...(condition.columnName
-	                                              ? getColumnValues(condition.columnName).map(val => ({
-	                                                value: String(val),
-	                                                label: String(val)
-	                                              }))
-	                                              : [])
-	                                          ]}
-	                                          updateField={(_section, _subsection, _fieldName, value) => {
-	                                            updateCondition(index, conditionIndex, { value })
-	                                          }}
-	                                        />
-	                                      </div>
-	                                      <Button
-	                                        className='btn-sm btn-danger'
-	                                        onClick={() => removeCondition(index, conditionIndex)}
-	                                      >
-	                                        Remove Condition
-	                                      </Button>
-	                                    </div>
-	                                  ))}
-	                                </div>
-	                              )}
+                              {variable.conditions && variable.conditions.length > 0 && (
+                                <div className='conditions-list mb-2'>
+                                  {variable.conditions.map((condition, conditionIndex) => (
+                                    <div
+                                      key={`condition-${index}-${conditionIndex}`}
+                                      className='condition-item p-2 border rounded mb-2'
+                                      style={{ backgroundColor: '#f8f9fa' }}
+                                    >
+                                      <div className='mb-2'>
+                                        <Select
+                                          value={condition.columnName || ''}
+                                          fieldName={`condition-column-${index}-${conditionIndex}`}
+                                          label='Column'
+                                          options={[
+                                            { value: '', label: 'Select Column...' },
+                                            ...getAvailableColumns.map(col => ({ value: col, label: col }))
+                                          ]}
+                                          updateField={(_section, _subsection, _fieldName, newColumnName) => {
+                                            updateCondition(index, conditionIndex, {
+                                              columnName: newColumnName,
+                                              value: ''
+                                            })
+                                          }}
+                                        />
+                                      </div>
+                                      <div className='mb-2'>
+                                        <Select
+                                          value={condition.isOrIsNotEqualTo || 'is'}
+                                          fieldName={`condition-operator-${index}-${conditionIndex}`}
+                                          label='Operator'
+                                          options={[
+                                            { value: 'is', label: 'is' },
+                                            { value: 'is not', label: 'is not' }
+                                          ]}
+                                          updateField={(_section, _subsection, _fieldName, value) => {
+                                            updateCondition(index, conditionIndex, {
+                                              isOrIsNotEqualTo: value as 'is' | 'is not'
+                                            })
+                                          }}
+                                        />
+                                      </div>
+                                      <div className='mb-2'>
+                                        <Select
+                                          value={condition.value || ''}
+                                          fieldName={`condition-value-${index}-${conditionIndex}`}
+                                          label='Value'
+                                          options={[
+                                            { value: '', label: 'Select Value...' },
+                                            ...(condition.columnName
+                                              ? getColumnValues(condition.columnName).map(val => ({
+                                                  value: String(val),
+                                                  label: String(val)
+                                                }))
+                                              : [])
+                                          ]}
+                                          updateField={(_section, _subsection, _fieldName, value) => {
+                                            updateCondition(index, conditionIndex, { value })
+                                          }}
+                                        />
+                                      </div>
+                                      <Button
+                                        className='btn-sm btn-danger'
+                                        onClick={() => removeCondition(index, conditionIndex)}
+                                      >
+                                        Remove Condition
+                                      </Button>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
 
-	                              <Button className='btn-sm mb-3' onClick={() => addCondition(index)}>
-	                                <Icon display='plus' size={14} className='mr-1' />
-	                                Add Condition
-	                              </Button>
+                              <Button className='btn-sm mb-3' onClick={() => addCondition(index)}>
+                                <Icon display='plus' size={14} className='mr-1' />
+                                Add Condition
+                              </Button>
 
                               {editorSourceType !== 'icon' && (
                                 <>
@@ -933,9 +980,9 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                                           </Tooltip.Target>
                                           <Tooltip.Content>
                                             <p>
-                                              Choose whether this variable shows every row that matches dashboard filters
-                                              and conditions, or only the first matching row. Showing all rows keeps the
-                                              default list-style output.
+                                              Choose whether this variable shows every row that matches dashboard
+                                              filters and conditions, or only the first matching row. Showing all rows
+                                              keeps the default list-style output.
                                             </p>
                                           </Tooltip.Content>
                                         </Tooltip>
@@ -951,38 +998,42 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                                       }}
                                     />
                                   </div>
+                                  {firstRowSelectionWarning && (
+                                    <div className='warning' role='alert'>
+                                      {firstRowSelectionWarning}
+                                    </div>
+                                  )}
                                 </>
                               )}
-
-	                            </Accordion.Section>
-	                          )}
+                            </Accordion.Section>
+                          )}
 
                           {((sourceType === 'column' && editorSourceType !== 'icon') ||
                             (sourceType === 'metadata' && hasMetadataKeys)) && (
-                              <Accordion.Section title='Formatting Options'>
-                                <div className='mb-3'>
-                                  <CheckBox
-                                    value={variable.addCommas || false}
-                                    fieldName='addCommas'
-                                    label='Format numbers with commas'
-                                    updateField={(_section, _subsection, _fieldName, value) =>
-                                      updateVariable(index, { addCommas: value })
-                                    }
-                                  />
-                                </div>
+                            <Accordion.Section title='Formatting Options'>
+                              <div className='mb-3'>
+                                <CheckBox
+                                  value={variable.addCommas || false}
+                                  fieldName='addCommas'
+                                  label='Format numbers with commas'
+                                  updateField={(_section, _subsection, _fieldName, value) =>
+                                    updateVariable(index, { addCommas: value })
+                                  }
+                                />
+                              </div>
 
-                                <div className='mb-3'>
-                                  <CheckBox
-                                    value={variable.hideOnNull || false}
-                                    fieldName='hideOnNull'
-                                    label='Hide section when value is null'
-                                    updateField={(_section, _subsection, _fieldName, value) =>
-                                      updateVariable(index, { hideOnNull: value })
-                                    }
-                                  />
-                                </div>
-                              </Accordion.Section>
-                            )}
+                              <div className='mb-3'>
+                                <CheckBox
+                                  value={variable.hideOnNull || false}
+                                  fieldName='hideOnNull'
+                                  label='Hide section when value is null'
+                                  updateField={(_section, _subsection, _fieldName, value) =>
+                                    updateVariable(index, { hideOnNull: value })
+                                  }
+                                />
+                              </div>
+                            </Accordion.Section>
+                          )}
                         </Accordion>
 
                         <div className='mt-3 pt-3 border-t' style={{ textAlign: 'center' }}>
@@ -991,7 +1042,8 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                             onClick={() => {
                               if (
                                 window.confirm(
-                                  `Are you sure you want to delete the variable "${variable.name || 'Unnamed Variable'
+                                  `Are you sure you want to delete the variable "${
+                                    variable.name || 'Unnamed Variable'
                                   }"?`
                                 )
                               ) {

--- a/packages/core/components/EditorPanel/components/MarkupVariablesEditor.tsx
+++ b/packages/core/components/EditorPanel/components/MarkupVariablesEditor.tsx
@@ -837,14 +837,85 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
 
                           {sourceType === 'column' && (
                             <Accordion.Section title='Conditions'>
-                              <div className='text-sm text-gray-500 mb-2'>
-                                Add conditions to filter when this variable should display data.
-                              </div>
+	                              <div className='text-sm text-gray-500 mb-2'>
+	                                Add conditions to filter when this variable should display data.
+	                              </div>
 
-                              <Button className='btn-sm mb-3' onClick={() => addCondition(index)}>
-                                <Icon display='plus' size={14} className='mr-1' />
-                                Add Condition
-                              </Button>
+	                              {variable.conditions && variable.conditions.length > 0 && (
+	                                <div className='conditions-list mb-2'>
+	                                  {variable.conditions.map((condition, conditionIndex) => (
+	                                    <div
+	                                      key={`condition-${index}-${conditionIndex}`}
+	                                      className='condition-item p-2 border rounded mb-2'
+	                                      style={{ backgroundColor: '#f8f9fa' }}
+	                                    >
+	                                      <div className='mb-2'>
+	                                        <Select
+	                                          value={condition.columnName || ''}
+	                                          fieldName={`condition-column-${index}-${conditionIndex}`}
+	                                          label='Column'
+	                                          options={[
+	                                            { value: '', label: 'Select Column...' },
+	                                            ...getAvailableColumns.map(col => ({ value: col, label: col }))
+	                                          ]}
+	                                          updateField={(_section, _subsection, _fieldName, newColumnName) => {
+	                                            updateCondition(index, conditionIndex, {
+	                                              columnName: newColumnName,
+	                                              value: ''
+	                                            })
+	                                          }}
+	                                        />
+	                                      </div>
+	                                      <div className='mb-2'>
+	                                        <Select
+	                                          value={condition.isOrIsNotEqualTo || 'is'}
+	                                          fieldName={`condition-operator-${index}-${conditionIndex}`}
+	                                          label='Operator'
+	                                          options={[
+	                                            { value: 'is', label: 'is' },
+	                                            { value: 'is not', label: 'is not' }
+	                                          ]}
+	                                          updateField={(_section, _subsection, _fieldName, value) => {
+	                                            updateCondition(index, conditionIndex, {
+	                                              isOrIsNotEqualTo: value as 'is' | 'is not'
+	                                            })
+	                                          }}
+	                                        />
+	                                      </div>
+	                                      <div className='mb-2'>
+	                                        <Select
+	                                          value={condition.value || ''}
+	                                          fieldName={`condition-value-${index}-${conditionIndex}`}
+	                                          label='Value'
+	                                          options={[
+	                                            { value: '', label: 'Select Value...' },
+	                                            ...(condition.columnName
+	                                              ? getColumnValues(condition.columnName).map(val => ({
+	                                                value: String(val),
+	                                                label: String(val)
+	                                              }))
+	                                              : [])
+	                                          ]}
+	                                          updateField={(_section, _subsection, _fieldName, value) => {
+	                                            updateCondition(index, conditionIndex, { value })
+	                                          }}
+	                                        />
+	                                      </div>
+	                                      <Button
+	                                        className='btn-sm btn-danger'
+	                                        onClick={() => removeCondition(index, conditionIndex)}
+	                                      >
+	                                        Remove Condition
+	                                      </Button>
+	                                    </div>
+	                                  ))}
+	                                </div>
+	                              )}
+
+	                              <Button className='btn-sm mb-3' onClick={() => addCondition(index)}>
+	                                <Icon display='plus' size={14} className='mr-1' />
+	                                Add Condition
+	                              </Button>
 
                               {editorSourceType !== 'icon' && (
                                 <>
@@ -883,78 +954,8 @@ const MarkupVariablesEditor: React.FC<MarkupVariablesEditorProps> = ({
                                 </>
                               )}
 
-                              {variable.conditions && variable.conditions.length > 0 && (
-                                <div className='conditions-list mb-2'>
-                                  {variable.conditions.map((condition, conditionIndex) => (
-                                    <div
-                                      key={`condition-${index}-${conditionIndex}`}
-                                      className='condition-item p-2 border rounded mb-2'
-                                      style={{ backgroundColor: '#f8f9fa' }}
-                                    >
-                                      <div className='mb-2'>
-                                        <Select
-                                          value={condition.columnName || ''}
-                                          fieldName={`condition-column-${index}-${conditionIndex}`}
-                                          label='Column'
-                                          options={[
-                                            { value: '', label: 'Select Column...' },
-                                            ...getAvailableColumns.map(col => ({ value: col, label: col }))
-                                          ]}
-                                          updateField={(_section, _subsection, _fieldName, newColumnName) => {
-                                            updateCondition(index, conditionIndex, {
-                                              columnName: newColumnName,
-                                              value: ''
-                                            })
-                                          }}
-                                        />
-                                      </div>
-                                      <div className='mb-2'>
-                                        <Select
-                                          value={condition.isOrIsNotEqualTo || 'is'}
-                                          fieldName={`condition-operator-${index}-${conditionIndex}`}
-                                          label='Operator'
-                                          options={[
-                                            { value: 'is', label: 'is' },
-                                            { value: 'is not', label: 'is not' }
-                                          ]}
-                                          updateField={(_section, _subsection, _fieldName, value) => {
-                                            updateCondition(index, conditionIndex, {
-                                              isOrIsNotEqualTo: value as 'is' | 'is not'
-                                            })
-                                          }}
-                                        />
-                                      </div>
-                                      <div className='mb-2'>
-                                        <Select
-                                          value={condition.value || ''}
-                                          fieldName={`condition-value-${index}-${conditionIndex}`}
-                                          label='Value'
-                                          options={[
-                                            { value: '', label: 'Select Value...' },
-                                            ...(condition.columnName
-                                              ? getColumnValues(condition.columnName).map(val => ({
-                                                value: String(val),
-                                                label: String(val)
-                                              }))
-                                              : [])
-                                          ]}
-                                          updateField={(_section, _subsection, _fieldName, value) => {
-                                            updateCondition(index, conditionIndex, { value })
-                                          }}
-                                        />
-                                      </div>
-                                      <Button
-                                        className='btn-sm btn-danger'
-                                        onClick={() => removeCondition(index, conditionIndex)}
-                                      >
-                                        Remove Condition
-                                      </Button>
-                                    </div>
-                                  ))}
-                                </div>
-                              )}
-                            </Accordion.Section>
-                          )}
+	                            </Accordion.Section>
+	                          )}
 
                           {((sourceType === 'column' && editorSourceType !== 'icon') ||
                             (sourceType === 'metadata' && hasMetadataKeys)) && (

--- a/packages/core/components/EditorPanel/components/PanelMarkup.tsx
+++ b/packages/core/components/EditorPanel/components/PanelMarkup.tsx
@@ -39,12 +39,11 @@ const PanelMarkup: React.FC<PanelMarkupProps> = ({
   withAccordion = true,
   dataMetadata
 }) => {
-  const sourceData = Array.isArray(editorData) && editorData.length ? editorData : data
-
   const content = (
     <MarkupVariablesEditor
       markupVariables={markupVariables || []}
-      data={sourceData}
+      data={data}
+      editorData={editorData}
       onChange={onMarkupVariablesChange}
       enableMarkupVariables={enableMarkupVariables || false}
       onToggleEnable={onToggleEnable}

--- a/packages/core/helpers/markupProcessor.ts
+++ b/packages/core/helpers/markupProcessor.ts
@@ -186,6 +186,27 @@ export const processMarkupVariables = (
               : filterDataByConditions(variableData, [...workingVariable.conditions])
         }
 
+        if (sourceType === 'column' && workingVariable.selectionMode === 'first') {
+          const firstMatchingRow = conditionFilteredData?.[0]
+          const firstValue = firstMatchingRow?.[effectiveColumnName]
+          const finalDisplay =
+            firstValue === undefined || firstValue === null || firstValue === ''
+              ? ''
+              : workingVariable.addCommas && !isNaN(parseFloat(firstValue))
+                ? parseFloat(firstValue).toLocaleString(locale, { useGrouping: true })
+                : String(firstValue)
+
+          if (showNoDataMessage && finalDisplay === '') {
+            noDataMessageChecker.push(true)
+          }
+
+          if (finalDisplay === '' && allowHideSection) {
+            emptyVariableChecker.push(true)
+          }
+
+          return finalDisplay
+        }
+
         // Extract values with error handling
         const variableValues: string[] = _.uniq(
           (conditionFilteredData || []).map(dataObject => {

--- a/packages/core/helpers/markupProcessor.ts
+++ b/packages/core/helpers/markupProcessor.ts
@@ -266,7 +266,7 @@ export const processMarkupVariables = (
 /**
  * Filters data based on multiple conditions
  */
-const filterDataByConditions = (data: any[], conditions: MarkupCondition[]): any[] => {
+export const filterDataByConditions = (data: any[], conditions: MarkupCondition[]): any[] => {
   if (!conditions.length) return data
 
   const [currentCondition, ...remainingConditions] = conditions

--- a/packages/core/helpers/tests/markupProcessor.test.ts
+++ b/packages/core/helpers/tests/markupProcessor.test.ts
@@ -174,6 +174,81 @@ describe('processMarkupVariables', () => {
     })
   })
 
+  describe('Selection Mode', () => {
+    it('keeps omitted selectionMode on the existing multi-match behavior', () => {
+      const variables: MarkupVariable[] = [
+        {
+          name: 'State',
+          tag: '{{state}}',
+          columnName: 'state',
+          conditions: []
+        }
+      ]
+
+      const result = processMarkupVariables('{{state}}', testData, variables, { locale: 'en-US' })
+
+      expect(result.processedContent).toBe('California, Texas, and Florida')
+    })
+
+    it('returns only the first matching row value when selectionMode is first', () => {
+      const variables: MarkupVariable[] = [
+        {
+          name: 'State',
+          tag: '{{state}}',
+          columnName: 'state',
+          conditions: [],
+          selectionMode: 'first'
+        }
+      ]
+
+      const result = processMarkupVariables('{{state}}', testData, variables, { locale: 'en-US' })
+
+      expect(result.processedContent).toBe('California')
+    })
+
+    it('resolves the first row from already-filtered dashboard data after variable conditions', () => {
+      const dashboardFilteredData = [
+        { state: 'California', measure: 'A', year: '2023', text: 'wrong measure' },
+        { state: 'California', measure: 'B', year: '2023', text: 'first match' },
+        { state: 'California', measure: 'B', year: '2023', text: 'second match' }
+      ]
+      const variables: MarkupVariable[] = [
+        {
+          name: 'Text',
+          tag: '{{text}}',
+          columnName: 'text',
+          conditions: [{ columnName: 'measure', isOrIsNotEqualTo: 'is', value: 'B' }],
+          selectionMode: 'first'
+        }
+      ]
+
+      const result = processMarkupVariables('{{text}}', dashboardFilteredData, variables, { locale: 'en-US' })
+
+      expect(result.processedContent).toBe('first match')
+    })
+
+    it('returns empty output when selectionMode first has no matching rows', () => {
+      const variables: MarkupVariable[] = [
+        {
+          name: 'State',
+          tag: '{{state}}',
+          columnName: 'state',
+          conditions: [{ columnName: 'state', isOrIsNotEqualTo: 'is', value: 'NonExistent' }],
+          selectionMode: 'first'
+        }
+      ]
+
+      const result = processMarkupVariables('State: {{state}}', testData, variables, {
+        showNoDataMessage: true,
+        isEditor: false,
+        locale: 'en-US'
+      })
+
+      expect(result.processedContent).toBe('State: ')
+      expect(result.shouldShowNoDataMessage).toBe(true)
+    })
+  })
+
   describe('Empty Values and Null Handling', () => {
     it('should filter out empty string values', () => {
       const dataWithEmpty = [{ name: 'Alice' }, { name: '' }, { name: 'Bob' }, { name: '' }]

--- a/packages/core/helpers/ver/4.26.5.ts
+++ b/packages/core/helpers/ver/4.26.5.ts
@@ -1,6 +1,91 @@
 import cloneConfig from '../cloneConfig'
 import { DashboardConfig } from '@cdc/dashboard/src/types/DashboardConfig'
 
+const normalizeMarkupTagName = (value: string): string => {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+
+  return normalized || 'filtered-text'
+}
+
+const getDataRowsForValidation = config => {
+  if (Array.isArray(config.formattedData) && config.formattedData.length) return config.formattedData
+  if (Array.isArray(config.data) && config.data.length) return config.data
+  return []
+}
+
+const canUseTextColumn = (config, textColumn: string): boolean => {
+  const dataRows = getDataRowsForValidation(config)
+  if (!dataRows.length) return true
+  return dataRows.some(row => row && Object.prototype.hasOwnProperty.call(row, textColumn))
+}
+
+const getFilteredTextConditions = config => {
+  if (!Array.isArray(config.filters)) return []
+
+  return config.filters
+    .filter(filter => filter?.columnName && filter.columnValue !== undefined && filter.columnValue !== null)
+    .map(filter => ({
+      columnName: filter.columnName,
+      isOrIsNotEqualTo: 'is',
+      value: String(filter.columnValue)
+    }))
+}
+
+const migrateFilteredText = config => {
+  if (config.type !== 'filtered-text') return
+
+  const textColumn = typeof config.textColumn === 'string' ? config.textColumn.trim() : ''
+  const hasUsableTextColumn = !!textColumn && canUseTextColumn(config, textColumn)
+  const tagName = normalizeMarkupTagName(textColumn)
+  const tag = `{{${tagName}}}`
+  const conditions = getFilteredTextConditions(config)
+
+  console.info(
+    `[COVE migration 4.26.5] Migrating filtered-text config to markup-include${
+      config.uid ? ` (uid: ${config.uid})` : ''
+    }${textColumn ? ` using textColumn "${textColumn}"` : ' without a usable textColumn'}.`
+  )
+
+  const contentEditor = {
+    ...(config.contentEditor || {}),
+    inlineHTML: hasUsableTextColumn
+      ? tag
+      : '<p>Filtered text could not be migrated because its textColumn is missing or unavailable.</p>',
+    showHeader: true,
+    srcUrl: '',
+    style: 'default',
+    title: config.title || config.contentEditor?.title || '',
+    titleStyle: config.titleStyle || config.contentEditor?.titleStyle || 'small',
+    useInlineHTML: true
+  }
+
+  config.type = 'markup-include'
+  config.visualizationType = 'markup-include'
+  config.contentEditor = contentEditor
+  config.filters = []
+  config.enableMarkupVariables = true
+  config.markupVariables = hasUsableTextColumn
+    ? [
+        {
+          sourceType: 'column',
+          outputType: 'value',
+          columnName: textColumn,
+          conditions,
+          name: textColumn,
+          tag,
+          selectionMode: 'first'
+        }
+      ]
+    : []
+
+  delete config.title
+  delete config.textColumn
+}
+
 const applyYAxisTitlePlacement = config => {
   if (config.type === 'chart') {
     config.yAxis = config.yAxis || {}
@@ -8,12 +93,6 @@ const applyYAxisTitlePlacement = config => {
     if (!config.yAxis.titlePlacement) {
       config.yAxis.titlePlacement = 'side'
     }
-  }
-
-  if (config.type === 'dashboard' && config.visualizations) {
-    Object.values((config as DashboardConfig).visualizations).forEach(visualization => {
-      applyYAxisTitlePlacement(visualization)
-    })
   }
 }
 
@@ -25,14 +104,24 @@ const applyLegacyDashboardComponentStyleDefaults = config => {
   }
 
   if (config.type === 'waffle-chart') {
-    if (config.visualizationType === undefined || config.visualizationType === null || config.visualizationType === '') {
+    if (
+      config.visualizationType === undefined ||
+      config.visualizationType === null ||
+      config.visualizationType === ''
+    ) {
       config.visualizationType = 'Waffle'
     }
   }
+}
+
+const run_4_26_5_migrations = config => {
+  applyYAxisTitlePlacement(config)
+  migrateFilteredText(config)
+  applyLegacyDashboardComponentStyleDefaults(config)
 
   if (config.type === 'dashboard' && config.visualizations) {
     Object.values((config as DashboardConfig).visualizations).forEach(visualization => {
-      applyLegacyDashboardComponentStyleDefaults(visualization)
+      run_4_26_5_migrations(visualization)
     })
   }
 }
@@ -40,11 +129,10 @@ const applyLegacyDashboardComponentStyleDefaults = config => {
 const update_4_26_5 = config => {
   const ver = '4.26.5'
   const newConfig = cloneConfig(config)
-  applyYAxisTitlePlacement(newConfig)
-  applyLegacyDashboardComponentStyleDefaults(newConfig)
+  run_4_26_5_migrations(newConfig)
   newConfig.version = ver
   return newConfig
 }
 
-export { applyYAxisTitlePlacement, applyLegacyDashboardComponentStyleDefaults }
+export { applyYAxisTitlePlacement, applyLegacyDashboardComponentStyleDefaults, migrateFilteredText }
 export default update_4_26_5

--- a/packages/core/helpers/ver/tests/4.26.5.test.ts
+++ b/packages/core/helpers/ver/tests/4.26.5.test.ts
@@ -1,7 +1,17 @@
 import update_4_26_5, { applyLegacyDashboardComponentStyleDefaults } from '../4.26.5'
-import { describe, expect, it } from 'vitest'
+import { coveUpdateWorker } from '../../coveUpdateWorker'
+import { processMarkupVariables } from '../../markupProcessor'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('update_4_26_5', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('backfills side placement for legacy chart configs', () => {
     const config: any = {
       type: 'chart',
@@ -82,7 +92,7 @@ describe('update_4_26_5', () => {
     expect(waffleConfig.visualizationType).toBe('Waffle')
   })
 
-  it('applies legacy style defaults recursively inside dashboards', () => {
+  it('applies legacy style defaults to dashboard visualizations', () => {
     const config: any = {
       type: 'dashboard',
       version: '4.26.4',
@@ -113,5 +123,156 @@ describe('update_4_26_5', () => {
 
     expect(result.visualizations.bite1.biteStyle).toBe('tp5')
     expect(result.visualizations.waffle1.visualizationType).toBe('TP5 Gauge')
+  })
+
+  it('migrates a basic filtered-text config into markup-include', () => {
+    const config: any = {
+      type: 'filtered-text',
+      version: '4.26.4',
+      uid: 'filtered-text-1',
+      title: 'Featured text',
+      textColumn: 'Message',
+      theme: 'theme-blue',
+      data: [{ Message: 'Hello from filtered text' }],
+      visual: {
+        border: true,
+        accent: false,
+        background: true,
+        hideBackgroundColor: false,
+        borderColorTheme: false
+      }
+    }
+
+    const result = update_4_26_5(config)
+
+    expect(result.type).toBe('markup-include')
+    expect(result.visualizationType).toBe('markup-include')
+    expect(result.contentEditor.title).toBe('Featured text')
+    expect(result.contentEditor.inlineHTML).toBe('{{message}}')
+    expect(result.contentEditor.useInlineHTML).toBe(true)
+    expect(result.markupVariables).toEqual([
+      {
+        sourceType: 'column',
+        outputType: 'value',
+        columnName: 'Message',
+        conditions: [],
+        name: 'Message',
+        tag: '{{message}}',
+        selectionMode: 'first'
+      }
+    ])
+    expect(result.enableMarkupVariables).toBe(true)
+    expect(result.data).toEqual(config.data)
+    expect(result.theme).toBe('theme-blue')
+    expect(result.visual).toEqual(config.visual)
+    expect(result.title).toBeUndefined()
+    expect(result.textColumn).toBeUndefined()
+    expect(result.filters).toEqual([])
+    expect(console.info).toHaveBeenCalledWith(
+      '[COVE migration 4.26.5] Migrating filtered-text config to markup-include (uid: filtered-text-1) using textColumn "Message".'
+    )
+  })
+
+  it('converts one or more local filtered-text filters into markup variable conditions', () => {
+    const config: any = {
+      type: 'filtered-text',
+      textColumn: 'Message',
+      filters: [
+        { columnName: 'State', columnValue: 'CA' },
+        { columnName: 'Year', columnValue: 2024 }
+      ],
+      data: [{ State: 'CA', Year: 2024, Message: 'Combined match' }]
+    }
+
+    const result = update_4_26_5(config)
+
+    expect(result.markupVariables[0].conditions).toEqual([
+      { columnName: 'State', isOrIsNotEqualTo: 'is', value: 'CA' },
+      { columnName: 'Year', isOrIsNotEqualTo: 'is', value: '2024' }
+    ])
+    expect(result.filters).toEqual([])
+  })
+
+  it('preserves dashboard dataKey and shared-filter behavior while migrating child visualizations', () => {
+    const config: any = {
+      type: 'dashboard',
+      version: '4.26.4',
+      dashboard: {
+        sharedFilters: [{ columnName: 'State', active: 'CA', values: ['CA', 'TX'] }]
+      },
+      rows: [{ columns: [{ width: 12, widget: 'filtered1' }], dataKey: 'dashboard-data' }],
+      visualizations: {
+        filtered1: {
+          type: 'filtered-text',
+          uid: 'filtered1',
+          dataKey: 'dashboard-data',
+          dataDescription: { horizontal: false, series: false },
+          textColumn: 'Message'
+        }
+      }
+    }
+
+    const result = coveUpdateWorker(config)
+    const migrated = result.visualizations.filtered1
+
+    expect(migrated.type).toBe('markup-include')
+    expect(migrated.dataKey).toBe('dashboard-data')
+    expect(migrated.dataDescription).toEqual({ horizontal: false, series: false })
+    expect(result.dashboard.sharedFilters).toEqual(config.dashboard.sharedFilters)
+    expect(migrated.markupVariables[0]).toMatchObject({
+      columnName: 'Message',
+      selectionMode: 'first'
+    })
+  })
+
+  it('uses combined condition matching instead of the old filtered-text last-filter loop behavior', () => {
+    const config: any = {
+      type: 'filtered-text',
+      textColumn: 'Message',
+      filters: [
+        { columnName: 'State', columnValue: 'CA' },
+        { columnName: 'Year', columnValue: '2024' }
+      ],
+      data: [
+        { State: 'TX', Year: '2024', Message: 'wrong state' },
+        { State: 'CA', Year: '2023', Message: 'wrong year' },
+        { State: 'CA', Year: '2024', Message: 'correct row' }
+      ]
+    }
+
+    const result = update_4_26_5(config)
+    const processed = processMarkupVariables(result.contentEditor.inlineHTML, result.data, result.markupVariables, {
+      locale: 'en-US'
+    })
+
+    expect(processed.processedContent).toBe('correct row')
+  })
+
+  it('migrates conservatively with a clear message when textColumn is missing', () => {
+    const result = update_4_26_5({
+      type: 'filtered-text',
+      title: 'Broken legacy config',
+      data: [{ Message: 'Do not guess' }]
+    } as any)
+
+    expect(result.type).toBe('markup-include')
+    expect(result.markupVariables).toEqual([])
+    expect(result.enableMarkupVariables).toBe(true)
+    expect(result.contentEditor.inlineHTML).toContain('textColumn is missing or unavailable')
+  })
+
+  it('ignores the old migration skip flag and still migrates filtered-text configs', () => {
+    const result = update_4_26_5({
+      type: 'filtered-text',
+      textColumn: 'Message',
+      __skipFilteredTextMigration: true
+    } as any)
+
+    expect(result.type).toBe('markup-include')
+    expect(result.textColumn).toBeUndefined()
+    expect(result.markupVariables[0]).toMatchObject({
+      columnName: 'Message',
+      selectionMode: 'first'
+    })
   })
 })

--- a/packages/core/helpers/ver/tests/coveUpdateWorker.test.ts
+++ b/packages/core/helpers/ver/tests/coveUpdateWorker.test.ts
@@ -220,5 +220,22 @@ describe('coveUpdateWorker', () => {
       expect(result.visualizations.markup1.contentEditor.style).toBe('default')
       expectVersionAtLeast(result.version, '4.26.4-1')
     })
+
+    it('migrates legacy filtered-text configs when they reach the 4.26.5 migration', () => {
+      const config: any = {
+        type: 'filtered-text',
+        version: '4.26.4',
+        textColumn: 'Message'
+      }
+
+      const result = coveUpdateWorker(config)
+
+      expect(result.type).toBe('markup-include')
+      expect(result.markupVariables[0]).toMatchObject({
+        columnName: 'Message',
+        selectionMode: 'first'
+      })
+      expectVersionAtLeast(result.version, '4.26.5')
+    })
   })
 })

--- a/packages/core/types/MarkupVariable.ts
+++ b/packages/core/types/MarkupVariable.ts
@@ -10,6 +10,8 @@ export type MarkupVariableSourceType = 'column' | 'metadata' | 'icon'
 
 export type MarkupVariableOutputType = 'value' | 'svg'
 
+export type MarkupVariableSelectionMode = 'all' | 'first'
+
 export type MarkupVariableSvgMapping = {
   sourceValue: string
   svgId: SvgRegistryId
@@ -21,6 +23,7 @@ export type MarkupVariable = {
   name: string
   tag: string
   sourceType?: MarkupVariableSourceType
+  selectionMode?: MarkupVariableSelectionMode
   addCommas?: boolean
   hideOnNull?: boolean
   metadataKey?: string

--- a/packages/dashboard/CONFIG.md
+++ b/packages/dashboard/CONFIG.md
@@ -62,7 +62,7 @@ Rows, datasets, and child visualizations also use the shared `ConfigureData` fie
 | `rows[].equalHeight` | `boolean` | No | `false` | Forces equal-height cards within the row. | TP5 layouts may also trigger equalization automatically. |
 | `rows[].multiVizColumn` | `string` | No | None | Column used to split one visualization into multiple cards. | Used by multi-viz dashboard flows. |
 | `rows[].expandCollapseAllButtons` | `boolean` | No | `false` | Adds expand/collapse-all controls to multi-viz rows. | Only meaningful when `multiVizColumn` is set. |
-| `visualizations` | `Record<string, AnyVisualization>` | Yes | `{}` in practice | Child visualizations rendered by the dashboard. | Each nested config follows the child package contract for `chart`, `map`, `data-bite`, `waffle-chart`, `markup-include`, `filtered-text`, `table`, or `dashboardFilters`. |
+| `visualizations` | `Record<string, AnyVisualization>` | Yes | `{}` in practice | Child visualizations rendered by the dashboard. | Each nested config follows the child package contract for `chart`, `map`, `data-bite`, `waffle-chart`, `markup-include`, `table`, or `dashboardFilters`. Legacy saved `filtered-text` configs migrate to `markup-include` in Phase 1; new authored text should use `markup-include`. |
 
 Rows also accept the shared `ConfigureData` fields from the core reference, which the editor uses when a row owns its own dataset.
 

--- a/packages/dashboard/src/_stories/FilteredTextMigrationComparison.stories.tsx
+++ b/packages/dashboard/src/_stories/FilteredTextMigrationComparison.stories.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import CdcFilteredText from '@cdc/filtered-text/src/CdcFilteredText'
+import CdcMarkupInclude from '@cdc/markup-include/src/CdcMarkupInclude'
+import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import { expect, waitFor } from 'storybook/test'
+
+const comparisonData = [
+  {
+    State: 'CA',
+    Message: 'Representative filtered text output'
+  }
+]
+
+const meta: Meta = {
+  title: 'Components/Pages/Dashboard/Filtered Text Migration Comparison'
+}
+
+type Story = StoryObj
+
+export const Standalone_Handoff_And_Migrated_Output: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+      <CdcFilteredText
+        config={{
+          type: 'filtered-text',
+          title: 'Legacy filtered text',
+          textColumn: 'Message',
+          data: comparisonData,
+          filters: [{ columnName: 'State', columnValue: 'CA' }]
+        }}
+        isEditor={false}
+      />
+      <CdcMarkupInclude
+        config={
+          {
+            type: 'markup-include',
+            theme: 'theme-blue',
+            data: comparisonData,
+            enableMarkupVariables: true,
+            markupVariables: [
+              {
+                sourceType: 'column',
+                outputType: 'value',
+                name: 'Message',
+                tag: '{{message}}',
+                columnName: 'Message',
+                conditions: [{ columnName: 'State', isOrIsNotEqualTo: 'is', value: 'CA' }],
+                selectionMode: 'first'
+              }
+            ],
+            contentEditor: {
+              title: 'Migrated markup include',
+              inlineHTML: '{{message}}',
+              useInlineHTML: true,
+              srcUrl: '',
+              showHeader: true,
+              style: 'default'
+            },
+            visual: {
+              border: false,
+              accent: false,
+              background: false,
+              hideBackgroundColor: false,
+              borderColorTheme: false
+            }
+          } as any
+        }
+        configUrl=''
+        datasets={{}}
+        isEditor={false}
+        isDashboard={false}
+        setConfig={() => {}}
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+    await waitFor(() => {
+      expect(canvasElement.textContent).toContain('Filtered Text Has Been Migrated')
+      expect(canvasElement.textContent).toContain('Use the markup-include package to render this visualization.')
+      expect(canvasElement.textContent?.match(/Representative filtered text output/g)?.length).toBe(1)
+    })
+  }
+}
+
+export default meta

--- a/packages/dashboard/src/components/VisualizationRow.test.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.test.tsx
@@ -8,6 +8,10 @@ vi.mock('@cdc/markup-include/src/CdcMarkupInclude', () => ({
   default: ({ config }) => <div>{config.contentEditor?.title}</div>
 }))
 
+vi.mock('@cdc/filtered-text/src/CdcFilteredText', () => ({
+  default: ({ config }) => <div>{config.title}</div>
+}))
+
 describe('VisualizationRow', () => {
   it('renders the first matching conditional entry and hides rows with no resolved widgets', () => {
     const matchingRow = {
@@ -143,5 +147,60 @@ describe('VisualizationRow', () => {
     expect(screen.getByText('Fallback conditional content')).toBeInTheDocument()
     expect(screen.queryByText('Should not render')).not.toBeInTheDocument()
     expect(container.querySelectorAll('[data-row-index]').length).toBe(1)
+  })
+
+  it('still renders existing legacy filtered-text dashboard widgets during phase one', () => {
+    const legacyRow = {
+      columns: [{ width: 12, widget: 'legacy-filtered-text' }],
+      expandCollapseAllButtons: false
+    } as any
+
+    const contextValue = {
+      ...initialState,
+      config: {
+        type: 'dashboard',
+        dashboard: { sharedFilters: [] },
+        datasets: {},
+        rows: [legacyRow],
+        visualizations: {
+          'legacy-filtered-text': {
+            uid: 'legacy-filtered-text',
+            type: 'filtered-text',
+            visualizationType: 'filtered-text',
+            title: 'Legacy filtered text'
+          }
+        }
+      } as any,
+      filteredData: {},
+      data: {},
+      outerContainerRef: vi.fn(),
+      setParentConfig: vi.fn(),
+      isDebug: false,
+      isEditor: false,
+      reloadURLData: vi.fn(),
+      loadAPIFilters: vi.fn(),
+      setAPIFilterDropdowns: vi.fn(),
+      setAPILoading: vi.fn()
+    }
+
+    render(
+      <DashboardContext.Provider value={contextValue}>
+        <VisualizationRow
+          allExpanded
+          groupName=''
+          row={legacyRow}
+          rowIndex={0}
+          inNoDataState={false}
+          setSharedFilter={vi.fn()}
+          updateChildConfig={vi.fn()}
+          apiFilterDropdowns={{}}
+          currentViewport={{} as any}
+          isLastRow={true}
+          interactionLabel='dashboard-test'
+        />
+      </DashboardContext.Provider>
+    )
+
+    expect(screen.getByText('Legacy filtered text')).toBeInTheDocument()
   })
 })

--- a/packages/dashboard/src/components/VisualizationsPanel/VisualizationsPanel.test.tsx
+++ b/packages/dashboard/src/components/VisualizationsPanel/VisualizationsPanel.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DashboardContext, DashboardDispatchContext, initialState } from '../../DashboardContext'
+import VisualizationsPanel from './VisualizationsPanel'
+
+vi.mock('../Widget/Widget', () => ({
+  default: ({ type }: { type: string }) => <div data-testid='creation-widget'>{type}</div>
+}))
+
+vi.mock('@cdc/core/components/AdvancedEditor', () => ({
+  default: () => <div data-testid='advanced-editor' />
+}))
+
+describe('VisualizationsPanel', () => {
+  it('does not expose filtered-text in dashboard creation surfaces', () => {
+    render(
+      <DashboardContext.Provider
+        value={{
+          ...initialState,
+          config: {
+            type: 'dashboard',
+            dashboard: { sharedFilters: [] },
+            datasets: {},
+            rows: [],
+            visualizations: {}
+          } as any,
+          outerContainerRef: vi.fn(),
+          setParentConfig: vi.fn(),
+          isDebug: false,
+          isEditor: true,
+          reloadURLData: vi.fn(),
+          loadAPIFilters: vi.fn(),
+          setAPIFilterDropdowns: vi.fn(),
+          setAPILoading: vi.fn(),
+          data: {}
+        }}
+      >
+        <DashboardDispatchContext.Provider value={vi.fn()}>
+          <VisualizationsPanel />
+        </DashboardDispatchContext.Provider>
+      </DashboardContext.Provider>
+    )
+
+    const creationTypes = screen.getAllByTestId('creation-widget').map(widget => widget.textContent)
+    expect(creationTypes).toContain('markup-include')
+    expect(creationTypes).not.toContain('filtered-text')
+  })
+})

--- a/packages/dashboard/src/components/VisualizationsPanel/VisualizationsPanel.tsx
+++ b/packages/dashboard/src/components/VisualizationsPanel/VisualizationsPanel.tsx
@@ -45,7 +45,6 @@ const VisualizationsPanel = () => {
         <Widget addVisualization={() => addVisualization('data-bite', '')} type='data-bite' />
         <Widget addVisualization={() => addVisualization('waffle-chart', 'Waffle')} type='waffle-chart' />
         <Widget addVisualization={() => addVisualization('markup-include', '')} type='markup-include' />
-        <Widget addVisualization={() => addVisualization('filtered-text', '')} type='filtered-text' />
         <Widget addVisualization={() => addVisualization('dashboardFilters', '')} type='dashboardFilters' />
         <Widget addVisualization={() => addVisualization('table', '')} type='table' />
       </div>

--- a/packages/dashboard/src/helpers/addVisualization.ts
+++ b/packages/dashboard/src/helpers/addVisualization.ts
@@ -2,6 +2,12 @@ import type { AnyVisualization } from '@cdc/core/types/Visualization'
 import type { Table } from '@cdc/core/types/Table'
 
 export const addVisualization = (type, subType) => {
+  if (type === 'filtered-text') {
+    throw new Error(
+      'Cannot create new filtered-text visualizations. filtered-text is deprecated; use markup-include instead.'
+    )
+  }
+
   const modalWillOpen = type !== 'markup-include'
   const newVisualizationConfig: Partial<AnyVisualization> = {
     filters: [],
@@ -36,9 +42,6 @@ export const addVisualization = (type, subType) => {
       break
     case 'data-bite':
       newVisualizationConfig.biteStyle = 'tp5'
-      newVisualizationConfig.visualizationType = type
-      break
-    case 'filtered-text':
       newVisualizationConfig.visualizationType = type
       break
     case 'waffle-chart':

--- a/packages/dashboard/src/helpers/tests/addVisualization.test.ts
+++ b/packages/dashboard/src/helpers/tests/addVisualization.test.ts
@@ -55,7 +55,19 @@ describe('addVisualization', () => {
     vi.spyOn(Date, 'now').mockReturnValue(12345)
 
     expect(addVisualization('waffle-chart', 'Gauge')).toMatchObject({ visualizationType: 'Gauge' })
-    expect(addVisualization('filtered-text')).toMatchObject({ visualizationType: 'filtered-text' })
+  })
+
+  it('preserves visualizationType for current lightweight visualizations', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(12345)
+
+    expect(addVisualization('data-bite')).toMatchObject({ visualizationType: 'data-bite' })
+    expect(addVisualization('markup-include')).toMatchObject({ visualizationType: 'markup-include' })
+  })
+
+  it('throws when asked to create deprecated filtered-text visualizations', () => {
+    expect(() => addVisualization('filtered-text')).toThrow(
+      'Cannot create new filtered-text visualizations. filtered-text is deprecated; use markup-include instead.'
+    )
   })
 
   it('creates dashboard filters with grey background disabled by default', () => {

--- a/packages/filtered-text/src/CdcFilteredText.jsx
+++ b/packages/filtered-text/src/CdcFilteredText.jsx
@@ -63,7 +63,14 @@ const CdcFilteredText = ({
     }
 
     let newConfig = { ...config, ...response }
+    if (!Object.prototype.hasOwnProperty.call(response, 'version')) delete newConfig.version
     const processedConfig = { ...coveUpdateWorker(newConfig) }
+
+    if (processedConfig.type === 'markup-include') {
+      setConfig(processedConfig)
+      setLoading(false)
+      return
+    }
 
     updateConfig(processedConfig)
     setLoading(false)
@@ -119,6 +126,22 @@ const CdcFilteredText = ({
   let content = <Loading />
 
   if (loading === false) {
+    if (config.type === 'markup-include') {
+      return (
+        <ErrorBoundary component='CdcFilteredText'>
+          <section className='waiting' data-testid='filtered-text-migrated-message'>
+            <section className='waiting-container'>
+              <h3>Filtered Text Has Been Migrated</h3>
+              <p>
+                This legacy filtered-text package no longer renders migrated configs. Use the markup-include package to
+                render this visualization.
+              </p>
+            </section>
+          </section>
+        </ErrorBoundary>
+      )
+    }
+
     const body = (
       <VisualizationContent
         innerClassName={innerContainerClasses.join(' ')}

--- a/packages/filtered-text/src/test/CdcFilteredText.migration.test.jsx
+++ b/packages/filtered-text/src/test/CdcFilteredText.migration.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import coveUpdateWorker from '@cdc/core/helpers/coveUpdateWorker'
+import CdcFilteredText from '../CdcFilteredText'
+import defaults from '../data/initial-state'
+
+describe('CdcFilteredText migration handoff', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('migrates unversioned standalone filtered-text configs before rendering', () => {
+    const result = coveUpdateWorker({
+      ...defaults,
+      type: 'filtered-text',
+      textColumn: 'Message',
+      filters: [{ columnName: 'State', columnValue: 'CA' }],
+      data: [{ State: 'CA', Message: 'Migrated text' }]
+    })
+
+    expect(result.type).toBe('markup-include')
+  })
+
+  it('fails clearly after standalone filtered-text configs migrate to markup-include', async () => {
+    render(
+      <CdcFilteredText
+        isEditor={true}
+        config={{
+          type: 'filtered-text',
+          textColumn: 'Message',
+          title: 'Legacy Text',
+          filters: [{ columnName: 'State', columnValue: 'CA' }],
+          data: [{ State: 'CA', Message: 'Migrated text' }]
+        }}
+      />
+    )
+
+    const message = await screen.findByTestId('filtered-text-migrated-message')
+
+    expect(message).toHaveTextContent('Filtered Text Has Been Migrated')
+    expect(message).toHaveTextContent('Use the markup-include package to render this visualization.')
+  })
+})

--- a/packages/markup-include/CONFIG.md
+++ b/packages/markup-include/CONFIG.md
@@ -62,6 +62,8 @@ The package uses several shared config shapes that are documented in `@cdc/core`
 | `markupVariables` | `MarkupVariable[]` | No | `[]` | Root-level placeholder definitions available to authored text. | Shared type documented in core. This is the preferred location. |
 | `contentEditor.markupVariables` | `MarkupVariable[]` | No | `[]` | Legacy nested copy of the same variable list. | Accepted for backward compatibility; the migration helper moves it to root level. |
 
+Column value variables support `selectionMode: 'first'` when authored in the Conditions area. This is mainly used by migrated `filtered-text` configs; the default remains the multi-match list output.
+
 ### Filters
 
 | Field | Type | Required | Default | Description | Allowed values / Notes |

--- a/packages/markup-include/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/markup-include/src/components/EditorPanel/EditorPanel.tsx
@@ -390,7 +390,8 @@ const EditorPanel: React.FC<MarkupIncludeEditorPanelProps> = ({ datasets }) => {
           <Accordion.Section title='Markup Variables'>
             <MarkupVariablesEditor
               markupVariables={config.markupVariables || []}
-              data={markupEditorData}
+              data={Array.isArray(data) ? data : []}
+              editorData={markupEditorData}
               datasets={datasets}
               config={config}
               onChange={handleMarkupVariablesChange}

--- a/packages/markup-include/src/test/CdcMarkupInclude.test.jsx
+++ b/packages/markup-include/src/test/CdcMarkupInclude.test.jsx
@@ -8,7 +8,12 @@ import { describe, it, expect, vi } from 'vitest'
 import CdcMarkupInclude from '../CdcMarkupInclude'
 
 vi.mock('@cdc/core/components/EditorPanel/components/MarkupVariablesEditor', () => ({
-  default: ({ data }) => <div data-testid='markup-variables-editor-data'>{JSON.stringify(data)}</div>
+  default: ({ data, editorData }) => (
+    <div>
+      <div data-testid='markup-variables-editor-data'>{JSON.stringify(data)}</div>
+      <div data-testid='markup-variables-editor-editor-data'>{JSON.stringify(editorData)}</div>
+    </div>
+  )
 }))
 
 const extractMarkedExampleConfig = (content, label) => {
@@ -28,7 +33,7 @@ describe('Markup Include', () => {
     expect(result).toBe(true)
   }, 300000)
 
-  it('uses dashboard rawData for markup variable editor choices when editing', async () => {
+  it('uses dashboard rawData for markup variable editor choices while preserving render data when editing', async () => {
     const filteredData = [{ category: 'Filtered only' }]
     const fullData = [{ category: 'Value A' }, { category: 'Value B' }]
 
@@ -65,7 +70,8 @@ describe('Markup Include', () => {
       />
     )
 
-    expect(JSON.parse((await screen.findByTestId('markup-variables-editor-data')).textContent)).toEqual(fullData)
+    expect(JSON.parse((await screen.findByTestId('markup-variables-editor-data')).textContent)).toEqual(filteredData)
+    expect(JSON.parse((await screen.findByTestId('markup-variables-editor-editor-data')).textContent)).toEqual(fullData)
   })
 
   it('keeps the minimal example in sync with the README docs', () => {


### PR DESCRIPTION
## Summary

This is [phase 1](https://github.com/CDCgov/cdc-open-viz/blob/dev-12963-deprecate-ft/docs/FILTERED_TEXT_DEPRECATION.md) of filtered text package deprecation. It migrates all filtered text configs to markup includes and removes filtered text components from the editor.

In order to support this migration, a new `selectionMode` property has been added to markup variables and is available in the conditions section of the markup variable editor as "Display all matching rows". When `selectionMode` is `all` (the default), a markup variable retains its legacy behavior of returning and concatenating all matching rows. When it is set to `first`, it renders only the first matching row to replicate the behavior of `filtered-text`. If it is set to `first`, but the data returns multiple unique values, a warning in the editor is displayed:

<img width="280" height="268" alt="Screenshot 2026-05-04 at 11 44 43 AM" src="https://github.com/user-attachments/assets/9623e7c9-f412-4624-9bf4-dba2a453ee6f" />

## Testing Steps

Open a dashboard config containing a filtered text element ([one.json](https://github.com/user-attachments/files/27244679/one.json), [two.json](https://github.com/user-attachments/files/27244680/two.json)) and check that it is rendered the same on this branch as on `dev`. When you edit the dashboard, you should be able to edit the component as a markup include.
