### PR TITLE
fix: column sizing

### DIFF
--- a/packages/dashboard/src/scss/main.scss
+++ b/packages/dashboard/src/scss/main.scss
@@ -282,33 +282,20 @@ button.row-menu__btn[title*='Equal Height Rows'] {
       > [class*='col-'] {
         padding-left: 0;
         padding-right: 0;
+        min-width: 0;
       }
 
       > .col-md-12 {
-        flex: 0 0 100%;
-        max-width: 100%;
-        width: 100%;
+        flex: 12 1 0;
       }
-
       > .col-md-8 {
-        // Keep the existing 8-column span while accounting for the single inter-column gap.
-        flex: 0 0 calc(((100% - var(--dashboard-column-gap)) / 3 * 2) + var(--dashboard-column-gap));
-        max-width: calc(((100% - var(--dashboard-column-gap)) / 3 * 2) + var(--dashboard-column-gap));
-        width: calc(((100% - var(--dashboard-column-gap)) / 3 * 2) + var(--dashboard-column-gap));
+        flex: 8 1 0;
       }
-
       > .col-md-6 {
-        // Keep the existing 6-column span while accounting for the single inter-column gap.
-        flex: 0 0 calc((100% - var(--dashboard-column-gap)) / 2);
-        max-width: calc((100% - var(--dashboard-column-gap)) / 2);
-        width: calc((100% - var(--dashboard-column-gap)) / 2);
+        flex: 6 1 0;
       }
-
       > .col-md-4 {
-        // Keep the existing 4-column span while accounting for the two inter-column gaps.
-        flex: 0 0 calc((100% - (var(--dashboard-column-gap) * 2)) / 3);
-        max-width: calc((100% - (var(--dashboard-column-gap) * 2)) / 3);
-        width: calc((100% - (var(--dashboard-column-gap) * 2)) / 3);
+        flex: 4 1 0;
       }
     }
 

--- a/packages/dashboard/src/scss/main.scss
+++ b/packages/dashboard/src/scss/main.scss
@@ -204,40 +204,28 @@ button.row-menu__btn[title*='Equal Height Rows'] {
     --dashboard-column-gap: 1.5rem;
     margin-right: 0;
     margin-left: 0;
+    column-gap: 0;
     // Row spacing for desktop
     margin-bottom: 1.5rem;
+
+    > [class*='col-'] {
+      // Remove side padding when columns stack to full width.
+      padding-left: 0;
+      padding-right: 0;
+      flex: 0 0 100%;
+      max-width: 100%;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+
+    // Last column doesn't need margin (row margin handles gap to next row)
+    > [class*='col-']:last-child {
+      margin-bottom: 0;
+    }
 
     // Last row doesn't need bottom margin
     &:last-child {
       margin-bottom: 0;
-    }
-  }
-
-  // Stacked layout for tablet/mobile widths
-  @media (max-width: 991.98px) {
-    .row {
-      margin-bottom: 1.5rem;
-      column-gap: 0;
-
-      > [class*='col-'] {
-        // Remove side padding when columns stack to full width.
-        padding-left: 0;
-        padding-right: 0;
-        flex: 0 0 100%;
-        max-width: 100%;
-        width: 100%;
-        margin-bottom: 1.5rem;
-      }
-
-      // Last column doesn't need margin (row margin handles gap to next row)
-      > [class*='col-']:last-child {
-        margin-bottom: 0;
-      }
-
-      // Last row doesn't need extra margin
-      &:last-child {
-        margin-bottom: 0;
-      }
     }
   }
 
@@ -275,14 +263,15 @@ button.row-menu__btn[title*='Equal Height Rows'] {
     width: 100%;
   }
 
-  @media (min-width: 992px) {
+  @include breakpoint(md) {
     .row {
       column-gap: var(--dashboard-column-gap);
 
       > [class*='col-'] {
-        padding-left: 0;
-        padding-right: 0;
         min-width: 0;
+        width: auto;
+        max-width: none;
+        margin-bottom: 0;
       }
 
       > .col-md-12 {
@@ -424,12 +413,6 @@ button.row-menu__btn[title*='Equal Height Rows'] {
           min-height: 0 !important;
         }
 
-        @media (max-width: 767.98px) {
-          flex: 0 0 100% !important;
-          max-width: 100% !important;
-          width: 100% !important;
-        }
-
         .cove-visualization .cove-visualization__body.bite__style--tp5 > .cove-visualization__body-wrap {
           display: flex !important;
           flex-direction: column !important;
@@ -555,7 +538,7 @@ button.row-menu__btn[title*='Equal Height Rows'] {
         }
       }
 
-      @media (min-width: 768px) {
+      @include breakpoint(md) {
         > .col-md-12 {
           flex: 12 1 0 !important;
         }

--- a/packages/dashboard/src/scss/main.scss
+++ b/packages/dashboard/src/scss/main.scss
@@ -349,7 +349,6 @@ button.row-menu__btn[title*='Equal Height Rows'] {
       [class*='col-'] {
         display: flex;
         flex-direction: column !important;
-        flex: 1 1 auto !important;
         align-items: stretch !important;
         min-height: 0 !important;
 
@@ -423,6 +422,12 @@ button.row-menu__btn[title*='Equal Height Rows'] {
         .cdc-callout__body {
           flex: 1 1 auto !important;
           min-height: 0 !important;
+        }
+
+        @media (max-width: 767.98px) {
+          flex: 0 0 100% !important;
+          max-width: 100% !important;
+          width: 100% !important;
         }
 
         .cove-visualization .cove-visualization__body.bite__style--tp5 > .cove-visualization__body-wrap {
@@ -547,6 +552,24 @@ button.row-menu__btn[title*='Equal Height Rows'] {
         .cove-visualization .cove-visualization__body.bite__style--tp5 .cdc-callout__content {
           flex: 1 1 auto !important;
           min-height: 0 !important;
+        }
+      }
+
+      @media (min-width: 768px) {
+        > .col-md-12 {
+          flex: 12 1 0 !important;
+        }
+
+        > .col-md-8 {
+          flex: 8 1 0 !important;
+        }
+
+        > .col-md-6 {
+          flex: 6 1 0 !important;
+        }
+
+        > .col-md-4 {
+          flex: 4 1 0 !important;
         }
       }
     }


### PR DESCRIPTION
This pull request simplifies the CSS flexbox layout rules for the dashboard grid columns in `main.scss`. The main change is replacing explicit width and max-width calculations with simpler flex shorthand properties, making the grid more maintainable and flexible. Additionally, a `min-width: 0` rule is added to prevent column overflow issues.

**Grid layout simplification:**

* Replaced explicit `flex`, `width`, and `max-width` calculations for `.col-md-12`, `.col-md-8`, `.col-md-6`, and `.col-md-4` with simpler `flex` shorthand values, improving maintainability and flexibility of the grid system.
* Added `min-width: 0` to column classes to prevent content from overflowing their containers in flex layouts.