### PR TITLE
Fix bug with waffle rerenders

### DIFF
--- a/packages/dashboard/src/test/CdcDashboard.test.tsx
+++ b/packages/dashboard/src/test/CdcDashboard.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CdcDashboard from '../CdcDashboard'
+
+vi.mock('resize-observer-polyfill', () => ({
+  default: vi.fn(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn()
+  }))
+}))
+
+const createDashboardConfig = () => ({
+  type: 'dashboard',
+  dashboard: {
+    theme: 'theme-blue',
+    titleStyle: 'small',
+    sharedFilters: [
+      {
+        key: 'Year',
+        showDropdown: true,
+        values: ['2024', '2025'],
+        orderedValues: ['2024', '2025'],
+        type: 'datafilter',
+        filterStyle: 'dropdown',
+        columnName: 'year',
+        defaultValue: '2025',
+        active: '2025',
+        usedBy: ['waffle']
+      }
+    ]
+  },
+  rows: [{ columns: [{ width: 12, widget: 'filters' }] }, { columns: [{ width: 12, widget: 'waffle' }] }],
+  visualizations: {
+    filters: {
+      type: 'dashboardFilters',
+      visualizationType: 'dashboardFilters',
+      filterBehavior: 'Filter Change',
+      sharedFilterIndexes: [0],
+      uid: 'filters'
+    },
+    waffle: {
+      type: 'waffle-chart',
+      uid: 'waffle',
+      title: 'Year Waffle',
+      showTitle: false,
+      visualizationType: 'Waffle',
+      visualizationSubType: 'linear',
+      showPercent: false,
+      showDenominator: false,
+      valueDescription: 'out of 100',
+      content: 'during {{year}}',
+      subtext: '',
+      orientation: 'horizontal',
+      filters: [],
+      fontSize: '',
+      overallFontSize: 'medium',
+      dataColumn: 'value',
+      dataFunction: 'Max',
+      dataConditionalColumn: '',
+      dataConditionalOperator: '',
+      dataConditionalComparate: '',
+      invalidComparate: false,
+      customDenom: false,
+      dataDenom: '100',
+      dataDenomColumn: '',
+      dataDenomFunction: '',
+      suffix: '',
+      roundToPlace: '0',
+      shape: 'circle',
+      nodeWidth: '10',
+      nodeSpacer: '2',
+      theme: 'theme-blue',
+      gauge: {
+        height: 35,
+        width: '100%'
+      },
+      visual: {
+        border: true,
+        accent: false,
+        background: false,
+        useWrap: false,
+        hideBackgroundColor: false,
+        borderColorTheme: false,
+        colors: {
+          'theme-blue': '#005eaa'
+        }
+      },
+      markupVariables: [
+        {
+          sourceType: 'column',
+          name: 'year',
+          tag: '{{year}}',
+          columnName: 'year',
+          conditions: [],
+          addCommas: false,
+          hideOnNull: false,
+          outputType: 'value'
+        }
+      ],
+      enableMarkupVariables: true,
+      filterBehavior: 'Filter Change',
+      dataKey: 'waffle-data.json',
+      version: '4.26.4-1'
+    }
+  },
+  datasets: {
+    'waffle-data.json': {
+      data: [
+        { year: '2024', value: 24 },
+        { year: '2025', value: 25 }
+      ]
+    }
+  },
+  table: {
+    show: false
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('CdcDashboard', () => {
+  it('updates waffle chart markup when a dashboard loaded through configUrl changes data filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue(createDashboardConfig())
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<CdcDashboard configUrl='/dashboard-with-waffle.json' interactionLabel='dashboard-test' />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/during 2025/)).toBeInTheDocument()
+    })
+
+    await userEvent.selectOptions(screen.getByLabelText('Year'), '2024')
+
+    await waitFor(() => {
+      expect(screen.getByText(/during 2024/)).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText(/during 2025/)).not.toBeInTheDocument()
+  })
+})

--- a/packages/waffle-chart/src/CdcWaffleChart.tsx
+++ b/packages/waffle-chart/src/CdcWaffleChart.tsx
@@ -866,22 +866,25 @@ const CdcWaffleChart = ({
     dispatch({ type: 'SET_CONFIG', payload: newConfig })
   }
 
-  const loadConfig = useCallback(async () => {
-    let response = configObj || (await (await fetch(configUrl)).json())
-    let responseData = response.data ?? {}
+  const loadConfig = useCallback(
+    async (nextConfig?: Config) => {
+      let response = nextConfig || (await (await fetch(configUrl)).json())
+      let responseData = response.data ?? {}
 
-    if (response.dataUrl) {
-      const { data, dataMetadata } = await fetchRemoteData(response.dataUrl)
-      responseData = data
-      response.dataMetadata = dataMetadata
-    }
+      if (response.dataUrl) {
+        const { data, dataMetadata } = await fetchRemoteData(response.dataUrl)
+        responseData = data
+        response.dataMetadata = dataMetadata
+      }
 
-    response.data = responseData
+      response.data = responseData
 
-    const processedConfig = { ...coveUpdateWorker(response) }
-    updateConfig({ ...defaults, ...processedConfig })
-    dispatch({ type: 'SET_LOADING', payload: false })
-  }, [])
+      const processedConfig = { ...coveUpdateWorker(response) }
+      updateConfig({ ...defaults, ...processedConfig })
+      dispatch({ type: 'SET_LOADING', payload: false })
+    },
+    [configUrl]
+  )
 
   // Custom Functions
 
@@ -902,7 +905,7 @@ const CdcWaffleChart = ({
 
   //Load initial config
   useEffect(() => {
-    loadConfig().catch(err => console.warn(err))
+    loadConfig(configObj).catch(err => console.warn(err))
   }, [])
 
   useEffect(() => {
@@ -916,7 +919,7 @@ const CdcWaffleChart = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (configObj && config && JSON.stringify(configObj.data) !== JSON.stringify(config.data)) {
-      loadConfig().catch(err => console.warn(err))
+      loadConfig(configObj).catch(err => console.warn(err))
     }
   }, [configObj?.data])
 

--- a/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
+++ b/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
@@ -26,6 +26,7 @@ vi.mock('@cdc/core/components/ui/TrendArrow', () => ({
 
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 const extractMarkedExampleConfig = (content, label) => {
@@ -136,6 +137,58 @@ describe('Waffle Chart', () => {
 
     expect(getPrimaryValueText(container)).toBeTruthy()
     expect(getPrimaryValueText(container)).not.toContain('out of')
+  })
+
+  it('runs migrations for legacy configs loaded through configUrl', async () => {
+    const config = JSON.parse(JSON.stringify(legacyCountExampleConfig))
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue(config)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container } = render(<CdcWaffleChart configUrl='/legacy-count-waffle.json' />)
+
+    await waitFor(() => {
+      expect(container.querySelector('.cove-waffle-chart')).toBeInTheDocument()
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('/legacy-count-waffle.json')
+    expect(getPrimaryValueText(container)).toBeTruthy()
+    expect(getPrimaryValueText(container)).not.toContain('out of')
+  })
+
+  it('syncs direct config prop data updates into rendered markup variables', async () => {
+    const markupVariables = [
+      {
+        sourceType: 'column',
+        name: 'year',
+        tag: '{{year}}',
+        columnName: 'year',
+        conditions: [],
+        addCommas: false,
+        hideOnNull: false,
+        outputType: 'value'
+      }
+    ]
+    const createYearConfig = (year, value) =>
+      createBaseConfig({
+        data: [{ year, value }],
+        content: 'during {{year}}',
+        enableMarkupVariables: true,
+        markupVariables
+      })
+
+    const { container, rerender } = render(<CdcWaffleChart config={createYearConfig(2025, 65)} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('.cove-waffle-chart__data--text')).toHaveTextContent('during 2025')
+    })
+
+    rerender(<CdcWaffleChart config={createYearConfig(2024, 67.5)} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('.cove-waffle-chart__data--text')).toHaveTextContent('during 2024')
+    })
   })
 
   it('moves the trend indicator below the value when a trend label is configured', async () => {


### PR DESCRIPTION
## Summary

Fixes an issue where waffle charts do not rerender when dashboard filters are changed.

## Testing Steps

[This config](https://github.com/user-attachments/files/27248240/broken-waffle-data.json) illustrates the issue.