### PR TITLE
Dev 13032 b race condition

### DIFF
--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -260,7 +260,10 @@ export default function CdcDashboard({
         return acc
       }, {})
       const _newData = { ...newData, ...dataFiles }
-      dispatch({ type: 'SET_DATA', payload: _newData })
+      dispatch({
+        type: 'SET_DATA',
+        payload: { data: _newData, activeDashboard: config.activeDashboard }
+      })
       const dataFilterIndexes = config.dashboard.sharedFilters.reduce((acc, filter, index) => {
         if (filter.type === 'datafilter') acc.push(index)
         return acc
@@ -277,7 +280,10 @@ export default function CdcDashboard({
         {},
         _newData
       )
-      dispatch({ type: 'SET_FILTERED_DATA', payload: filteredData })
+      dispatch({
+        type: 'SET_FILTERED_DATA',
+        payload: { filteredData, activeDashboard: config.activeDashboard }
+      })
       const visualizations = reloadURLHelpers.getVisualizationsWithFormattedData(
         config.visualizations as Record<string, Visualization>,
         newData
@@ -321,7 +327,7 @@ export default function CdcDashboard({
 
     const newFilteredData = getFilteredData({ ...state, config: newConfig }, filteredData)
 
-    dispatch({ type: 'SET_FILTERED_DATA', payload: newFilteredData })
+    dispatch({ type: 'SET_FILTERED_DATA', payload: { filteredData: newFilteredData } })
     dispatch({ type: 'SET_CONFIG', payload: newConfig })
     dispatch({ type: 'SET_SHARED_FILTERS', payload: newConfig.dashboard.sharedFilters })
   }
@@ -336,8 +342,8 @@ export default function CdcDashboard({
       }, {})
       const newConfig = { ...state, data: { ...data, ...newDatasets } }
       const newFilteredData = getFilteredData(newConfig, cloneDeep(filteredData))
-      dispatch({ type: 'SET_FILTERED_DATA', payload: newFilteredData })
-      dispatch({ type: 'SET_DATA', payload: { ...data, ...newDatasets } })
+      dispatch({ type: 'SET_FILTERED_DATA', payload: { filteredData: newFilteredData } })
+      dispatch({ type: 'SET_DATA', payload: { data: { ...data, ...newDatasets } } })
     } catch (e) {
       console.error('Error setting event data: ', e)
     }
@@ -377,8 +383,8 @@ export default function CdcDashboard({
   useEffect(() => {
     return () => {
       // Clear all data when component unmounts to prevent memory leaks
-      dispatch({ type: 'SET_DATA', payload: {} })
-      dispatch({ type: 'SET_FILTERED_DATA', payload: {} })
+      dispatch({ type: 'SET_DATA', payload: { data: {} } })
+      dispatch({ type: 'SET_FILTERED_DATA', payload: { filteredData: {} } })
 
       // Clear any pending API requests
       setAPILoading(false)

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
@@ -192,7 +192,7 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
       }
     }
     const newFilteredData = getFilteredData(clonedState)
-    dispatch({ type: 'SET_FILTERED_DATA', payload: newFilteredData })
+    dispatch({ type: 'SET_FILTERED_DATA', payload: { filteredData: newFilteredData } })
 
     publishAnalyticsEvent({
       vizType: dashboardConfig.type,
@@ -279,7 +279,7 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
           }
         }
         const newFilteredData = getFilteredData(clonedState)
-        dispatch({ type: 'SET_FILTERED_DATA', payload: newFilteredData })
+        dispatch({ type: 'SET_FILTERED_DATA', payload: { filteredData: newFilteredData } })
         dispatch({ type: 'SET_SHARED_FILTERS', payload: updatedFilters })
       }
     }

--- a/packages/dashboard/src/components/Grid.tsx
+++ b/packages/dashboard/src/components/Grid.tsx
@@ -4,6 +4,7 @@ import Button from '@cdc/core/components/elements/Button'
 
 import { DashboardContext, DashboardDispatchContext } from '../DashboardContext'
 import { ConfigRow } from '../types/ConfigRow'
+import { createRowUuid } from '../helpers/createRowUuid'
 
 const Grid = () => {
   const { config } = useContext(DashboardContext)
@@ -12,7 +13,7 @@ const Grid = () => {
   const rows = config.rows
   const updateConfig = config => dispatch({ type: 'UPDATE_CONFIG', payload: [config] })
   const addRow = () => {
-    const blankRow: Partial<ConfigRow> = { columns: [{ width: 12 }], uuid: Date.now() }
+    const blankRow: Partial<ConfigRow> = { columns: [{ width: 12 }], uuid: createRowUuid() }
     updateConfig({
       ...config,
       rows: [...rows, blankRow]

--- a/packages/dashboard/src/components/Header/Header.tsx
+++ b/packages/dashboard/src/components/Header/Header.tsx
@@ -51,7 +51,7 @@ const Header = (props: HeaderProps) => {
         return acc
       }, {})
 
-      dispatch({ type: 'SET_DATA', payload: sampleDataRemoved })
+      dispatch({ type: 'SET_DATA', payload: { data: sampleDataRemoved } })
     }
   }
 

--- a/packages/dashboard/src/components/Row.test.tsx
+++ b/packages/dashboard/src/components/Row.test.tsx
@@ -185,4 +185,37 @@ describe('Row', () => {
     const nextConfig = dispatch.mock.calls[0][0].payload[0]
     expect(nextConfig.dashboard.sharedFilters[0].usedBy).toEqual(['condition-1', 'legacy-footnote-target', 'viz-1', 0])
   })
+
+  it('assigns distinct row uuids when moving a row even if Date.now matches', () => {
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(1234567890)
+    const mathRandomSpy = vi.spyOn(Math, 'random')
+    mathRandomSpy.mockReturnValueOnce(0.11111).mockReturnValueOnce(0.22222)
+
+    const { dispatch } = renderRowWithConfig({
+      type: 'dashboard',
+      dashboard: { sharedFilters: [] },
+      datasets: {},
+      rows: [
+        {
+          uuid: 'row-a',
+          columns: [],
+          expandCollapseAllButtons: false
+        },
+        {
+          uuid: 'row-b',
+          columns: [],
+          expandCollapseAllButtons: false
+        }
+      ],
+      visualizations: {}
+    } as any)
+
+    fireEvent.click(screen.getByTitle('Move Row Down'))
+
+    const nextConfig = dispatch.mock.calls[0][0].payload[0]
+    expect(nextConfig.rows[0].uuid).not.toEqual(nextConfig.rows[1].uuid)
+
+    dateNowSpy.mockRestore()
+    mathRandomSpy.mockRestore()
+  })
 })

--- a/packages/dashboard/src/components/Row.tsx
+++ b/packages/dashboard/src/components/Row.tsx
@@ -30,6 +30,7 @@ import {
   remapRowTargetsInSharedFilters
 } from '../helpers/dashboardFilterTargets'
 import { getColumnPrimaryWidget, getColumnWidgetKeys } from '../helpers/dashboardColumnWidgets'
+import { createRowUuid } from '../helpers/createRowUuid'
 
 type RowMenuProps = {
   rowIdx: number
@@ -99,8 +100,8 @@ const RowMenu: React.FC<RowMenuProps> = ({ rowIdx }) => {
     rows[newIdx] = row
     rows[rowIdx] = temp
 
-    rows[newIdx].uuid = Date.now()
-    rows[rowIdx].uuid = Date.now()
+    rows[newIdx].uuid = createRowUuid()
+    rows[rowIdx].uuid = createRowUuid()
 
     const remappedSharedFilters = remapRowTargetsInSharedFilters(
       config.dashboard.sharedFilters || [],
@@ -119,6 +120,8 @@ const RowMenu: React.FC<RowMenuProps> = ({ rowIdx }) => {
 
     let rowEle = document.querySelector("[data-row-id='" + rowIdx + "']") as HTMLElement
     let rowNewEle = document.querySelector("[data-row-id='" + newIdx + "']") as HTMLElement
+
+    if (!rowEle || !rowNewEle) return
 
     rowEle.style.pointerEvents = 'none'
     rowNewEle.style.pointerEvents = 'none'

--- a/packages/dashboard/src/components/Widget/Widget.tsx
+++ b/packages/dashboard/src/components/Widget/Widget.tsx
@@ -114,7 +114,7 @@ const Widget = ({
             // the HEADER component removes the data when you toggle to the main viz panel.
             // data will be cached only when it's loaded via dashboard preview.
             ;(responseData as any).sample = true
-            dispatch({ type: 'SET_DATA', payload: { ...data, [dataKey]: responseData } })
+            dispatch({ type: 'SET_DATA', payload: { data: { ...data, [dataKey]: responseData } } })
           })
           .catch(error => {
             console.error('Failed to fetch sample data:', error)

--- a/packages/dashboard/src/helpers/createRowUuid.ts
+++ b/packages/dashboard/src/helpers/createRowUuid.ts
@@ -1,0 +1,1 @@
+export const createRowUuid = () => `row-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`

--- a/packages/dashboard/src/store/dashboard.actions.ts
+++ b/packages/dashboard/src/store/dashboard.actions.ts
@@ -22,10 +22,10 @@ type MOVE_VISUALIZATION = Action<
 >
 type SET_CONFIG = Action<'SET_CONFIG', Partial<Config> & { activeDashboard?: number }>
 type UPDATE_CONFIG = Action<'UPDATE_CONFIG', [Config, Object?]>
-type SET_DATA = Action<'SET_DATA', Record<string, any[]>>
+type SET_DATA = Action<'SET_DATA', { data: Record<string, any[]>; activeDashboard?: number }>
 type SET_LOADING = Action<'SET_LOADING', boolean>
 type SET_PREVIEW = Action<'SET_PREVIEW', boolean>
-type SET_FILTERED_DATA = Action<'SET_FILTERED_DATA', Object>
+type SET_FILTERED_DATA = Action<'SET_FILTERED_DATA', { filteredData: Object; activeDashboard?: number }>
 type SET_SHARED_FILTERS = Action<'SET_SHARED_FILTERS', SharedFilter[]>
 type SET_TAB_SELECTED = Action<'SET_TAB_SELECTED', Tab>
 type RENAME_DASHBOARD_TAB = Action<'RENAME_DASHBOARD_TAB', { current: string; new: string }>

--- a/packages/dashboard/src/store/dashboard.reducer.test.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.test.ts
@@ -48,6 +48,36 @@ describe('RENAME_DASHBOARD_TAB', () => {
   })
 })
 
+describe('tab-scoped async updates', () => {
+  it('ignores stale SET_DATA updates from a previously active dashboard', () => {
+    const state = makeState()
+    state.data = { fresh: [{ value: 'tab-b' }] }
+    state.config.activeDashboard = 1
+
+    const next = reducer(state, {
+      type: 'SET_DATA',
+      payload: { data: { stale: [{ value: 'tab-a' }] }, activeDashboard: 0 }
+    })
+
+    expect(next).toBe(state)
+    expect(next.data).toEqual({ fresh: [{ value: 'tab-b' }] })
+  })
+
+  it('ignores stale SET_FILTERED_DATA updates from a previously active dashboard', () => {
+    const state = makeState()
+    state.filteredData = { fresh: [{ value: 'tab-b' }] }
+    state.config.activeDashboard = 1
+
+    const next = reducer(state, {
+      type: 'SET_FILTERED_DATA',
+      payload: { filteredData: { stale: [{ value: 'tab-a' }] }, activeDashboard: 0 }
+    })
+
+    expect(next).toBe(state)
+    expect(next.filteredData).toEqual({ fresh: [{ value: 'tab-b' }] })
+  })
+})
+
 const baseState = (): DashboardState =>
   ({
     config: {

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -82,10 +82,22 @@ const reducer = (state: DashboardState, action: DashboardActions): DashboardStat
       } else return state // ignore SET_CONFIG calls that have the wrong activeDashboard due to async api fetching
     }
     case 'SET_DATA': {
-      return { ...state, data: action.payload }
+      if (
+        action.payload.activeDashboard !== undefined &&
+        state.config.activeDashboard !== action.payload.activeDashboard
+      ) {
+        return state
+      }
+      return { ...state, data: action.payload.data }
     }
     case 'SET_FILTERED_DATA': {
-      return { ...state, filteredData: action.payload }
+      if (
+        action.payload.activeDashboard !== undefined &&
+        state.config.activeDashboard !== action.payload.activeDashboard
+      ) {
+        return state
+      }
+      return { ...state, filteredData: action.payload.filteredData }
     }
     case 'SET_LOADING': {
       return { ...state, loading: action.payload }


### PR DESCRIPTION
  The clearest introduction point is January 16, 2025 in commit d2ae17d156 (fix dev-10289 multi tab switching causing issues). That change added a safeguard so late async
  results could no longer overwrite config for the wrong tab in packages/dashboard/src/store/dashboard.reducer.ts:75, but it did not add the same safeguard for data and
  filteredData. So after that commit, a slow request from tab A could still finish after you switched to tab B and overwrite the shared data state, even though the config
  write was blocked.

  In simple terms, the bug was:

  - Tab A starts loading data.
  - You switch to tab B before tab A finishes.
  - Tab A’s request comes back late.
  - The app correctly says “don’t overwrite tab B’s config,” but it still says “go ahead and overwrite the data.”
  - Result: tab B can show tab A’s content, which looks like one tab overwrote the other.