### PR TITLE
Improve local dev environment

### DIFF
--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -3,7 +3,7 @@ name: Test Storybook
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, test]
 
 jobs:
   storybook-tests:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,7 +2,7 @@ name: Unit Test CI
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [main, dev, test]
 
 jobs:
   unit-tests:

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -21,7 +21,7 @@
   }
 
   /* Add 1rem padding when editor isn't visible to mimic DFE */
-  .cove-storybook:not(:has(.isEditor)) {
+  .cove-storybook:not(:has(.cove-visualization.is-editor, .cove-visualization.is-dashboard-editor)) {
     padding: 1rem;
   }
 

--- a/docs/CONFIG_DOCUMENTATION_GUIDE.md
+++ b/docs/CONFIG_DOCUMENTATION_GUIDE.md
@@ -41,6 +41,8 @@ Document fields where they are owned.
 | Internal-only runtime/editor fields | Usually do not document field-by-field; mention them briefly in a package-level `Fields You Can Ignore` section when consumers may encounter them |
 | Unsupported editor export artifacts | Usually do not document field-by-field; mention them briefly in a package-level `Fields You Can Ignore` section when consumers may encounter them |
 
+Do not add fields to a package-level `Fields You Can Ignore` section just because they appear in local, in-progress, or branch-only config changes. Treat that section as documentation for fields consumers may encounter from supported configs, saved editor exports, or legacy configs on the target branch. Add new ignored fields only when the user explicitly asks for them, or when your current task intentionally introduces/changes a field that consumers can actually encounter.
+
 ## When To Update `packages/core/CONFIG.md`
 
 Update the shared core config reference whenever a package doc needs to describe:

--- a/packages/chart/src/index.jsx
+++ b/packages/chart/src/index.jsx
@@ -9,12 +9,15 @@ let isEditor = window.location.href.includes('editor=true')
 let isDebug = window.location.href.includes('debug=true')
 
 let domContainer = document.getElementsByClassName('react-container')[0]
+let configUrl = domContainer.dataset.configUrl
+let injectedConfig = domContainer.coveConfig
 
 ReactDOM.createRoot(domContainer).render(
   <React.StrictMode>
     <CdcChart
-      interactionLabel={domContainer.attributes['data-config']?.value}
-      configUrl={domContainer.attributes['data-config'].value}
+      interactionLabel={configUrl}
+      config={injectedConfig}
+      configUrl={injectedConfig ? undefined : configUrl}
       isEditor={isEditor}
       isDebug={isDebug}
     />

--- a/packages/core/devTemplate/dev.js
+++ b/packages/core/devTemplate/dev.js
@@ -9,6 +9,22 @@ const previewEnabled = params.get('preview') === 'true'
 const sectionGapParam = params.get('sectionGap')
 const fontSizeParam = params.get('fontSize')
 const metaFontSizeParam = params.get('metaFontSize')
+const defaultConfigPath = '/examples/default.json'
+const initialConfigPath = configParam || defaultConfigPath
+
+const attachConfigToContainer = async (container, configPath) => {
+  if (!container) return
+
+  container.setAttribute('data-config-url', configPath)
+
+  try {
+    const response = await fetch(configPath)
+    container.coveConfig = await response.json()
+  } catch (error) {
+    console.warn(`Unable to load config for ${configPath}; falling back to configUrl rendering.`, error)
+    delete container.coveConfig
+  }
+}
 
 if (sectionGapParam) {
   const numericGap = Number(sectionGapParam)
@@ -57,9 +73,7 @@ window.addEventListener('message', event => {
   }
 })
 
-if (configParam) {
-  document.querySelector('.react-container').setAttribute('data-config', configParam)
-}
+await attachConfigToContainer(document.querySelector('.react-container'), initialConfigPath)
 if (editorEnabled) {
   document.querySelector('.react-container').setAttribute('data-editor', 'true')
 }
@@ -71,7 +85,8 @@ await import('./src/index')
 window.reloadVisualization = async configUrl => {
   const wrapper = document.getElementById('viz-wrapper')
   const editorAttr = editorEnabled ? ' data-editor="true"' : ''
-  wrapper.innerHTML = `<div class="react-container" data-config="${configUrl}"${editorAttr}></div>`
+  wrapper.innerHTML = `<div class="react-container" data-config-url="${configUrl}"${editorAttr}></div>`
+  await attachConfigToContainer(document.querySelector('.react-container'), configUrl)
   await import(/* @vite-ignore */ `./src/index?t=${Date.now()}`)
 }
 
@@ -91,7 +106,7 @@ if (!sidebarDisabled) {
   const examples = await response.json()
 
   // Get current config
-  const currentConfig = configParam || '/examples/default.json'
+  const currentConfig = initialConfigPath
 
   // Build sidebar HTML
   const sidebarRoot = document.getElementById('dev-sidebar-root')
@@ -267,7 +282,7 @@ if (!sidebarDisabled) {
 
     // Reload visualization with new editor state
     const currentConfig =
-      document.querySelector('.react-container')?.getAttribute('data-config') || '/examples/default.json'
+      document.querySelector('.react-container')?.getAttribute('data-config-url') || defaultConfigPath
     await window.reloadVisualization(currentConfig)
   })
 

--- a/packages/core/devTemplate/index.html
+++ b/packages/core/devTemplate/index.html
@@ -20,7 +20,7 @@
     </script>
     <div id="dev-sidebar-root"></div>
     <div id="viz-wrapper">
-      <div class="react-container" data-config="/examples/default.json"></div>
+      <div class="react-container" data-config-url="/examples/default.json"></div>
     </div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script type="module">

--- a/packages/core/devTemplate/preview.html
+++ b/packages/core/devTemplate/preview.html
@@ -668,7 +668,7 @@
                 <div class="dfe-block__inner">
                   <div class="mb-3">
                     <div id="viz-wrapper">
-                      <div class="react-container" data-config="/examples/default.json"></div>
+                      <div class="react-container" data-config-url="/examples/default.json"></div>
                     </div>
                   </div>
                 </div>

--- a/packages/dashboard/src/index.tsx
+++ b/packages/dashboard/src/index.tsx
@@ -9,13 +9,16 @@ import MultiDashboardWrapper from './CdcDashboard'
 let isEditor = window.location.href.includes('editor=true')
 let isDebug = window.location.href.includes('debug=true')
 
-let domContainer = document.getElementsByClassName('react-container')[0]
+let domContainer = document.getElementsByClassName('react-container')[0] as HTMLElement & { coveConfig?: any }
+let configUrl = domContainer.dataset.configUrl
+let injectedConfig = domContainer.coveConfig
 
 ReactDOM.createRoot(domContainer).render(
   <React.StrictMode>
     <MultiDashboardWrapper
-      configUrl={domContainer.attributes['data-config'].value}
-      interactionLabel={domContainer.attributes['data-config'].value}
+      config={injectedConfig}
+      configUrl={injectedConfig ? undefined : configUrl}
+      interactionLabel={configUrl}
       isEditor={isEditor}
       isDebug={isDebug}
     />

--- a/packages/data-bite/src/index.jsx
+++ b/packages/data-bite/src/index.jsx
@@ -9,12 +9,15 @@ import CdcDataBite from './CdcDataBite'
 let isEditor = window.location.href.includes('editor=true')
 
 let domContainer = document.getElementsByClassName('react-container')[0]
+let configUrl = domContainer.dataset.configUrl
+let injectedConfig = domContainer.coveConfig
 
 ReactDOM.createRoot(domContainer).render(
   <React.StrictMode>
     <CdcDataBite
-      configUrl={domContainer.attributes['data-config']?.value}
-      interactionLabel={domContainer.attributes['data-config']?.value}
+      config={injectedConfig}
+      configUrl={injectedConfig ? undefined : configUrl}
+      interactionLabel={configUrl}
       isEditor={isEditor}
     />
   </React.StrictMode>

--- a/packages/data-table/src/index.tsx
+++ b/packages/data-table/src/index.tsx
@@ -8,12 +8,14 @@ import '@cdc/core/styles/cove-main.scss'
 
 let isEditor = window.location.href.includes('editor=true')
 
-let domContainer = document.getElementsByClassName('react-container')[0]
+let domContainer = document.getElementsByClassName('react-container')[0] as HTMLElement & { coveConfig?: any }
+let configUrl = domContainer.dataset.configUrl
+let injectedConfig = domContainer.coveConfig
 
 ReactDOM.createRoot(domContainer).render(
   <React.StrictMode>
     <ErrorBoundary component='CdcDataTable'>
-      <CdcDataTable configUrl={domContainer.attributes['data-config']?.value} isEditor={isEditor} />
+      <CdcDataTable config={injectedConfig} configUrl={injectedConfig ? undefined : configUrl} isEditor={isEditor} />
     </ErrorBoundary>
   </React.StrictMode>
 )

--- a/packages/filtered-text/src/index.jsx
+++ b/packages/filtered-text/src/index.jsx
@@ -9,9 +9,11 @@ import CdcFilteredText from './CdcFilteredText'
 let isEditor = window.location.href.includes('editor=true')
 
 let domContainer = document.getElementsByClassName('react-container')[0]
+let configUrl = domContainer.dataset.configUrl
+let injectedConfig = domContainer.coveConfig
 
 ReactDOM.createRoot(domContainer).render(
   <React.StrictMode>
-    <CdcFilteredText configUrl={domContainer.attributes['data-config'].value} isEditor={isEditor} />
+    <CdcFilteredText config={injectedConfig} configUrl={injectedConfig ? undefined : configUrl} isEditor={isEditor} />
   </React.StrictMode>
 )

--- a/packages/map/src/index.jsx
+++ b/packages/map/src/index.jsx
@@ -8,13 +8,16 @@ import CdcMap from './CdcMap'
 
 let isEditor = window.location.href.includes('editor=true')
 let domContainer = document.getElementsByClassName('react-container')[0]
+let configUrl = domContainer.dataset.configUrl
+let injectedConfig = domContainer.coveConfig
 
 ReactDOM.createRoot(domContainer).render(
   <React.StrictMode>
     <CdcMap
       isEditor={isEditor}
-      configUrl={domContainer.attributes['data-config'].value}
-      interactionLabel={domContainer.attributes['data-config'].value}
+      config={injectedConfig}
+      configUrl={injectedConfig ? undefined : configUrl}
+      interactionLabel={configUrl}
       containerEl={domContainer}
     />
   </React.StrictMode>

--- a/packages/markup-include/src/index.tsx
+++ b/packages/markup-include/src/index.tsx
@@ -9,14 +9,17 @@ import CdcMarkupInclude from './CdcMarkupInclude'
 
 let isEditor = window.location.href.includes('editor=true')
 
-let domContainer = document.getElementsByClassName('react-container')[0]
+let domContainer = document.getElementsByClassName('react-container')[0] as HTMLElement & { coveConfig?: any }
+let configUrl = domContainer.dataset.configUrl
+let injectedConfig = domContainer.coveConfig
 
 ReactDOM.createRoot(domContainer).render(
   <React.StrictMode>
     <GlobalContextProvider>
       <CdcMarkupInclude
-        configUrl={domContainer.attributes['data-config'].value}
-        interactionLabel={domContainer.attributes['data-config'].value}
+        config={injectedConfig}
+        configUrl={injectedConfig ? undefined : configUrl}
+        interactionLabel={configUrl}
         isEditor={isEditor}
       />
     </GlobalContextProvider>

--- a/packages/waffle-chart/src/index.jsx
+++ b/packages/waffle-chart/src/index.jsx
@@ -8,12 +8,15 @@ import CdcWaffleChart from './CdcWaffleChart'
 let isEditor = window.location.href.includes('editor=true')
 
 let domContainer = document.getElementsByClassName('react-container')[0]
+let configUrl = domContainer.dataset.configUrl
+let injectedConfig = domContainer.coveConfig
 
 ReactDOM.createRoot(domContainer).render(
   <React.StrictMode>
     <CdcWaffleChart
-      configUrl={domContainer.attributes['data-config'].value}
-      interactionLabel={domContainer.attributes['data-config'].value}
+      config={injectedConfig}
+      configUrl={injectedConfig ? undefined : configUrl}
+      interactionLabel={configUrl}
       isEditor={isEditor}
     />
   </React.StrictMode>


### PR DESCRIPTION
## Summary

A few general improvements for development:

* Visualizations components are loaded using the `config=` prop instead of `configUrl=`. This matches behavior of WCMS more closely and should help catch some issues earlier. Storybook still uses a mixture of `config=` and `configUrl=`, useful or testing.
* Get rid of extra storybook page padding in editor mode
* Turn on unit/storybook tests for PRs into test branch
* CONFIG.md fields don't need to be added to "fields to ignore" unless explicitly asked for
