### PR TITLE
Fix [DEV-13019] Fix image in pass through mode

### DIFF
--- a/packages/data-bite/src/CdcDataBite.tsx
+++ b/packages/data-bite/src/CdcDataBite.tsx
@@ -555,7 +555,11 @@ const CdcDataBite = (props: CdcDataBiteProps) => {
     let imageAlt = imageData.alt
 
     if ('dynamic' === imageData.display && imageData.options && imageData.options?.length > 0) {
-      let targetVal = Number(calculateDataBite(false))
+      const rawTargetVal = calculateDataBite(false)
+      const targetVal =
+        rawTargetVal === undefined || rawTargetVal === null || String(rawTargetVal).trim() === ''
+          ? undefined
+          : Number(rawTargetVal)
       let argumentActive = false
 
       if (Number.isFinite(targetVal)) {

--- a/packages/data-bite/src/test/CdcDataBite.test.jsx
+++ b/packages/data-bite/src/test/CdcDataBite.test.jsx
@@ -155,6 +155,20 @@ describe('Data Bite', () => {
     expect(image).toHaveAttribute('src', veryLowImageUrl)
   })
 
+  it.each(['', ' ', null, undefined])('uses the dynamic image fallback when pass-through value is %s', async value => {
+    render(<CdcDataBite config={dynamicImageConfig(value, 'Pass Through')} />)
+
+    const image = await screen.findByAltText('Limited / No Data')
+    expect(image).toHaveAttribute('src', fallbackImageUrl)
+  })
+
+  it('matches dynamic image options for a real zero pass-through value', async () => {
+    render(<CdcDataBite config={dynamicImageConfig('0', 'Pass Through')} />)
+
+    const image = await screen.findByAltText('Very Low')
+    expect(image).toHaveAttribute('src', veryLowImageUrl)
+  })
+
   it.each(['Mean (Average)', 'Median'])('renders an empty value when %s has no numeric values', dataFunction => {
     const { container } = render(<CdcDataBite config={dynamicImageConfig(' ', dataFunction)} />)
 


### PR DESCRIPTION
## Summary

Fixes an issue with dynamic data bite images in pass through mode.

## Testing Steps

Load the [state-page-combined2.json](https://github.com/user-attachments/files/27448146/state-page-combined2.json) dashboard config. When you select U.S. Virgin Islands, the image displayed should be the Limited/No Data image.