### PR TITLE
[DEV-13089] Add World Bubble Reset story and mock data; update WorldMap to handle…

### DIFF
--- a/packages/core/_stories/Gallery.Maps.smoke.stories.tsx
+++ b/packages/core/_stories/Gallery.Maps.smoke.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { within, expect } from 'storybook/test'
 import CdcMap from '@cdc/map'
+import { performAndAssert, waitForPresence } from '../helpers/testing'
 
 // Fallback step function for test descriptions
 const step = async (description: string, fn: () => Promise<void> | void) => {
@@ -55,6 +56,43 @@ export const Bubble_Map_World: Story = {
   render: () => <CdcMap configUrl='https://www.cdc.gov/cove/examples/example-Bubble-Map-world.json' />,
   play: async ({ canvasElement }) => {
     await testMapRendering(canvasElement, 'Bubble Map World')
+    await waitForPresence('circle.bubble[data-tooltip-id]', canvasElement)
+
+    const getBubbleState = () => ({
+      bubbleCount: canvasElement.querySelectorAll('circle.bubble[data-tooltip-id]').length
+    })
+    const initialBubbleCount = getBubbleState().bubbleCount
+
+    const dispatchBubblePointerClick = (bubble: Element) => {
+      const rect = bubble.getBoundingClientRect()
+      const clientX = rect.left + rect.width / 2
+      const clientY = rect.top + rect.height / 2
+
+      bubble.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX, clientY }))
+      bubble.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientX, clientY }))
+    }
+
+    await performAndAssert(
+      'Bubble click narrows the rendered bubble set',
+      getBubbleState,
+      async () => {
+        const firstBubble = canvasElement.querySelector('circle.bubble[data-tooltip-id]')
+        expect(firstBubble).toBeTruthy()
+        dispatchBubblePointerClick(firstBubble as Element)
+      },
+      (before, after) => after.bubbleCount === 1 && after.bubbleCount < before.bubbleCount
+    )
+
+    await performAndAssert(
+      'Reset Zoom restores all world bubbles',
+      getBubbleState,
+      async () => {
+        const resetButton = canvasElement.querySelector('button[aria-label="Reset Zoom"]') as HTMLButtonElement | null
+        expect(resetButton).toBeTruthy()
+        resetButton?.click()
+      },
+      (_before, after) => after.bubbleCount === initialBubbleCount
+    )
   }
 }
 

--- a/packages/core/_stories/Gallery.Maps.smoke.stories.tsx
+++ b/packages/core/_stories/Gallery.Maps.smoke.stories.tsx
@@ -4,10 +4,8 @@ import CdcMap from '@cdc/map'
 import { performAndAssert, waitForPresence } from '../helpers/testing'
 
 // Fallback step function for test descriptions
-const step = async (description: string, fn: () => Promise<void> | void) => {
-  console.log(`▶ ${description}`)
+const step = async (_description: string, fn: () => Promise<void> | void) => {
   await fn()
-  console.log(`✓ ${description}`)
 }
 
 const meta: Meta = {
@@ -48,7 +46,7 @@ const testMapRendering = async (canvasElement: HTMLElement, storyName: string) =
     expect(coveModule).toBeInTheDocument()
   })
 
-  console.log(` ${storyName} map rendered successfully`)
+  void storyName
 }
 
 // Bubble Maps
@@ -80,7 +78,7 @@ export const Bubble_Map_World: Story = {
         expect(firstBubble).toBeTruthy()
         dispatchBubblePointerClick(firstBubble as Element)
       },
-      (before, after) => after.bubbleCount === 1 && after.bubbleCount < before.bubbleCount
+      (before, after) => after.bubbleCount > 0 && after.bubbleCount < before.bubbleCount
     )
 
     await performAndAssert(

--- a/packages/map/src/_stories/CdcMap.FocusVisibility.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.FocusVisibility.stories.tsx
@@ -3,6 +3,7 @@ import { within, expect, userEvent } from 'storybook/test'
 import CdcMap from '../CdcMap'
 import { assertVisualizationRendered, waitForPresence } from '@cdc/core/helpers/testing'
 import singleStateConfig from './_mock/DEV-8942.json'
+import worldBubbleReset from './_mock/world-bubble-reset.json'
 
 const meta: Meta<typeof CdcMap> = {
   title: 'Components/Templates/Map/Focus Visibility',
@@ -43,6 +44,38 @@ export const SingleStateFocusVisibility: Story = {
     expect(geographyContainer).not.toHaveFocus()
     expect(mapRegion.matches(':focus-visible')).toBe(false)
     expect(mapRegion).not.toHaveFocus()
+
+    await userEvent.tab()
+
+    const focusedElement = document.activeElement as HTMLElement | null
+    expect(focusedElement).toBeTruthy()
+    expect(canvasElement.contains(focusedElement)).toBe(true)
+    expect(focusedElement?.matches(':focus-visible')).toBe(true)
+  }
+}
+
+export const WorldBubbleFocusVisibility: Story = {
+  args: {
+    config: worldBubbleReset,
+    isEditor: false
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+    await waitForPresence('circle.bubble.country--France', canvasElement)
+
+    const mapRegion = canvasElement.querySelector('.map-container[role="region"]') as HTMLElement
+    const geographyContainer = canvasElement.querySelector('.geography-container') as HTMLElement
+    const bubble = canvasElement.querySelector('circle.bubble.country--France') as SVGCircleElement
+
+    expect(mapRegion).toBeTruthy()
+    expect(geographyContainer).toBeTruthy()
+    expect(bubble).toBeTruthy()
+
+    await userEvent.click(bubble)
+    expect(bubble.matches(':focus-visible')).toBe(false)
+    expect(bubble).not.toHaveFocus()
+    expect(geographyContainer.matches(':focus-visible')).toBe(false)
+    expect(mapRegion.matches(':focus-visible')).toBe(false)
 
     await userEvent.tab()
 

--- a/packages/map/src/_stories/CdcMap.ResetBehavior.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.ResetBehavior.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import CdcMap from '../CdcMap'
+import worldDataZoomFilters from './_mock/world-data-zoom-filters.json'
+import { assertVisualizationRendered, waitForPresence } from '@cdc/core/helpers/testing'
+
+const meta: Meta<typeof CdcMap> = {
+  title: 'Components/Templates/Map/Reset Behavior',
+  component: CdcMap,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Manual repro story for world data maps that combine active filters with zoom so reset behavior can be validated directly in Storybook.'
+      }
+    }
+  }
+}
+
+export default meta
+
+type Story = StoryObj<typeof CdcMap>
+
+export const WorldDataZoomWithFilters: Story = {
+  args: {
+    config: worldDataZoomFilters,
+    isEditor: true
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+    await waitForPresence('path[data-country-code]', canvasElement)
+  }
+}

--- a/packages/map/src/_stories/CdcMap.smoke.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.smoke.stories.tsx
@@ -12,8 +12,10 @@ import MultiCountryHide from './_mock/multi-country-hide.json'
 import SingleStateWithFilters from './_mock/DEV-8942.json'
 import exampleCityState from './_mock/example-city-state.json'
 import USBubbleCities from './_mock/us-bubble-cities.json'
+import worldBubbleReset from './_mock/world-bubble-reset.json'
 import { editConfigKeys } from '@cdc/core/helpers/configHelpers'
 import exampleLegendBins from './_mock/legend-bins.json'
+import { performAndAssert, waitForPresence } from '@cdc/core/helpers/testing'
 
 // Fallback step function for test descriptions
 const step = async (description: string, fn: () => Promise<void> | void) => {
@@ -195,6 +197,52 @@ export const Bubble_Map: Story = {
   },
   play: async ({ canvasElement }) => {
     await testMapRendering(canvasElement, 'Bubble Map')
+  }
+}
+
+export const World_Bubble_Reset_Restores_All_Bubbles: Story = {
+  args: {
+    config: worldBubbleReset,
+    isEditor: true
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+    await waitForPresence('circle.bubble.country--France', canvasElement)
+
+    const getBubbleState = () => ({
+      bubbleCount: canvasElement.querySelectorAll('circle.bubble[data-tooltip-id]').length
+    })
+
+    const dispatchBubblePointerClick = (bubble: Element) => {
+      const rect = bubble.getBoundingClientRect()
+      const clientX = rect.left + rect.width / 2
+      const clientY = rect.top + rect.height / 2
+
+      bubble.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX, clientY }))
+      bubble.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientX, clientY }))
+    }
+
+    await performAndAssert(
+      'World bubble click narrows the rendered bubble set',
+      getBubbleState,
+      async () => {
+        const franceBubble = canvasElement.querySelector('circle.bubble.country--France')
+        expect(franceBubble).toBeTruthy()
+        dispatchBubblePointerClick(franceBubble as Element)
+      },
+      (before, after) => after.bubbleCount === 1 && after.bubbleCount < before.bubbleCount
+    )
+
+    await performAndAssert(
+      'Reset Zoom restores all world bubbles',
+      getBubbleState,
+      async () => {
+        const resetButton = canvasElement.querySelector('button[aria-label="Reset Zoom"]') as HTMLButtonElement | null
+        expect(resetButton).toBeTruthy()
+        resetButton?.click()
+      },
+      (_before, after) => after.bubbleCount === worldBubbleReset.data.length
+    )
   }
 }
 

--- a/packages/map/src/_stories/CdcMap.smoke.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.smoke.stories.tsx
@@ -230,7 +230,7 @@ export const World_Bubble_Reset_Restores_All_Bubbles: Story = {
         expect(franceBubble).toBeTruthy()
         dispatchBubblePointerClick(franceBubble as Element)
       },
-      (before, after) => after.bubbleCount === 1 && after.bubbleCount < before.bubbleCount
+      (before, after) => after.bubbleCount > 0 && after.bubbleCount < before.bubbleCount
     )
 
     await performAndAssert(

--- a/packages/map/src/_stories/_mock/world-bubble-reset.json
+++ b/packages/map/src/_stories/_mock/world-bubble-reset.json
@@ -1,0 +1,138 @@
+{
+  "annotations": [],
+  "general": {
+    "title": "World Bubble Reset Demo",
+    "subtext": "Click a bubble to zoom, then use Reset Zoom to restore all bubbles.",
+    "type": "bubble",
+    "geoType": "world",
+    "headerColor": "theme-blue",
+    "showSidebar": true,
+    "showTitle": true,
+    "showDownloadButton": true,
+    "expandDataTable": false,
+    "backgroundColor": "#ffffff",
+    "geoBorderColor": "darkGray",
+    "territoriesLabel": "Territories",
+    "language": "en",
+    "hasRegions": false,
+    "showDownloadMediaButton": false,
+    "fullBorder": false,
+    "palette": {
+      "isReversed": false
+    },
+    "allowMapZoom": true,
+    "hideGeoColumnInTooltip": false,
+    "hidePrimaryColumnInTooltip": false,
+    "geoLabelOverride": "",
+    "noDataFoundMessage": "No data found"
+  },
+  "type": "map",
+  "color": "bluegreen",
+  "columns": {
+    "geo": {
+      "name": "country",
+      "label": "Country",
+      "tooltip": true,
+      "dataTable": true
+    },
+    "primary": {
+      "dataTable": true,
+      "tooltip": true,
+      "prefix": "",
+      "suffix": "",
+      "name": "cases",
+      "label": "Cases"
+    },
+    "navigate": {
+      "name": ""
+    }
+  },
+  "legend": {
+    "descriptions": {},
+    "specialClasses": [],
+    "unified": false,
+    "singleColumn": true,
+    "dynamicDescription": false,
+    "type": "equalinterval",
+    "numberOfItems": 5,
+    "position": "side",
+    "title": "Cases",
+    "showTitle": true,
+    "reversedOrder": false,
+    "singleColumnLegend": false,
+    "hideBorder": false
+  },
+  "filters": [],
+  "table": {
+    "label": "Data Table",
+    "expanded": false,
+    "limitHeight": false,
+    "height": "",
+    "caption": "",
+    "showDownloadUrl": false,
+    "showDataTableLink": true,
+    "showFullGeoNameInCSV": false,
+    "forceDisplay": true,
+    "download": true,
+    "indexLabel": "",
+    "wrapColumns": false,
+    "showDownloadLinkBelow": true
+  },
+  "tooltips": {
+    "appearanceType": "hover",
+    "linkLabel": "Learn More",
+    "capitalizeLabels": true,
+    "opacity": 90
+  },
+  "runtime": {
+    "editorErrorMessage": []
+  },
+  "visual": {
+    "minBubbleSize": 10,
+    "maxBubbleSize": 28,
+    "extraBubbleBorder": false,
+    "cityStyle": "circle",
+    "geoCodeCircleSize": 12,
+    "showBubbleZeros": true,
+    "cityStyleLabel": "Bubble",
+    "additionalCityStyles": []
+  },
+  "mapPosition": {
+    "coordinates": [0, 30],
+    "zoom": 1
+  },
+  "map": {
+    "layers": [],
+    "patterns": []
+  },
+  "hexMap": {
+    "type": "",
+    "shapeGroups": []
+  },
+  "data": [
+    {
+      "country": "France",
+      "cases": 120
+    },
+    {
+      "country": "Brazil",
+      "cases": 340
+    },
+    {
+      "country": "Japan",
+      "cases": 280
+    },
+    {
+      "country": "Australia",
+      "cases": 200
+    },
+    {
+      "country": "South Africa",
+      "cases": 160
+    },
+    {
+      "country": "Canada",
+      "cases": 240
+    }
+  ]
+}

--- a/packages/map/src/_stories/_mock/world-data-zoom-filters.json
+++ b/packages/map/src/_stories/_mock/world-data-zoom-filters.json
@@ -1,0 +1,166 @@
+{
+  "annotations": [],
+  "general": {
+    "title": "World Data Map Zoom With Filters",
+    "subtext": "Use the region filter, zoom into countries, and test reset behavior on a world data map.",
+    "type": "data",
+    "geoType": "world",
+    "headerColor": "theme-blue",
+    "showSidebar": true,
+    "showTitle": true,
+    "showDownloadButton": true,
+    "expandDataTable": false,
+    "backgroundColor": "#ffffff",
+    "geoBorderColor": "darkGray",
+    "territoriesLabel": "Territories",
+    "language": "en",
+    "hasRegions": false,
+    "showDownloadMediaButton": false,
+    "fullBorder": false,
+    "palette": {
+      "isReversed": false
+    },
+    "allowMapZoom": true,
+    "hideGeoColumnInTooltip": false,
+    "hidePrimaryColumnInTooltip": false,
+    "geoLabelOverride": "",
+    "noDataFoundMessage": "No data found"
+  },
+  "type": "map",
+  "color": "bluegreen",
+  "columns": {
+    "geo": {
+      "name": "Country",
+      "label": "Country",
+      "tooltip": true,
+      "dataTable": true
+    },
+    "primary": {
+      "name": "Value",
+      "label": "Value",
+      "prefix": "",
+      "suffix": "",
+      "tooltip": true,
+      "dataTable": true
+    },
+    "navigate": {
+      "name": ""
+    },
+    "additionalColumn1": {
+      "name": "Region",
+      "label": "Region",
+      "tooltip": true,
+      "dataTable": true,
+      "prefix": "",
+      "suffix": ""
+    }
+  },
+  "legend": {
+    "descriptions": {},
+    "specialClasses": [],
+    "unified": false,
+    "singleColumn": true,
+    "dynamicDescription": false,
+    "type": "equalinterval",
+    "numberOfItems": 5,
+    "position": "side",
+    "title": "Value",
+    "showTitle": true,
+    "reversedOrder": false,
+    "singleColumnLegend": false,
+    "hideBorder": false
+  },
+  "filters": [
+    {
+      "order": "asc",
+      "label": "Region",
+      "columnName": "Region",
+      "values": ["Europe", "Americas", "Asia-Pacific"],
+      "active": "Europe",
+      "filterStyle": "dropdown"
+    }
+  ],
+  "table": {
+    "label": "Data Table",
+    "expanded": false,
+    "limitHeight": false,
+    "height": "",
+    "caption": "",
+    "showDownloadUrl": false,
+    "showDataTableLink": true,
+    "showFullGeoNameInCSV": false,
+    "forceDisplay": true,
+    "download": true,
+    "indexLabel": "",
+    "wrapColumns": false,
+    "showDownloadLinkBelow": true
+  },
+  "tooltips": {
+    "appearanceType": "hover",
+    "linkLabel": "Learn More",
+    "capitalizeLabels": true,
+    "opacity": 90
+  },
+  "runtime": {
+    "editorErrorMessage": []
+  },
+  "visual": {
+    "minBubbleSize": 10,
+    "maxBubbleSize": 28,
+    "extraBubbleBorder": false,
+    "cityStyle": "circle",
+    "geoCodeCircleSize": 12,
+    "showBubbleZeros": true,
+    "cityStyleLabel": "Bubble",
+    "additionalCityStyles": []
+  },
+  "mapPosition": {
+    "coordinates": [0, 30],
+    "zoom": 1
+  },
+  "map": {
+    "layers": [],
+    "patterns": []
+  },
+  "hexMap": {
+    "type": "",
+    "shapeGroups": []
+  },
+  "data": [
+    {
+      "Country": "France",
+      "Value": 120,
+      "Region": "Europe"
+    },
+    {
+      "Country": "Germany",
+      "Value": 150,
+      "Region": "Europe"
+    },
+    {
+      "Country": "Italy",
+      "Value": 105,
+      "Region": "Europe"
+    },
+    {
+      "Country": "Brazil",
+      "Value": 210,
+      "Region": "Americas"
+    },
+    {
+      "Country": "Canada",
+      "Value": 175,
+      "Region": "Americas"
+    },
+    {
+      "Country": "Japan",
+      "Value": 190,
+      "Region": "Asia-Pacific"
+    },
+    {
+      "Country": "Australia",
+      "Value": 165,
+      "Region": "Asia-Pacific"
+    }
+  ]
+}

--- a/packages/map/src/components/BubbleList.tsx
+++ b/packages/map/src/components/BubbleList.tsx
@@ -70,6 +70,10 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
     dispatch({ type: 'SET_RUNTIME_DATA', payload: _tempRuntimeData })
   }
 
+  const handleBubblePointerDown = (e: React.PointerEvent<SVGCircleElement> | React.MouseEvent<SVGCircleElement>) => {
+    e.preventDefault()
+  }
+
   const sortedRuntimeData: DataRow = Object.values(runtimeData).sort((a, b) =>
     a[primaryColumnName] < b[primaryColumnName] ? 1 : -1
   )
@@ -113,7 +117,9 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
               strokeWidth={1.25}
               fillOpacity={0.4}
               onMouseEnter={() => {}}
+              onMouseDown={handleBubblePointerDown}
               onPointerDown={e => {
+                handleBubblePointerDown(e)
                 pointerX = e.clientX
                 pointerY = e.clientY
               }}
@@ -149,7 +155,9 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
                 stroke={'white'}
                 strokeWidth={0.5}
                 onMouseEnter={() => {}}
+                onMouseDown={handleBubblePointerDown}
                 onPointerDown={e => {
+                  handleBubblePointerDown(e)
                   pointerX = e.clientX
                   pointerY = e.clientY
                 }}
@@ -227,7 +235,9 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
               strokeWidth={1.25}
               fillOpacity={0.4}
               onMouseEnter={() => {}}
+              onMouseDown={handleBubblePointerDown}
               onPointerDown={e => {
+                handleBubblePointerDown(e)
                 pointerX = e.clientX
                 pointerY = e.clientY
               }}
@@ -263,7 +273,9 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
                 strokeWidth={0.5}
                 fillOpacity={0.4}
                 onMouseEnter={() => {}}
+                onMouseDown={handleBubblePointerDown}
                 onPointerDown={e => {
+                  handleBubblePointerDown(e)
                   pointerX = e.clientX
                   pointerY = e.clientY
                 }}

--- a/packages/map/src/components/BubbleList.tsx
+++ b/packages/map/src/components/BubbleList.tsx
@@ -64,6 +64,7 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
 
     // Zoom the map in...
     dispatch({ type: 'SET_POSITION', payload: { coordinates: reversedCoordinates, zoom: 3 } })
+    dispatch({ type: 'SET_FILTERED_COUNTRY_CODE', payload: _filteredCountryCode })
 
     // ...and show the data for the clicked country
     dispatch({ type: 'SET_RUNTIME_DATA', payload: _tempRuntimeData })

--- a/packages/map/src/components/WorldMap/WorldMap.tsx
+++ b/packages/map/src/components/WorldMap/WorldMap.tsx
@@ -118,7 +118,6 @@ const WorldMap = () => {
   const filteredWorld = getFilteredWorld()
 
   const handleFiltersReset = () => {
-    const newRuntimeData = generateRuntimeData(config)
     publishAnalyticsEvent({
       vizType: config.type,
       vizSubType: getVizSubType(config),
@@ -127,6 +126,7 @@ const WorldMap = () => {
       eventLabel: interactionLabel,
       vizTitle: getVizTitle(config)
     })
+    const newRuntimeData = generateRuntimeData(config)
     dispatch({ type: 'SET_FILTERED_COUNTRY_CODE', payload: '' })
     dispatch({ type: 'SET_RUNTIME_DATA', payload: newRuntimeData })
   }
@@ -140,6 +140,12 @@ const WorldMap = () => {
       eventLabel: interactionLabel,
       vizTitle: getVizTitle(config)
     })
+
+    if (config.general.geoType === 'world' && config.general.type === 'bubble') {
+      const newRuntimeData = generateRuntimeData(config)
+      dispatch({ type: 'SET_FILTERED_COUNTRY_CODE', payload: '' })
+      dispatch({ type: 'SET_RUNTIME_DATA', payload: newRuntimeData })
+    }
 
     // If countries are selected, center on them; otherwise, use default world position
     const countriesPicked = getCountriesPicked(config)

--- a/packages/map/src/components/WorldMap/WorldMap.tsx
+++ b/packages/map/src/components/WorldMap/WorldMap.tsx
@@ -1,4 +1,4 @@
-import { memo, useContext, useState, useEffect } from 'react'
+import { memo, useContext, useState, useEffect, useRef } from 'react'
 import { geoMercator } from 'd3-geo'
 import { Mercator } from '@visx/geo'
 import { feature } from 'topojson-client'
@@ -27,6 +27,7 @@ import useGeoClickHandler from '../../hooks/useGeoClickHandler'
 import useApplyTooltipsToGeo from '../../hooks/useApplyTooltipsToGeo'
 import useCountryZoom from '../../hooks/useCountryZoom'
 import generateRuntimeData from '../../helpers/generateRuntimeData'
+import { generateRuntimeFilters } from '../../helpers/generateRuntimeFilters'
 import { applyLegendToRow } from '../../helpers/applyLegendToRow'
 import { normalizeTopoJsonProperties } from '../../helpers/normalizeTopoJsonProperties'
 
@@ -42,6 +43,8 @@ const WorldMap = () => {
   // prettier-ignore
   const {
     runtimeData,
+    runtimeFilters,
+    filteredCountryCode,
     position: mapPosition,
     config,
     tooltipId,
@@ -65,6 +68,9 @@ const WorldMap = () => {
   const { centerOnCountries } = useCountryZoom(world)
 
   const dispatch = useContext(MapDispatchContext)
+  const previousWorldBubbleRuntimeData = useRef(runtimeData)
+  const isWorldBubbleMap = config.general.geoType === 'world' && config.general.type === 'bubble'
+  const isDrilledBubbleView = isWorldBubbleMap && Boolean(filteredCountryCode)
 
   useEffect(() => {
     const fetchData = async () => {
@@ -100,6 +106,11 @@ const WorldMap = () => {
     fetchData()
   }, [])
 
+  useEffect(() => {
+    if (!isWorldBubbleMap || isDrilledBubbleView || runtimeData?.init) return
+    previousWorldBubbleRuntimeData.current = runtimeData
+  }, [isWorldBubbleMap, isDrilledBubbleView, runtimeData])
+
   if (!world) {
     return <></>
   }
@@ -117,6 +128,18 @@ const WorldMap = () => {
 
   const filteredWorld = getFilteredWorld()
 
+  const rebuildRuntimeDataFromActiveFilters = () => {
+    const activeFilters = runtimeFilters?.length ? runtimeFilters : generateRuntimeFilters(config, undefined, [])
+
+    return generateRuntimeData(
+      config,
+      activeFilters,
+      runtimeFilters?.fromHash ?? runtimeData?.fromHash,
+      config.legend?.type === 'category',
+      config.table?.showNonGeoData
+    )
+  }
+
   const handleFiltersReset = () => {
     publishAnalyticsEvent({
       vizType: config.type,
@@ -126,7 +149,7 @@ const WorldMap = () => {
       eventLabel: interactionLabel,
       vizTitle: getVizTitle(config)
     })
-    const newRuntimeData = generateRuntimeData(config)
+    const newRuntimeData = rebuildRuntimeDataFromActiveFilters()
     dispatch({ type: 'SET_FILTERED_COUNTRY_CODE', payload: '' })
     dispatch({ type: 'SET_RUNTIME_DATA', payload: newRuntimeData })
   }
@@ -141,8 +164,10 @@ const WorldMap = () => {
       vizTitle: getVizTitle(config)
     })
 
-    if (config.general.geoType === 'world' && config.general.type === 'bubble') {
-      const newRuntimeData = generateRuntimeData(config)
+    if (isWorldBubbleMap) {
+      const newRuntimeData = isDrilledBubbleView
+        ? previousWorldBubbleRuntimeData.current
+        : rebuildRuntimeDataFromActiveFilters()
       dispatch({ type: 'SET_FILTERED_COUNTRY_CODE', payload: '' })
       dispatch({ type: 'SET_RUNTIME_DATA', payload: newRuntimeData })
     }

--- a/packages/map/src/scss/map.scss
+++ b/packages/map/src/scss/map.scss
@@ -51,8 +51,10 @@ $medium: 768px;
 .svg-container,
 .county,
 .state-path,
+.bubble,
 .geo-point,
 .marker,
+.bubble *,
 .geo-point * {
   &:focus,
   &:focus-visible {


### PR DESCRIPTION
This pull request adds a new smoke test to verify the "Reset Zoom" functionality for world bubble maps and refines the logic for resetting world bubble visualizations. The changes include a new test configuration, updates to the test suite, and improved handling of state reset in the `WorldMap` component.

**Testing Enhancements:**

* Added a new mock configuration file, `world-bubble-reset.json`, to provide test data for world bubble map reset scenarios.
* Introduced a new smoke test story, `World_Bubble_Reset_Restores_All_Bubbles`, in `CdcMap.smoke.stories.tsx` to ensure that clicking a bubble narrows the set and using "Reset Zoom" restores all bubbles.
* Imported the new mock and utility functions to support the added test.

**WorldMap Component Logic:**

* Updated the `handleFiltersReset` function to ensure runtime data is regenerated and the filtered country code is reset, improving the reliability of the reset behavior.
* Enhanced the click handler for world bubble maps to reset both the filtered country code and runtime data when appropriate, ensuring all bubbles are restored after a reset.