### PR TITLE
Fix [DEV-13103] Fix legend click

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -27,7 +27,6 @@ import parse from 'html-react-parser'
 import cloneDeep from 'lodash/cloneDeep'
 import defaultsDeep from 'lodash/defaultsDeep'
 import lodashDefaults from 'lodash/defaults'
-import findKey from 'lodash/findKey'
 import forEach from 'lodash/forEach'
 import get from 'lodash/get'
 import isEmpty from 'lodash/isEmpty'
@@ -94,6 +93,7 @@ import { getComboChartConfig } from './helpers/getComboChartConfig'
 import { getExcludedData } from './helpers/getExcludedData'
 import { getColorScale } from './helpers/getColorScale'
 import { getTransformedData } from './helpers/getTransformedData'
+import { getLegendHighlightKey, shouldResetSeriesHighlight } from './helpers/seriesHighlight'
 import { getPiePercent } from './helpers/getPiePercent'
 import { prepareSmallMultiplesDataTable } from './helpers/smallMultiplesHelpers'
 import { ensureSpecialChartAxisTypes } from './helpers/ensureSpecialChartAxisTypes'
@@ -874,15 +874,13 @@ const CdcChart: React.FC<CdcChartProps> = ({
 
   // Called on legend click, highlights/unhighlights the data series with the given label
   const highlight = (label: Label): void => {
+    const newHighlight = getLegendHighlightKey(config.runtime.seriesLabels, label.datum)
+
     if (
-      seriesHighlight.length + 1 === config.runtime.seriesKeys.length &&
-      config.visualizationType !== 'Forecasting' &&
-      !seriesHighlight.includes(label.datum)
+      shouldResetSeriesHighlight(seriesHighlight, config.runtime.seriesKeys, newHighlight, config.visualizationType)
     ) {
       return handleShowAll()
     }
-
-    const newHighlight = findKey(config.runtime.seriesLabels, v => v === label.datum) || label.datum
 
     const newSeriesHighlight = xor(seriesHighlight, [newHighlight])
     dispatch({ type: 'SET_SERIES_HIGHLIGHT', payload: newSeriesHighlight })

--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -873,8 +873,8 @@ const CdcChart: React.FC<CdcChartProps> = ({
   }, [config, stateData, getProcessedAxisLabels, dispatch, editorContext, isEditor, isDashboard])
 
   // Called on legend click, highlights/unhighlights the data series with the given label
-  const highlight = (label: Label): void => {
-    const newHighlight = getLegendHighlightKey(config.runtime.seriesLabels, label.datum)
+  const highlight = (label: Label | string): void => {
+    const newHighlight = getLegendHighlightKey(config.runtime.seriesLabels, label)
 
     if (
       shouldResetSeriesHighlight(seriesHighlight, config.runtime.seriesKeys, newHighlight, config.visualizationType)

--- a/packages/chart/src/helpers/seriesHighlight.ts
+++ b/packages/chart/src/helpers/seriesHighlight.ts
@@ -1,0 +1,16 @@
+export const getLegendHighlightKey = (seriesLabels: Record<string, string> = {}, labelDatum: string): string => {
+  return Object.entries(seriesLabels).find(([, label]) => label === labelDatum)?.[0] || labelDatum
+}
+
+export const shouldResetSeriesHighlight = (
+  seriesHighlight: string[],
+  seriesKeys: string[] = [],
+  highlightKey: string,
+  visualizationType?: string
+): boolean => {
+  return (
+    seriesHighlight.length + 1 === seriesKeys.length &&
+    visualizationType !== 'Forecasting' &&
+    !seriesHighlight.includes(highlightKey)
+  )
+}

--- a/packages/chart/src/helpers/seriesHighlight.ts
+++ b/packages/chart/src/helpers/seriesHighlight.ts
@@ -1,4 +1,13 @@
-export const getLegendHighlightKey = (seriesLabels: Record<string, string> = {}, labelDatum: string): string => {
+import type { Label } from '../types/Label'
+
+type LegendHighlightSource = Pick<Label, 'datum'> | string
+
+export const getLegendHighlightKey = (
+  seriesLabels: Record<string, string> = {},
+  legendSource: LegendHighlightSource
+): string => {
+  const labelDatum = typeof legendSource === 'string' ? legendSource : legendSource.datum
+
   return Object.entries(seriesLabels).find(([, label]) => label === labelDatum)?.[0] || labelDatum
 }
 
@@ -11,6 +20,7 @@ export const shouldResetSeriesHighlight = (
   return (
     seriesHighlight.length + 1 === seriesKeys.length &&
     visualizationType !== 'Forecasting' &&
+    seriesKeys.includes(highlightKey) &&
     !seriesHighlight.includes(highlightKey)
   )
 }

--- a/packages/chart/src/helpers/tests/seriesHighlight.test.ts
+++ b/packages/chart/src/helpers/tests/seriesHighlight.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { getLegendHighlightKey, shouldResetSeriesHighlight } from '../seriesHighlight'
+
+describe('seriesHighlight helpers', () => {
+  const seriesLabels = {
+    nonfatal_rate_alldrugs: 'All drugs',
+    opioid_nonfatal_rate: 'All opioids',
+    stimulant_nonfatal_rate: 'All stimulants'
+  }
+
+  it('normalizes a legend label to the stored series highlight key', () => {
+    expect(getLegendHighlightKey(seriesLabels, 'All opioids')).toBe('opioid_nonfatal_rate')
+    expect(getLegendHighlightKey(seriesLabels, 'unmapped_series')).toBe('unmapped_series')
+  })
+
+  it('does not reset when removing one selected item from a three-series legend', () => {
+    expect(
+      shouldResetSeriesHighlight(
+        ['nonfatal_rate_alldrugs', 'opioid_nonfatal_rate'],
+        Object.keys(seriesLabels),
+        'opioid_nonfatal_rate',
+        'Line'
+      )
+    ).toBe(false)
+  })
+
+  it('resets when selecting the only remaining unselected item', () => {
+    expect(
+      shouldResetSeriesHighlight(
+        ['nonfatal_rate_alldrugs', 'opioid_nonfatal_rate'],
+        Object.keys(seriesLabels),
+        'stimulant_nonfatal_rate',
+        'Line'
+      )
+    ).toBe(true)
+  })
+})

--- a/packages/chart/src/helpers/tests/seriesHighlight.test.ts
+++ b/packages/chart/src/helpers/tests/seriesHighlight.test.ts
@@ -13,6 +13,19 @@ describe('seriesHighlight helpers', () => {
     expect(getLegendHighlightKey(seriesLabels, 'unmapped_series')).toBe('unmapped_series')
   })
 
+  it('accepts legend label objects and legacy raw string callers', () => {
+    expect(
+      getLegendHighlightKey(seriesLabels, {
+        datum: 'All stimulants',
+        index: 2,
+        text: 'All stimulants',
+        value: '#075290'
+      })
+    ).toBe('stimulant_nonfatal_rate')
+
+    expect(getLegendHighlightKey(seriesLabels, 'Highlighted bar')).toBe('Highlighted bar')
+  })
+
   it('does not reset when removing one selected item from a three-series legend', () => {
     expect(
       shouldResetSeriesHighlight(
@@ -33,5 +46,16 @@ describe('seriesHighlight helpers', () => {
         'Line'
       )
     ).toBe(true)
+  })
+
+  it('does not reset when the clicked item is not a known series key', () => {
+    expect(
+      shouldResetSeriesHighlight(
+        ['nonfatal_rate_alldrugs', 'opioid_nonfatal_rate'],
+        Object.keys(seriesLabels),
+        'suppressed-data-note',
+        'Line'
+      )
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Fixes a bug when selecting the next-to-last item in a legend.

## Testing Steps

* Load [this dashboard config](https://github.com/user-attachments/files/27651972/dashboard-charts.json)
* Select any three series to display in the first chart by clicking on the legend
* Click on one of the selected legend items again

On `dev`, all lines will be incorrectly displayed on the chart. On this branch, it will show only two lines.
