### PR TITLE
fix: shared filters apply properly during setup

### DIFF
--- a/packages/dashboard/src/store/dashboard.reducer.test.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.test.ts
@@ -233,3 +233,40 @@ describe('dashboard reducer conditional columns', () => {
     expect(nextState.config.dashboard.sharedFilters[0].usedBy).toEqual(['condition-1-replacement', 'condition-2'])
   })
 })
+
+describe('SET_SHARED_FILTERS', () => {
+  it('recomputes filteredData when shared filter targets change', () => {
+    const state = {
+      ...makeState({
+        datasets: {
+          data1: { data: [{ name: 'Alice' }, { name: 'Bob' }] }
+        },
+        rows: [{ columns: [{ width: 12, widget: 'vizA' }] }],
+        visualizations: {
+          vizA: { uid: 'vizA', type: 'data-bite', visualizationType: 'data-bite', dataKey: 'data1' }
+        }
+      }),
+      data: {
+        data1: [{ name: 'Alice' }, { name: 'Bob' }]
+      },
+      filteredData: { vizA: [{ name: 'Bob' }] }
+    } as DashboardState
+
+    const next = reducer(state, {
+      type: 'SET_SHARED_FILTERS',
+      payload: [
+        {
+          key: 'Name',
+          type: 'datafilter',
+          columnName: 'name',
+          active: 'Alice',
+          usedBy: ['vizA']
+        }
+      ]
+    } as any)
+
+    expect(next.filteredData).toEqual({
+      vizA: [{ name: 'Alice' }]
+    })
+  })
+})

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import { getUpdateConfig } from '../helpers/getUpdateConfig'
+import { getFilteredData } from '../helpers/getFilteredData'
 import { MultiDashboard, MultiDashboardConfig } from '../types/MultiDashboard'
 import DashboardActions from './dashboard.actions'
 import { devToolsWrapper } from '@cdc/core/helpers/withDevTools'
@@ -95,9 +96,15 @@ const reducer = (state: DashboardState, action: DashboardActions): DashboardStat
     case 'SET_SHARED_FILTERS': {
       const newSharedFilters = action.payload
       const newDashboardConfig = { ...state.config.dashboard, sharedFilters: newSharedFilters }
+      const nextConfig = saveMultiChanges(
+        { ...state.config, dashboard: newDashboardConfig },
+        state.config.activeDashboard
+      )
+      const filteredData = getFilteredData({ ...state, config: nextConfig })
       return {
         ...state,
-        config: saveMultiChanges({ ...state.config, dashboard: newDashboardConfig }, state.config.activeDashboard)
+        config: nextConfig,
+        filteredData
       }
     }
     case 'SET_TAB_SELECTED': {


### PR DESCRIPTION
## Shared Filter Update

### Editor Config:  [dashboard-filter-issue.json](https://github.com/user-attachments/files/27449825/dashboard-filter-issue.json)

*Previous Behavior*
* Load Config > Open Filter Configuration > Assign Filters to Data Bites > Wrench Icon on Data Bites > No Data Shows

*New Behavior*
* Load Config > Open Filter Configuration > Assign Filters to Data Bites > Wrench Icon on Data Bites > **Data Shows**