### PR TITLE
Fix: Makes small multiples respond to correct viewport

### DIFF
--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -187,11 +187,10 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
 
   // height before bottom axis
   const initialHeight = useMemo(
-    () =>
-      visualizationType === 'Warming Stripes' ? WARMING_STRIPES_HEIGHT : calcInitialHeight(config, currentViewport),
+    () => (visualizationType === 'Warming Stripes' ? WARMING_STRIPES_HEIGHT : calcInitialHeight(config, vizViewport)),
     [
       visualizationType,
-      currentViewport,
+      vizViewport,
       config.heights?.vertical,
       config.heights?.horizontal,
       config.heights?.mobileVertical,
@@ -303,7 +302,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     yMax,
     xMax,
     yAxisAutoPaddingMode,
-    currentViewport
+    currentViewport: vizViewport
   })
 
   // Consolidated tick formatters
@@ -345,7 +344,7 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
     runtime.yAxis.label && !config.hideYAxisLabel && config.yAxis.titlePlacement !== 'top' ? 30 : 0
 
   const [yTickCount, xTickCount] = ['yAxis', 'xAxis'].map(axis =>
-    countNumOfTicks({ axis, max, runtime, currentViewport, isHorizontal, data, config, min })
+    countNumOfTicks({ axis, max, runtime, currentViewport: vizViewport, isHorizontal, data, config, min })
   )
   const handleNumTicks = isForestPlot ? config.data.length : yTickCount
 
@@ -434,11 +433,11 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
 
   const getManualStep = useCallback(() => {
     let manualStep = config.xAxis.manualStep
-    if (config.xAxis.viewportStepCount && config.xAxis.viewportStepCount[currentViewport]) {
-      manualStep = config.xAxis.viewportStepCount[currentViewport]
+    if (config.xAxis.viewportStepCount && config.xAxis.viewportStepCount[vizViewport]) {
+      manualStep = config.xAxis.viewportStepCount[vizViewport]
     }
     return manualStep
-  }, [config.xAxis.manualStep, config.xAxis.viewportStepCount, currentViewport])
+  }, [config.xAxis.manualStep, config.xAxis.viewportStepCount, vizViewport])
 
   const smallMultiplesSync = useSmallMultipleSynchronization(xMax, yMax, yAxisWidth, getXValueFromCoordinate)
 

--- a/packages/chart/src/components/LinearChart/tests/LinearChart.test.tsx
+++ b/packages/chart/src/components/LinearChart/tests/LinearChart.test.tsx
@@ -280,6 +280,71 @@ describe('LinearChart', () => {
       expect(bottomAxis).toBeTruthy()
     })
 
+    it('uses vizViewport for x-axis viewport tick overrides', () => {
+      const data = [
+        { Date: '2024-01-01', Value: 1 },
+        { Date: '2024-02-01', Value: 2 },
+        { Date: '2024-03-01', Value: 3 },
+        { Date: '2024-04-01', Value: 4 },
+        { Date: '2024-05-01', Value: 5 },
+        { Date: '2024-06-01', Value: 6 }
+      ]
+
+      const { container } = renderLinearChart(
+        {
+          data,
+          preliminaryData: [],
+          series: [{ dataKey: 'Value', axis: 'Left' }],
+          xAxis: {
+            type: 'date',
+            dataKey: 'Date',
+            label: 'X-Axis',
+            hideAxis: false,
+            hideLabel: false,
+            hideTicks: false,
+            size: '50',
+            tickRotation: 0,
+            maxTickRotation: 90,
+            anchors: [],
+            axisPadding: 0,
+            dateParseFormat: '%Y-%m-%d',
+            dateDisplayFormat: '%b %Y'
+          },
+          runtime: {
+            xAxis: {
+              type: 'date',
+              dataKey: 'Date',
+              label: 'X-Axis',
+              numTicks: 6,
+              viewportNumTicks: { xxs: 2 }
+            },
+            yAxis: {
+              size: 50,
+              label: 'Y-Axis',
+              gridLines: true
+            },
+            originalXAxis: {
+              dataKey: 'Date'
+            },
+            series: [{ dataKey: 'Value', axis: 'Left' }],
+            seriesKeys: ['Value'],
+            seriesLabels: { Value: 'Value' },
+            seriesLabelsAll: ['Value'],
+            uniqueId: 'test-chart'
+          }
+        },
+        {
+          currentViewport: 'lg',
+          vizViewport: 'xxs',
+          colorScale: () => '#000',
+          transformedData: data,
+          tableData: data
+        }
+      )
+
+      expect(container.querySelectorAll('.bottom-axis .vx-axis-tick')).toHaveLength(2)
+    })
+
     it('hides Y axis when hideAxis is true', () => {
       const { container } = renderLinearChart({
         yAxis: {


### PR DESCRIPTION
## Summary

Uses the local viewport to determine number of x-axis ticks and chart height.

## Testing Steps

Open or create a small multiple chart, change the x-axis viewport / num ticks setting, see that they are applied correctly.