### PR TITLE
Fix Tooltip Spacing

### DIFF
--- a/packages/core/components/ui/tooltip.scss
+++ b/packages/core/components/ui/tooltip.scss
@@ -44,6 +44,7 @@
 
     ul {
       list-style: none;
+      padding-left: 0;
 
       li {
         font-size: var(--cove-tooltip-font-size) !important;


### PR DESCRIPTION
## Summary
Simple tooltip spacing fix, remove extra padding that was present.


