### PR TITLE
fix: bump chart tooltip date formatting

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -96,6 +96,7 @@ import { getColorScale } from './helpers/getColorScale'
 import { getTransformedData } from './helpers/getTransformedData'
 import { getPiePercent } from './helpers/getPiePercent'
 import { prepareSmallMultiplesDataTable } from './helpers/smallMultiplesHelpers'
+import { ensureSpecialChartAxisTypes } from './helpers/ensureSpecialChartAxisTypes'
 
 // styles
 import './scss/main.scss'
@@ -324,9 +325,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
       })
     })
 
-    if (newConfig.visualizationType === 'Bump Chart') {
-      newConfig.xAxis.type === 'date-time'
-    }
+    ensureSpecialChartAxisTypes(newConfig)
     if (!isDashboard) return coveUpdateWorker(newConfig)
     return newConfig
   }
@@ -382,6 +381,8 @@ const CdcChart: React.FC<CdcChartProps> = ({
   const updateConfig = (_config: AllChartsConfig, dataOverride?: any[]) => {
     const newConfig = cloneConfig(_config)
     let data = dataOverride || stateData
+
+    ensureSpecialChartAxisTypes(newConfig)
 
     data = handleRankByValue(data, newConfig)
 

--- a/packages/chart/src/components/LineChart/components/LineChart.BumpCircle.tsx
+++ b/packages/chart/src/components/LineChart/components/LineChart.BumpCircle.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react'
+import { useContext } from 'react'
 import { Group } from '@visx/group'
-import { type Column } from '@cdc/core/types/Column'
 import React from 'react'
 import { type ChartConfig } from '../../../types/ChartConfig'
 import { APP_FONT_COLOR } from '@cdc/core/helpers/constants'
+import ConfigContext from '../../../ConfigContext'
+import { isDateScale } from '@cdc/core/helpers/cove/date'
+import { buildBumpChartTooltipHtml } from '../../../helpers/bumpChartTooltip'
 
 type LineChartBumpCircleProp = {
   config: ChartConfig
@@ -15,16 +17,14 @@ type LineChartBumpCircleProp = {
 
 const LineChartBumpCircle = (props: LineChartBumpCircleProp) => {
   const { config, xScale, yScale, parseDate, yAxisWidth } = props
+  const { colorScale, formatDate, formatTooltipsDate } = useContext(ConfigContext)
 
   // get xScale and yScale...
   if (!config?.runtime?.series) return
 
   const handleX = xValue => {
-    if (config.xAxis.type === 'date') {
+    if (isDateScale(config.xAxis)) {
       return parseDate(xValue).getTime()
-    }
-    if (config.xAxis.type === 'date-time') {
-      return new Date(xValue)
     }
     if (config.xAxis.type === 'categorical') {
       return xValue
@@ -35,20 +35,7 @@ const LineChartBumpCircle = (props: LineChartBumpCircleProp) => {
     return xScale.bandwidth ? xScale.bandwidth() / 2 + Number(xValue) : Number(xValue)
   }
 
-  const getListItems = dataRow => {
-    return Object.values(config.columns)
-      ?.filter(column => column.tooltips)
-      .map(column => {
-        const label = column.label || column.name
-        return `
-        <li className='tooltip-body'>
-          <strong>${label}</strong>: ${dataRow[column.name]}
-        </li>`
-      })
-      .join(' ')
-  }
-
-  const getTooltip = dataRow => `<ul> ${getListItems(dataRow)} </ul>`
+  const tooltipId = `cdc-open-viz-tooltip-${config.runtime.uniqueId}-bump`
 
   const circles = config.runtime?.series.map(series => {
     return config.data.map((d, dataIndex) => {
@@ -61,8 +48,18 @@ const LineChartBumpCircle = (props: LineChartBumpCircleProp) => {
               <>
                 <circle
                   key={`bump-circle-${series_dataKey}-${dataIndex}`}
-                  data-tooltip-html={getTooltip(d)}
-                  data-tooltip-id={`bump-chart`}
+                  data-tooltip-html={buildBumpChartTooltipHtml({
+                    config,
+                    colorScale,
+                    dataRow: d,
+                    series,
+                    helpers: {
+                      formatDate,
+                      formatTooltipsDate,
+                      parseDate
+                    }
+                  })}
+                  data-tooltip-id={tooltipId}
                   r={10}
                   cx={Number(checkBandScale(xScale(handleX(axis_dataKey))))}
                   cy={Number(yScale(series_dataKey))}

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -949,7 +949,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           )}
         {config.visualizationType === 'Bump Chart' && (
           <ReactTooltip
-            id={`bump-chart`}
+            id={`cdc-open-viz-tooltip-${config.runtime.uniqueId}-bump`}
             variant='light'
             arrowColor='rgba(0,0,0,0)'
             className='tooltip'

--- a/packages/chart/src/helpers/bumpChartTooltip.ts
+++ b/packages/chart/src/helpers/bumpChartTooltip.ts
@@ -1,0 +1,54 @@
+import { isDateScale } from '@cdc/core/helpers/cove/date'
+import { buildTooltipListHtml, getTooltipSeriesMarker } from './tooltipHelpers'
+import { type ChartConfig } from '../types/ChartConfig'
+import { type ColorScale } from '../types/ChartContext'
+
+type TooltipDateHelpers = {
+  formatDate: (date: Date) => string
+  formatTooltipsDate: (date: Date) => string
+  parseDate: (dateString: string, showError?: boolean) => Date
+}
+
+type BumpTooltipParams = {
+  config: ChartConfig
+  colorScale?: ColorScale
+  dataRow: Record<string, any>
+  series: { dataKey: string; name?: string }
+  helpers: TooltipDateHelpers
+}
+
+const formatXAxisValue = (
+  rawValue: unknown,
+  config: ChartConfig,
+  { formatDate, formatTooltipsDate, parseDate }: TooltipDateHelpers
+) => {
+  if (!isDateScale(config.xAxis) || rawValue === undefined || rawValue === null || rawValue === '') {
+    return rawValue
+  }
+
+  const parsedDate = parseDate(String(rawValue), false)
+  return config.tooltips.dateDisplayFormat ? formatTooltipsDate(parsedDate) : formatDate(parsedDate)
+}
+
+export const buildBumpChartTooltipHtml = ({ config, colorScale, dataRow, series, helpers }: BumpTooltipParams) => {
+  const formattedXAxisValue = formatXAxisValue(dataRow[config.xAxis.dataKey], config, helpers)
+  const xAxisLabel = config.runtime?.xAxis?.label || config.xAxis.dataKey
+  const heading = `${xAxisLabel ? `${xAxisLabel}: ` : ''}${formattedXAxisValue ?? ''}`
+
+  const seriesName = series.name || config.runtime?.seriesLabels?.[series.dataKey] || series.dataKey
+  const marker = getTooltipSeriesMarker(config, colorScale, series.dataKey)
+  const bodyRows = [
+    {
+      text: `${seriesName}: ${dataRow[series.dataKey]}`,
+      markerColor: marker?.markerColor,
+      markerShape: marker?.markerShape
+    },
+    ...Object.values(config.columns || {})
+      .filter(column => column.tooltips && column.name !== config.xAxis.dataKey && column.name !== series.dataKey)
+      .map(column => ({
+        text: `${column.label || column.name}: ${dataRow[column.name]}`
+      }))
+  ]
+
+  return buildTooltipListHtml({ heading, bodyRows })
+}

--- a/packages/chart/src/helpers/ensureSpecialChartAxisTypes.ts
+++ b/packages/chart/src/helpers/ensureSpecialChartAxisTypes.ts
@@ -1,0 +1,11 @@
+import { type ChartConfig } from '../types/ChartConfig'
+
+export const ensureSpecialChartAxisTypes = <T extends Pick<ChartConfig, 'visualizationType' | 'xAxis'>>(
+  config: T
+): T => {
+  if (config.visualizationType === 'Bump Chart' && config.xAxis) {
+    config.xAxis.type = 'date-time'
+  }
+
+  return config
+}

--- a/packages/chart/src/helpers/tests/bumpChartTooltip.test.ts
+++ b/packages/chart/src/helpers/tests/bumpChartTooltip.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { buildBumpChartTooltipHtml } from '../bumpChartTooltip'
+
+const buildConfig = overrides => ({
+  xAxis: {
+    dataKey: 'Timestamp',
+    type: 'date-time'
+  },
+  tooltips: {
+    dateDisplayFormat: '%Y'
+  },
+  columns: {
+    Timestamp: {
+      name: 'Timestamp',
+      label: 'Year',
+      tooltips: true
+    },
+    Frequency: {
+      name: 'Frequency',
+      label: 'Frequency',
+      tooltips: true
+    }
+  },
+  legend: {
+    hide: false,
+    style: 'circles',
+    groupBy: ''
+  },
+  runtime: {
+    xAxis: {
+      label: 'Year'
+    },
+    seriesLabels: {
+      Rank: 'Rank'
+    },
+    seriesLabelsAll: ['Rank', 'Other'],
+    seriesKeys: ['Rank', 'Other']
+  },
+  visualizationType: 'Bump Chart',
+  series: [{ dataKey: 'Rank' }, { dataKey: 'Other' }],
+  ...overrides
+})
+
+const helpers = {
+  parseDate: (value: string) => new Date(value),
+  formatDate: (date: Date) => String(date.getUTCFullYear()),
+  formatTooltipsDate: (date: Date) => `tooltip-${date.getUTCFullYear()}`
+}
+
+describe('buildBumpChartTooltipHtml', () => {
+  it('uses the shared x-axis formatter in the tooltip heading', () => {
+    const html = buildBumpChartTooltipHtml({
+      config: buildConfig(),
+      colorScale: undefined,
+      dataRow: { Timestamp: '2014-01-01T00:00:00.000Z', Rank: '1', Frequency: '149' },
+      series: { dataKey: 'Rank' },
+      helpers
+    })
+
+    expect(html).toContain('Year: tooltip-2014')
+  })
+
+  it('does not render the raw x-axis value as an extra tooltip row', () => {
+    const html = buildBumpChartTooltipHtml({
+      config: buildConfig(),
+      colorScale: undefined,
+      dataRow: { Timestamp: '2014-01-01T00:00:00.000Z', Rank: '1', Frequency: '149' },
+      series: { dataKey: 'Rank' },
+      helpers
+    })
+
+    expect(html).not.toContain('2014-01-01T00:00:00.000Z')
+    expect(html).toContain('Frequency: 149')
+  })
+})

--- a/packages/chart/src/helpers/tests/ensureSpecialChartAxisTypes.test.ts
+++ b/packages/chart/src/helpers/tests/ensureSpecialChartAxisTypes.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { ensureSpecialChartAxisTypes } from '../ensureSpecialChartAxisTypes'
+
+describe('ensureSpecialChartAxisTypes', () => {
+  it('forces bump charts to use a date-time x-axis', () => {
+    const config = {
+      visualizationType: 'Bump Chart',
+      xAxis: {
+        type: 'categorical',
+        dataKey: 'Timestamp',
+        dateParseFormat: '%m/%d/%Y',
+        dateDisplayFormat: '%Y'
+      }
+    }
+
+    expect(ensureSpecialChartAxisTypes(config as any).xAxis.type).toBe('date-time')
+  })
+
+  it('leaves non-bump chart axis types unchanged', () => {
+    const config = {
+      visualizationType: 'Line',
+      xAxis: {
+        type: 'categorical',
+        dataKey: 'Category'
+      }
+    }
+
+    expect(ensureSpecialChartAxisTypes(config as any).xAxis.type).toBe('categorical')
+  })
+})

--- a/packages/core/components/DataTable/helpers/getChartCellValue.ts
+++ b/packages/core/components/DataTable/helpers/getChartCellValue.ts
@@ -39,7 +39,8 @@ export const getChartCellValue = (
   rightAxisItemsMap
 ) => {
   // Variables for xAxis config
-  const { type, dateDisplayFormat, dateParseFormat, dataKey: xAxisDataKey } = config.xAxis || {}
+  const effectiveXAxis = config.runtime?.xAxis || config.xAxis || {}
+  const { type, dateDisplayFormat, dateParseFormat, dataKey: xAxisDataKey } = effectiveXAxis
   const { showMissingDataLabel } = config.general || {}
   const { visualizationType } = config || {}
 

--- a/packages/core/components/DataTable/helpers/tests/getChartCellValue.test.ts
+++ b/packages/core/components/DataTable/helpers/tests/getChartCellValue.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { getChartCellValue } from '../getChartCellValue'
+
+describe('getChartCellValue', () => {
+  it('uses runtime x-axis date settings when config.xAxis is stale', () => {
+    const config = {
+      xAxis: {
+        type: 'categorical',
+        dataKey: 'Timestamp',
+        dateParseFormat: '%m/%d/%Y',
+        dateDisplayFormat: '%Y'
+      },
+      runtime: {
+        xAxis: {
+          type: 'date-time',
+          dataKey: 'Timestamp',
+          dateParseFormat: '%m/%d/%Y',
+          dateDisplayFormat: '%Y'
+        }
+      },
+      table: {
+        dateDisplayFormat: '%Y'
+      },
+      general: {
+        showMissingDataLabel: true
+      },
+      visualizationType: 'Bump Chart',
+      locale: 'en-US',
+      dataFormat: {}
+    }
+
+    const runtimeData = [{ Timestamp: '1/1/2014' }]
+
+    expect(getChartCellValue('0', 'Timestamp', config as any, runtimeData as any, new Map())).toBe('2014')
+  })
+})


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes for bump chart handling, tooltip rendering, and axis configuration in the charting package. The main changes ensure that bump charts always use a date-time x-axis, improve the accuracy and formatting of tooltips, and fix issues with axis configuration propagation to data tables. Comprehensive tests are added to verify these behaviors.

**Bump Chart Axis Handling:**

* Added `ensureSpecialChartAxisTypes` helper to force bump charts to use a `date-time` x-axis, and integrated this into chart configuration flows. [[1]](diffhunk://#diff-fc67bc899b806d6159387c1edacbd0948ec4f85a8432619db9fbfa3ac7a788beR1-R11) [[2]](diffhunk://#diff-7da0e50a207d2d852717225ca9fada38f53fb4e47f9fe9e462b1923ba2d1c1b7R99) [[3]](diffhunk://#diff-7da0e50a207d2d852717225ca9fada38f53fb4e47f9fe9e462b1923ba2d1c1b7L327-R328) [[4]](diffhunk://#diff-7da0e50a207d2d852717225ca9fada38f53fb4e47f9fe9e462b1923ba2d1c1b7R385-R386)
* Added tests to verify that bump charts always use a `date-time` x-axis and that other chart types are unaffected.

**Tooltip Improvements:**

* Refactored bump chart tooltip logic into a new `buildBumpChartTooltipHtml` helper, ensuring consistent formatting, correct x-axis value display, and proper inclusion of series and column data. [[1]](diffhunk://#diff-e3d68dd064340bde2c9c35137b62c5f98c49430dd66a1ab238a88a183b8ce169R1-R54) [[2]](diffhunk://#diff-858020ae292538359f0e4d6b00e2f762806d444957bbe0842a03600402e30bcaL38-R38) [[3]](diffhunk://#diff-858020ae292538359f0e4d6b00e2f762806d444957bbe0842a03600402e30bcaL64-R62)
* Updated `LineChart.BumpCircle` to use the new tooltip helper and context-based formatting utilities for improved tooltip rendering. [[1]](diffhunk://#diff-858020ae292538359f0e4d6b00e2f762806d444957bbe0842a03600402e30bcaL1-R8) [[2]](diffhunk://#diff-858020ae292538359f0e4d6b00e2f762806d444957bbe0842a03600402e30bcaR20-L28)
* Updated tooltip IDs for bump charts to be unique per chart instance, preventing tooltip collisions.
* Added tests for tooltip formatting and content, ensuring correct x-axis heading and no duplicate/raw x-axis values in the tooltip body.

**Data Table Axis Configuration Fix:**

* Fixed `getChartCellValue` to use the runtime x-axis configuration (including date formatting) when the base config is stale, ensuring correct date formatting in data tables.
* Added a test to verify that the runtime x-axis settings are used for date formatting in data tables.