### PR TITLE
Never render empty filter rows

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -78,6 +78,7 @@ import { getAxisLabelFontSize } from './helpers/axisLabelFontSize'
 import { missingRequiredSections } from '@cdc/core/helpers/missingRequiredSections'
 import { filterVizData } from '@cdc/core/helpers/filterVizData'
 import { addValuesToFilters } from '@cdc/core/helpers/addValuesToFilters'
+import { hasVisibleVizFilters } from '@cdc/core/helpers/filterVisibility'
 import { publish, subscribe, unsubscribe } from '@cdc/core/helpers/events'
 import useDataVizClasses from '@cdc/core/helpers/useDataVizClasses'
 import numberFromString from '@cdc/core/helpers/numberFromString'
@@ -1319,7 +1320,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
             bodyClassName={bodyClasses.join(' ')}
             bodyWrapClassName={isTp5Treatment ? 'cdc-callout d-flex flex-column tp5-chart-callout' : ''}
             filters={
-              config.filters?.length > 0 && !externalFilters && config.visualizationType !== 'Spark Line' ? (
+              hasVisibleVizFilters(config.filters) && !externalFilters && config.visualizationType !== 'Spark Line' ? (
                 <Filters
                   config={config}
                   setFilters={setFilters}

--- a/packages/core/components/Filters/Filters.test.tsx
+++ b/packages/core/components/Filters/Filters.test.tsx
@@ -78,6 +78,13 @@ describe('Filters filter notes', () => {
     expect(wrapper).not.toHaveClass('filters-section__wrapper--multiple')
   })
 
+  it('renders no filter section when every filter is hidden', () => {
+    const { container } = renderFilters([{ ...createFilter('dropdown'), showDropdown: false }])
+
+    expect(container.querySelector('.filters-section')).not.toBeInTheDocument()
+    expect(container.querySelector('.filters-section__intro-text')).not.toBeInTheDocument()
+  })
+
   it('marks the wrapper as multiple-filter layout when more than one filter is visible', () => {
     const statusFilter = {
       ...createFilter('dropdown', 'Choose a status.'),

--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -25,6 +25,7 @@ import Dropdown from './components/Dropdown'
 import FilterNote from './components/FilterNote'
 import { publishAnalyticsEvent } from '../../helpers/metrics/helpers'
 import { getVizSubType, getVizTitle } from '@cdc/core/helpers/metrics/utils'
+import { hasVisibleVizFilters, isVisibleVizFilter } from '../../helpers/filterVisibility'
 
 export const VIZ_FILTER_STYLE = {
   combobox: 'combobox',
@@ -207,8 +208,7 @@ const Filters: React.FC<FilterProps> = ({
 
   if (visualizationConfig?.filters?.length === 0) return <></>
 
-  const hasVisibleFilters = filters?.some(filter => filter.showDropdown !== false)
-  if (!hasVisibleFilters) return <></>
+  if (!hasVisibleVizFilters(filters)) return <></>
 
   const getClasses = () => {
     const { legend } = visualizationConfig || {}
@@ -221,12 +221,7 @@ const Filters: React.FC<FilterProps> = ({
     return (singleFilter.queuedActive || [singleFilter.active, singleFilter.subGrouping?.active]) as [string, string]
   }
 
-  // Don't render filter section if all filters are hidden
-  const visibleFilters = vizFiltersWithValues.filter(filter => filter.showDropdown !== false)
-  const allFiltersHidden = visibleFilters.length === 0
-  if (allFiltersHidden) {
-    return null
-  }
+  const visibleFilters = vizFiltersWithValues.filter(isVisibleVizFilter)
   const wrapperClasses = [
     'd-flex',
     'flex-wrap',

--- a/packages/core/components/Layout/components/VisualizationContent.test.tsx
+++ b/packages/core/components/Layout/components/VisualizationContent.test.tsx
@@ -60,6 +60,12 @@ describe('VisualizationContent', () => {
     expect(bodyWrap?.children[1]).toBe(content)
   })
 
+  it('does not render a filters section when the filters slot is omitted', () => {
+    const { container } = render(<VisualizationContent>Wrapped content</VisualizationContent>)
+
+    expect(container.querySelector('.cove-visualization__filters-section')).not.toBeInTheDocument()
+  })
+
   it('adds the shared no-subtext body state only when outer subtext is absent', () => {
     const { container: withoutSubtext } = render(
       <VisualizationContent header={<div>Header</div>} message={<div>Message</div>}>

--- a/packages/core/helpers/filterVisibility.ts
+++ b/packages/core/helpers/filterVisibility.ts
@@ -1,0 +1,9 @@
+import { VizFilter } from '../types/VizFilter'
+
+type FilterVisibilityInput = Partial<Pick<VizFilter, 'showDropdown'>> | undefined | null
+
+export const isVisibleVizFilter = (filter: FilterVisibilityInput): boolean =>
+  Boolean(filter && filter.showDropdown !== false)
+
+export const hasVisibleVizFilters = (filters?: FilterVisibilityInput[] | null): boolean =>
+  Boolean(filters?.some(isVisibleVizFilter))

--- a/packages/core/helpers/tests/filterVisibility.test.ts
+++ b/packages/core/helpers/tests/filterVisibility.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { hasVisibleVizFilters, isVisibleVizFilter } from '../filterVisibility'
+
+describe('filterVisibility', () => {
+  it('treats missing, empty, and all-hidden visualization filters as not visible', () => {
+    expect(hasVisibleVizFilters()).toBe(false)
+    expect(hasVisibleVizFilters([])).toBe(false)
+    expect(hasVisibleVizFilters([{ showDropdown: false }])).toBe(false)
+    expect(isVisibleVizFilter(undefined)).toBe(false)
+  })
+
+  it('treats filters as visible unless showDropdown is explicitly false', () => {
+    expect(hasVisibleVizFilters([{ showDropdown: false }, {}])).toBe(true)
+    expect(hasVisibleVizFilters([{ showDropdown: true }])).toBe(true)
+  })
+})

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -16,6 +16,7 @@ import Tabs from '@cdc/core/components/Filters/components/Tabs'
 import FilterNote from '@cdc/core/components/Filters/components/FilterNote'
 import parse from 'html-react-parser'
 import './dashboardfilter.styles.css'
+import { isVisibleDashboardFilter } from '../../helpers/filterVisibility'
 
 type DashboardFilterProps = {
   show: number[]
@@ -63,17 +64,7 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
     ])
   }
 
-  const shouldRenderFilter = (filter: SharedFilter) => {
-    const urlFilterType = filter.type === 'urlfilter'
-    return (
-      urlFilterType ||
-      filter.showDropdown ||
-      filter.filterStyle === FILTER_STYLE.nestedDropdown ||
-      filter.filterStyle === FILTER_STYLE.tabSimple
-    )
-  }
-
-  const visibleFilterIndexes = show.filter(filterIndex => shouldRenderFilter(sharedFilters[filterIndex]))
+  const visibleFilterIndexes = show.filter(filterIndex => isVisibleDashboardFilter(sharedFilters[filterIndex]))
   const formClasses = [
     'dashboard-filters__form',
     'filters-section__wrapper',
@@ -86,10 +77,11 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
       <form className={formClasses.join(' ')}>
         {show.map(filterIndex => {
           const filter = sharedFilters[filterIndex]
-          const label = stripDuplicateLabelIncrement(filter.key || '')
 
-          if (!shouldRenderFilter(filter))
-            return <React.Fragment key={`${filter.key}-filtersection-${filterIndex}-option`} />
+          if (!isVisibleDashboardFilter(filter))
+            return <React.Fragment key={`${filter?.key || 'missing'}-filtersection-${filterIndex}-option`} />
+
+          const label = stripDuplicateLabelIncrement(filter.key || '')
           const values: JSX.Element[] = []
 
           const _key = filter.apiFilter?.apiEndpoint
@@ -244,11 +236,11 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
               variant='primary'
               className='mb-1 me-2'
               onClick={applyFilters}
-              disabled={show.some(filterIndex => {
+              disabled={visibleFilterIndexes.some(filterIndex => {
                 const emptyFilterValues = [undefined, '', '- Select -']
                 return (
-                  emptyFilterValues.includes(sharedFilters[filterIndex].queuedActive) &&
-                  emptyFilterValues.includes(sharedFilters[filterIndex].active)
+                  emptyFilterValues.includes(sharedFilters[filterIndex]?.queuedActive) &&
+                  emptyFilterValues.includes(sharedFilters[filterIndex]?.active)
                 )
               })}
             >

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.test.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.test.tsx
@@ -8,8 +8,8 @@ vi.mock('@cdc/core/components/ui/Icon', () => ({
   default: props => <span data-testid='mock-icon' {...props} />
 }))
 
-const sharedFilters = [
-  {
+const createSharedFilter = (overrides = {}) =>
+  ({
     key: 'Year',
     type: 'datafilter',
     filterStyle: 'dropdown',
@@ -17,18 +17,28 @@ const sharedFilters = [
     values: ['2023', '2024'],
     active: '2023',
     columnName: 'year',
-    parents: []
-  }
-] as any
+    parents: [],
+    ...overrides
+  } as any)
 
-const renderWrapper = (grayBackground?: boolean) => {
+const renderWrapper = ({
+  grayBackground,
+  sharedFilters = [createSharedFilter()],
+  sharedFilterIndexes = [0],
+  isEditor = false
+}: {
+  grayBackground?: boolean
+  sharedFilters?: any[]
+  sharedFilterIndexes?: any[]
+  isEditor?: boolean
+} = {}) => {
   const visualizationConfig = {
     uid: 'dashboardFilters1',
     type: 'dashboardFilters',
     visualizationType: 'dashboardFilters',
     filterBehavior: 'Filter Change',
     filterIntro: 'Choose a <strong>year</strong> to update the dashboard.',
-    sharedFilterIndexes: [0],
+    sharedFilterIndexes,
     visual: grayBackground === undefined ? undefined : { grayBackground }
   } as any
 
@@ -62,6 +72,7 @@ const renderWrapper = (grayBackground?: boolean) => {
           visualizationConfig={visualizationConfig}
           setConfig={vi.fn()}
           currentViewport={'lg' as any}
+          isEditor={isEditor}
           interactionLabel='dashboard-test'
         />
       </DashboardDispatchContext.Provider>
@@ -71,13 +82,13 @@ const renderWrapper = (grayBackground?: boolean) => {
 
 describe('DashboardFiltersWrapper visual styles', () => {
   it('wraps filters in the dashboard filters callout when grey background is enabled', () => {
-    const { container } = renderWrapper(true)
+    const { container } = renderWrapper({ grayBackground: true })
 
     expect(container.querySelector('.cdc-callout.cdc-callout--dashboard-filters')).toBeInTheDocument()
   })
 
   it.each([false, undefined])('keeps the existing unwrapped layout when grayBackground is %s', value => {
-    const { container } = renderWrapper(value)
+    const { container } = renderWrapper({ grayBackground: value })
 
     expect(container.querySelector('.cdc-callout.cdc-callout--dashboard-filters')).not.toBeInTheDocument()
   })
@@ -89,5 +100,43 @@ describe('DashboardFiltersWrapper visual styles', () => {
     expect(intro).toBeInTheDocument()
     expect(intro).toHaveTextContent('Choose a year to update the dashboard.')
     expect(intro?.querySelector('strong')).toHaveTextContent('year')
+  })
+
+  it('renders no dashboard filters container when every referenced filter is hidden', () => {
+    const { container } = renderWrapper({ sharedFilters: [createSharedFilter({ showDropdown: false })] })
+
+    expect(container.querySelector('.cove-dashboard-filters-container')).not.toBeInTheDocument()
+  })
+
+  it('renders no dashboard filters container when sharedFilterIndexes is empty', () => {
+    const { container } = renderWrapper({ sharedFilterIndexes: [] })
+
+    expect(container.querySelector('.cove-dashboard-filters-container')).not.toBeInTheDocument()
+  })
+
+  it('renders no dashboard filters container when sharedFilterIndexes only references missing filters', () => {
+    const { container } = renderWrapper({ sharedFilterIndexes: [4] })
+
+    expect(container.querySelector('.cove-dashboard-filters-container')).not.toBeInTheDocument()
+  })
+
+  it('keeps the editor sidebar available without rendering an empty runtime filters container', () => {
+    const { container, getByText } = renderWrapper({
+      sharedFilters: [createSharedFilter({ showDropdown: false })],
+      isEditor: true
+    })
+
+    expect(getByText('Configure Dashboard Filters')).toBeInTheDocument()
+    expect(container.querySelector('.cove-dashboard-filters-container')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['urlfilter', createSharedFilter({ type: 'urlfilter', showDropdown: false })],
+    ['nestedDropdown', createSharedFilter({ filterStyle: 'nested-dropdown', showDropdown: false })],
+    ['tabSimple', createSharedFilter({ filterStyle: 'tab-simple', showDropdown: false })]
+  ])('keeps %s dashboard filters visible under dashboard-specific rules', (_label, filter) => {
+    const { container } = renderWrapper({ sharedFilters: [filter] })
+
+    expect(container.querySelector('.cove-dashboard-filters-container')).toBeInTheDocument()
   })
 })

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFiltersWrapper.tsx
@@ -17,6 +17,7 @@ import { applyQueuedActive } from '@cdc/core/components/Filters/helpers/applyQue
 import { updateChildFilters } from '../../helpers/updateChildFilters'
 import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
+import { hasVisibleDashboardFiltersForIndexes } from '../../helpers/filterVisibility'
 
 type SubOptions = { subOptions?: Record<'value' | 'text', string>[] }
 
@@ -293,12 +294,10 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
     })
   }
 
-  // if all of the filters are hidden filters don't display the VisualizationWrapper
-  const filters = visualizationConfig?.sharedFilterIndexes
-    ?.map(Number)
-    ?.map(filterIndex => dashboardConfig.dashboard.sharedFilters[filterIndex])
-
-  const displayNone = filters?.length ? filters.every(filter => filter.showDropdown === false) : false
+  const hasVisibleFilterControls = hasVisibleDashboardFiltersForIndexes(
+    dashboardConfig.dashboard.sharedFilters,
+    visualizationConfig?.sharedFilterIndexes
+  )
   const filterControls = (
     <Filters
       show={visualizationConfig?.sharedFilterIndexes?.map(Number)}
@@ -316,7 +315,7 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
       }
     />
   )
-  if (displayNone && !isEditor) return <></>
+  if (!hasVisibleFilterControls && !isEditor) return <></>
   return (
     <VisualizationWrapper config={visualizationConfig} isEditor={isEditor} currentViewport={currentViewport}>
       {isEditor && (
@@ -330,7 +329,7 @@ const DashboardFiltersWrapper: React.FC<DashboardFiltersProps> = ({
         </Sidebar>
       )}
 
-      {!displayNone && (
+      {hasVisibleFilterControls && (
         <Responsive isEditor={isEditor}>
           <div
             className={`${

--- a/packages/dashboard/src/components/VisualizationRow.test.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.test.tsx
@@ -203,4 +203,129 @@ describe('VisualizationRow', () => {
 
     expect(screen.getByText('Legacy filtered text')).toBeInTheDocument()
   })
+
+  it('does not render a row that only contains dashboard filters with no visible referenced filters', () => {
+    const filterRow = {
+      columns: [{ width: 12, widget: 'dashboard-filters-hidden' }],
+      expandCollapseAllButtons: false
+    } as any
+
+    const contextValue = {
+      ...initialState,
+      config: {
+        type: 'dashboard',
+        dashboard: {
+          sharedFilters: [
+            {
+              key: 'Hidden year',
+              type: 'datafilter',
+              filterStyle: 'dropdown',
+              showDropdown: false,
+              values: ['2024'],
+              active: '2024',
+              columnName: 'year',
+              parents: []
+            }
+          ]
+        },
+        datasets: {},
+        rows: [filterRow],
+        visualizations: {
+          'dashboard-filters-hidden': {
+            uid: 'dashboard-filters-hidden',
+            type: 'dashboardFilters',
+            visualizationType: 'dashboardFilters',
+            filterBehavior: 'Filter Change',
+            sharedFilterIndexes: [0]
+          }
+        }
+      } as any,
+      filteredData: {},
+      data: {},
+      outerContainerRef: vi.fn(),
+      setParentConfig: vi.fn(),
+      isDebug: false,
+      isEditor: false,
+      reloadURLData: vi.fn(),
+      loadAPIFilters: vi.fn(),
+      setAPIFilterDropdowns: vi.fn(),
+      setAPILoading: vi.fn()
+    }
+
+    const { container } = render(
+      <DashboardContext.Provider value={contextValue}>
+        <VisualizationRow
+          allExpanded
+          groupName=''
+          row={filterRow}
+          rowIndex={0}
+          inNoDataState={false}
+          setSharedFilter={vi.fn()}
+          updateChildConfig={vi.fn()}
+          apiFilterDropdowns={{}}
+          currentViewport={{} as any}
+          isLastRow={true}
+          interactionLabel='dashboard-test'
+        />
+      </DashboardContext.Provider>
+    )
+
+    expect(container.querySelector('[data-row-index]')).not.toBeInTheDocument()
+  })
+
+  it('does not render a row that only contains a dashboard filter widget with empty sharedFilterIndexes', () => {
+    const filterRow = {
+      columns: [{ width: 12, widget: 'dashboard-filters-empty' }],
+      expandCollapseAllButtons: false
+    } as any
+
+    const contextValue = {
+      ...initialState,
+      config: {
+        type: 'dashboard',
+        dashboard: { sharedFilters: [] },
+        datasets: {},
+        rows: [filterRow],
+        visualizations: {
+          'dashboard-filters-empty': {
+            uid: 'dashboard-filters-empty',
+            type: 'dashboardFilters',
+            visualizationType: 'dashboardFilters',
+            filterBehavior: 'Filter Change',
+            sharedFilterIndexes: []
+          }
+        }
+      } as any,
+      filteredData: {},
+      data: {},
+      outerContainerRef: vi.fn(),
+      setParentConfig: vi.fn(),
+      isDebug: false,
+      isEditor: false,
+      reloadURLData: vi.fn(),
+      loadAPIFilters: vi.fn(),
+      setAPIFilterDropdowns: vi.fn(),
+      setAPILoading: vi.fn()
+    }
+
+    const { container } = render(
+      <DashboardContext.Provider value={contextValue}>
+        <VisualizationRow
+          allExpanded
+          groupName=''
+          row={filterRow}
+          rowIndex={0}
+          inNoDataState={false}
+          setSharedFilter={vi.fn()}
+          updateChildConfig={vi.fn()}
+          apiFilterDropdowns={{}}
+          currentViewport={{} as any}
+          isLastRow={true}
+          interactionLabel='dashboard-test'
+        />
+      </DashboardContext.Provider>
+    )
+
+    expect(container.querySelector('[data-row-index]')).not.toBeInTheDocument()
+  })
 })

--- a/packages/dashboard/src/components/VisualizationRow.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.tsx
@@ -27,6 +27,7 @@ import ExpandCollapseButtons from './ExpandCollapseButtons'
 import { ChartConfig } from '@cdc/chart/src/types/ChartConfig'
 import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
+import { hasVisibleDashboardFiltersForIndexes } from '../helpers/filterVisibility'
 
 type VisualizationWrapperProps = {
   allExpanded: boolean
@@ -251,10 +252,20 @@ const VisualizationRow: React.FC<VizRowProps> = ({
 
     return evaluateDashboardCondition(row.dashboardCondition, dashboardFilteredData[row.dashboardCondition.id])
   }, [dashboardFilteredData, row.dashboardCondition, shouldIgnoreDashboardConditions])
-  const hasVisibleWidgetColumn = row.columns.some(
-    (_column, columnIndex) =>
-      !!row.columns[columnIndex].width && !!columnDashboardConditionEvaluations[columnIndex]?.widget
-  )
+  const hasVisibleWidgetColumn = row.columns.some((_column, columnIndex) => {
+    if (!row.columns[columnIndex].width) return false
+
+    const widgetKey = columnDashboardConditionEvaluations[columnIndex]?.widget
+    if (!widgetKey) return false
+
+    const visualization = config.visualizations[widgetKey]
+    if (visualization?.type !== 'dashboardFilters') return true
+
+    return hasVisibleDashboardFiltersForIndexes(
+      config.dashboard.sharedFilters,
+      (visualization as DashboardFilters).sharedFilterIndexes
+    )
+  })
 
   if (!rowDashboardCondition.matches || !hasVisibleWidgetColumn) {
     return null
@@ -403,9 +414,7 @@ const VisualizationRow: React.FC<VizRowProps> = ({
 
           const hiddenDashboardFilters =
             type === 'dashboardFilters' &&
-            sharedFilterIndexes &&
-            sharedFilterIndexes.filter(idx => config.dashboard.sharedFilters?.[idx]?.showDropdown === false).length ===
-              sharedFilterIndexes.length
+            !hasVisibleDashboardFiltersForIndexes(config.dashboard.sharedFilters, sharedFilterIndexes)
 
           const vizWrapperClass = `col-12 col-md-${col.width}${!shouldShow ? ' d-none' : ''}${
             hideVisualization ? ' hide-parent-visualization' : ''

--- a/packages/dashboard/src/helpers/filterVisibility.ts
+++ b/packages/dashboard/src/helpers/filterVisibility.ts
@@ -1,0 +1,20 @@
+import { FILTER_STYLE } from '../types/FilterStyles'
+import { SharedFilter } from '../types/SharedFilter'
+
+export const isVisibleDashboardFilter = (filter?: SharedFilter | null): boolean =>
+  Boolean(
+    filter &&
+      (filter.type === 'urlfilter' ||
+        filter.showDropdown ||
+        filter.filterStyle === FILTER_STYLE.nestedDropdown ||
+        filter.filterStyle === FILTER_STYLE.tabSimple)
+  )
+
+export const hasVisibleDashboardFiltersForIndexes = (
+  sharedFilters?: SharedFilter[] | null,
+  sharedFilterIndexes?: (number | string)[] | null
+): boolean =>
+  Boolean(
+    sharedFilterIndexes?.length &&
+      sharedFilterIndexes.map(Number).some(filterIndex => isVisibleDashboardFilter(sharedFilters?.[filterIndex]))
+  )

--- a/packages/map/src/CdcMapComponent.tsx
+++ b/packages/map/src/CdcMapComponent.tsx
@@ -35,6 +35,7 @@ import {
 import { generateRuntimeFilters } from './helpers/generateRuntimeFilters'
 import { type MapReducerType, MapState } from './store/map.reducer'
 import { addValuesToFilters } from '@cdc/core/helpers/addValuesToFilters'
+import { hasVisibleVizFilters } from '@cdc/core/helpers/filterVisibility'
 import { processMarkupVariables } from '@cdc/core/helpers/markupProcessor'
 
 // Map Helpers
@@ -532,6 +533,8 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
     return config
   }
 
+  const filterConfig = applyStateFilter(config)
+
   return (
     <LegendMemoProvider legendMemo={legendMemo} legendSpecialClassLastMemo={legendSpecialClassLastMemo}>
       <ConfigContext.Provider value={mapProps}>
@@ -570,9 +573,9 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
                   .filter(Boolean)
                   .join(' ')}
                 filters={
-                  config?.filters?.length > 0 || config.general.showStateDropdown ? (
+                  hasVisibleVizFilters(filterConfig.filters) ? (
                     <Filters
-                      config={applyStateFilter(config)}
+                      config={filterConfig}
                       setFilters={setFilters}
                       dimensions={dimensions}
                       interactionLabel={interactionLabel}

--- a/packages/markup-include/src/CdcMarkupInclude.tsx
+++ b/packages/markup-include/src/CdcMarkupInclude.tsx
@@ -8,6 +8,7 @@ import { MarkupIncludeConfig } from '@cdc/core/types/MarkupInclude'
 import { publish } from '@cdc/core/helpers/events'
 import { processMarkupVariables } from '@cdc/core/helpers/markupProcessor'
 import { addValuesToFilters } from '@cdc/core/helpers/addValuesToFilters'
+import { hasVisibleVizFilters } from '@cdc/core/helpers/filterVisibility'
 import { resolveDataColor } from '@cdc/core/helpers/dataColors'
 import ConfigContext from './ConfigContext'
 import coveUpdateWorker from '@cdc/core/helpers/coveUpdateWorker'
@@ -343,7 +344,7 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({
           shouldApplyTopPadding ? ' has-top-padding' : ''
         }${shouldApplySidePadding ? ' has-side-padding' : ''}`.trim()}
         filters={
-          config.filters && config.filters.length > 0 ? (
+          hasVisibleVizFilters(config.filters) ? (
             <Filters
               config={config}
               setFilters={setFilters}
@@ -351,7 +352,7 @@ const CdcMarkupInclude: React.FC<CdcMarkupIncludeProps> = ({
               dimensions={[0, 0]}
               interactionLabel={interactionLabel || 'markup-include'}
             />
-          ) : null
+          ) : undefined
         }
         header={
           !isTp5Style ? (

--- a/packages/markup-include/src/test/CdcMarkupInclude.test.jsx
+++ b/packages/markup-include/src/test/CdcMarkupInclude.test.jsx
@@ -2,7 +2,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import vm from 'node:vm'
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { testStandaloneBuild } from '@cdc/core/helpers/tests/testStandaloneBuild.ts'
 import { describe, it, expect, vi } from 'vitest'
 import CdcMarkupInclude from '../CdcMarkupInclude'
@@ -72,6 +72,52 @@ describe('Markup Include', () => {
 
     expect(JSON.parse((await screen.findByTestId('markup-variables-editor-data')).textContent)).toEqual(filteredData)
     expect(JSON.parse((await screen.findByTestId('markup-variables-editor-editor-data')).textContent)).toEqual(fullData)
+  })
+
+  it('does not render the visualization filters section when every markup include filter is hidden', async () => {
+    const { container } = render(
+      <CdcMarkupInclude
+        config={{
+          type: 'markup-include',
+          theme: 'theme-blue',
+          data: [{ state: 'Alabama' }],
+          filters: [
+            {
+              columnName: 'state',
+              values: ['Alabama'],
+              showDropdown: false,
+              id: 1,
+              parents: [],
+              active: 'Alabama',
+              filterStyle: 'dropdown',
+              label: 'State',
+              order: 'asc',
+              type: 'url'
+            }
+          ],
+          markupVariables: [],
+          contentEditor: {
+            title: '',
+            inlineHTML: '<p>Example</p>',
+            useInlineHTML: true,
+            srcUrl: ''
+          },
+          visual: {
+            border: false,
+            accent: false,
+            background: false,
+            hideBackgroundColor: false,
+            borderColorTheme: false
+          }
+        }}
+        datasets={{}}
+        isDashboard={true}
+      />
+    )
+
+    await waitFor(() => expect(container.querySelector('.markup-include-content-container')).toBeInTheDocument())
+
+    expect(container.querySelector('.cove-visualization__filters-section')).not.toBeInTheDocument()
   })
 
   it('keeps the minimal example in sync with the README docs', () => {


### PR DESCRIPTION
## Summary

Fixes a few situations where empty filter rows are rendered, which take up space.

## Testing Steps

Load [dashboard-charts.json](https://github.com/user-attachments/files/27714600/dashboard-charts.json). On `dev`, there will be extra space between the first chart's title and the chart. On this branch, there will be the appropriate amount of space.
