### PR TITLE
Fix [DEV-13019] Dynamic data bite image

### DIFF
--- a/packages/data-bite/src/CdcDataBite.tsx
+++ b/packages/data-bite/src/CdcDataBite.tsx
@@ -431,10 +431,10 @@ const CdcDataBite = (props: CdcDataBiteProps) => {
         break
       }
       case DATA_FUNCTION_SUM:
-        if (numericalData.length === 0 && includePrefixSuffix === false) {
+      case DATA_FUNCTION_MEDIAN:
+        if (numericalData.length === 0) {
           return undefined
         }
-      case DATA_FUNCTION_MEDIAN:
       case DATA_FUNCTION_MAX:
       case DATA_FUNCTION_MIN: {
         const aggregateResult = aggregateByDataFunction(numericalData, dataFunction)
@@ -443,6 +443,9 @@ const CdcDataBite = (props: CdcDataBiteProps) => {
       }
       case DATA_FUNCTION_MEAN: {
         const meanValues = config.dataFormat.ignoreZeros ? numericalData.filter(num => num !== 0) : numericalData
+        if (meanValues.length === 0) {
+          return undefined
+        }
         const meanResult = aggregateByDataFunction(meanValues, DATA_FUNCTION_MEAN)
         dataBite = String(meanResult)
         break

--- a/packages/data-bite/src/CdcDataBite.tsx
+++ b/packages/data-bite/src/CdcDataBite.tsx
@@ -431,6 +431,9 @@ const CdcDataBite = (props: CdcDataBiteProps) => {
         break
       }
       case DATA_FUNCTION_SUM:
+        if (numericalData.length === 0 && includePrefixSuffix === false) {
+          return undefined
+        }
       case DATA_FUNCTION_MEDIAN:
       case DATA_FUNCTION_MAX:
       case DATA_FUNCTION_MIN: {
@@ -552,34 +555,36 @@ const CdcDataBite = (props: CdcDataBiteProps) => {
       let targetVal = Number(calculateDataBite(false))
       let argumentActive = false
 
-      imageData.options.forEach((option, index) => {
-        let argumentArr = option.arguments
-        let { source, alt } = option
+      if (Number.isFinite(targetVal)) {
+        imageData.options.forEach((option, index) => {
+          let argumentArr = option.arguments
+          let { source, alt } = option
 
-        if (false === argumentActive && argumentArr.length > 0) {
-          if (argumentArr[0].operator.length > 0 && argumentArr[0].threshold.length > 0) {
-            if (operators[argumentArr[0].operator](targetVal, argumentArr[0].threshold)) {
-              if (undefined !== argumentArr[1]) {
-                if (argumentArr[1].operator?.length > 0 && argumentArr[1].threshold?.length > 0) {
-                  if (operators[argumentArr[1].operator](targetVal, argumentArr[1].threshold)) {
-                    imageSource = source
-                    if (alt !== '' && alt !== undefined) {
-                      imageAlt = alt
+          if (false === argumentActive && argumentArr.length > 0) {
+            if (argumentArr[0].operator.length > 0 && argumentArr[0].threshold.length > 0) {
+              if (operators[argumentArr[0].operator](targetVal, argumentArr[0].threshold)) {
+                if (undefined !== argumentArr[1]) {
+                  if (argumentArr[1].operator?.length > 0 && argumentArr[1].threshold?.length > 0) {
+                    if (operators[argumentArr[1].operator](targetVal, argumentArr[1].threshold)) {
+                      imageSource = source
+                      if (alt !== '' && alt !== undefined) {
+                        imageAlt = alt
+                      }
+                      argumentActive = true
                     }
-                    argumentActive = true
                   }
+                } else {
+                  imageSource = source
+                  if (alt !== '' && alt !== undefined) {
+                    imageAlt = alt
+                  }
+                  argumentActive = true
                 }
-              } else {
-                imageSource = source
-                if (alt !== '' && alt !== undefined) {
-                  imageAlt = alt
-                }
-                argumentActive = true
               }
             }
           }
-        }
-      })
+        })
+      }
     }
 
     return imageSource.length > 0 && 'graphic' !== biteStyle && 'none' !== imageData.display ? (

--- a/packages/data-bite/src/test/CdcDataBite.test.jsx
+++ b/packages/data-bite/src/test/CdcDataBite.test.jsx
@@ -37,6 +37,40 @@ const extractMarkedExampleConfig = (content, label) => {
   return vm.runInNewContext(`(${configMatch[1]})`)
 }
 
+const fallbackImageUrl = 'https://example.com/limited-no-data.png'
+const veryLowImageUrl = 'https://example.com/very-low.png'
+
+const dynamicImageConfig = value => ({
+  type: 'data-bite',
+  theme: 'theme-blue',
+  dataColumn: 'value',
+  dataFunction: 'Sum',
+  bitePosition: 'Bottom',
+  biteFontSize: '17',
+  biteStyle: 'body',
+  biteBody: '',
+  dataFormat: {
+    prefix: '',
+    suffix: '',
+    commas: false,
+    roundToPlace: 2
+  },
+  imageData: {
+    display: 'dynamic',
+    url: fallbackImageUrl,
+    alt: 'Limited / No Data',
+    options: [
+      {
+        source: veryLowImageUrl,
+        arguments: [{ operator: '<=', threshold: '2.7' }],
+        alt: 'Very Low',
+        secondArgument: false
+      }
+    ]
+  },
+  data: [{ value }]
+})
+
 describe('Data Bite', () => {
   it('Can be built in isolation', async () => {
     const pkgDir = path.join(__dirname, '..')
@@ -72,6 +106,20 @@ describe('Data Bite', () => {
 
     expect(readmeBlock).toEqual(minimalExample)
     expect(minimalExample.version).toBeTruthy()
+  })
+
+  it('uses the dynamic image fallback when sum has no numeric values', async () => {
+    render(<CdcDataBite config={dynamicImageConfig(' ')} />)
+
+    const image = await screen.findByAltText('Limited / No Data')
+    expect(image).toHaveAttribute('src', fallbackImageUrl)
+  })
+
+  it('matches dynamic image options for a real zero sum value', async () => {
+    render(<CdcDataBite config={dynamicImageConfig('0')} />)
+
+    const image = await screen.findByAltText('Very Low')
+    expect(image).toHaveAttribute('src', veryLowImageUrl)
   })
 
   it('moves the trend indicator below the value when a trend label is configured', () => {

--- a/packages/data-bite/src/test/CdcDataBite.test.jsx
+++ b/packages/data-bite/src/test/CdcDataBite.test.jsx
@@ -40,11 +40,11 @@ const extractMarkedExampleConfig = (content, label) => {
 const fallbackImageUrl = 'https://example.com/limited-no-data.png'
 const veryLowImageUrl = 'https://example.com/very-low.png'
 
-const dynamicImageConfig = value => ({
+const dynamicImageConfig = (value, dataFunction = 'Sum') => ({
   type: 'data-bite',
   theme: 'theme-blue',
   dataColumn: 'value',
-  dataFunction: 'Sum',
+  dataFunction,
   bitePosition: 'Bottom',
   biteFontSize: '17',
   biteStyle: 'body',
@@ -109,10 +109,11 @@ describe('Data Bite', () => {
   })
 
   it('uses the dynamic image fallback when sum has no numeric values', async () => {
-    render(<CdcDataBite config={dynamicImageConfig(' ')} />)
+    const { container } = render(<CdcDataBite config={dynamicImageConfig(' ')} />)
 
     const image = await screen.findByAltText('Limited / No Data')
     expect(image).toHaveAttribute('src', fallbackImageUrl)
+    expect(container.querySelector('.bite-value')).toBeEmptyDOMElement()
   })
 
   it('matches dynamic image options for a real zero sum value', async () => {
@@ -120,6 +121,12 @@ describe('Data Bite', () => {
 
     const image = await screen.findByAltText('Very Low')
     expect(image).toHaveAttribute('src', veryLowImageUrl)
+  })
+
+  it.each(['Mean (Average)', 'Median'])('renders an empty value when %s has no numeric values', dataFunction => {
+    const { container } = render(<CdcDataBite config={dynamicImageConfig(' ', dataFunction)} />)
+
+    expect(container.querySelector('.bite-value')).toBeEmptyDOMElement()
   })
 
   it('moves the trend indicator below the value when a trend label is configured', () => {


### PR DESCRIPTION
## Summary

Fixes an issue with data bite dynamic images and undefined values.

## Testing Steps

Open [state-page-combined.json](https://github.com/user-attachments/files/27277664/state-page-combined.json), select U.S. Virgin Islands from the dropdown, the Limited/No Data image should appear.