### PR TITLE
Fix [DEV-13106] Linear brush slider region bug

### DIFF
--- a/packages/chart/src/components/Regions/components/Regions.tsx
+++ b/packages/chart/src/components/Regions/components/Regions.tsx
@@ -186,7 +186,7 @@ const isBarLike = (type: string): boolean => type === VIZ_TYPES.BAR || type === 
 
 // TODO: should regions be removed on categorical axis?
 const Regions: React.FC<RegionsProps> = ({ xScale, barWidth = 0, totalBarsInGroup = 1, yMax, xMax }) => {
-  const { parseDate, config, vizViewport } = useContext<ChartContext>(ConfigContext)
+  const { parseDate, config, tableData, vizViewport } = useContext<ChartContext>(ConfigContext)
 
   const { regions, visualizationType, orientation, xAxis } = config
   const isMobileViewport = isMobileFontViewport(vizViewport || 'lg')
@@ -198,15 +198,32 @@ const Regions: React.FC<RegionsProps> = ({ xScale, barWidth = 0, totalBarsInGrou
   // HELPER FUNCTIONS FOR PREVIOUS DAYS
   // ============================================
 
+  const getDataLastTime = (): number => {
+    const dataKey = config.xAxis.dataKey
+    if (!Array.isArray(tableData) || tableData.length === 0 || !dataKey) return NaN
+    let last = NaN
+    for (const row of tableData) {
+      const value = (row as Record<string, unknown>)[dataKey]
+      const t = parseDate(String(value))?.getTime()
+      if (typeof t === 'number' && !isNaN(t) && (isNaN(last) || t > last)) {
+        last = t
+      }
+    }
+    return last
+  }
+
   const calculatePreviousDaysFrom = (region: Region, axisType: string): number => {
     const previousDays = Number(region.from) || 0
     const domain = xScale.domain()
 
     // Determine the "to" reference date
-    const toRefDate =
-      region.toType === 'Last Date'
-        ? new Date(domain[domain.length - 1] as string | number).getTime()
-        : new Date(region.to)
+    let toRefDate: number | Date
+    if (region.toType === 'Last Date') {
+      const dataLastTime = getDataLastTime()
+      toRefDate = !isNaN(dataLastTime) ? dataLastTime : new Date(domain[domain.length - 1] as string | number).getTime()
+    } else {
+      toRefDate = new Date(region.to)
+    }
 
     const toFormatted = formatDate(config.xAxis.dateParseFormat, toRefDate, config.locale)
     const toDate = new Date(toFormatted)
@@ -439,19 +456,27 @@ const Regions: React.FC<RegionsProps> = ({ xScale, barWidth = 0, totalBarsInGrou
 
   const isRegionInVisibleDomain = (region: Region): boolean => {
     if (region.toType !== 'Last Date') return true
-    if (region.fromType === 'Previous Days') return true
     if (xAxis.type !== 'date' && xAxis.type !== 'date-time') return true
 
     const domain = xScale.domain()
     if (!domain || domain.length === 0) return true
-
     const visEnd = Number(domain[domain.length - 1])
-    const fromTime = parseDate(
-      formatDate(config.xAxis.dateParseFormat, new Date(region.from), config.locale)
-    )?.getTime()
+    if (isNaN(visEnd)) return true
 
-    if (isNaN(visEnd) || fromTime === undefined || isNaN(fromTime)) return true
-    return fromTime <= visEnd
+    let fromTime: number | undefined
+    if (region.fromType === 'Previous Days') {
+      const dataLastTime = getDataLastTime()
+      if (isNaN(dataLastTime)) return true
+      const previousDays = Number(region.from) || 0
+      const fromDate = new Date(dataLastTime)
+      fromDate.setDate(fromDate.getDate() - previousDays)
+      fromTime = fromDate.getTime()
+    } else {
+      fromTime = parseDate(formatDate(config.xAxis.dateParseFormat, new Date(region.from), config.locale))?.getTime()
+    }
+
+    if (fromTime === undefined || isNaN(fromTime)) return true
+    return fromTime < visEnd
   }
 
   // ============================================

--- a/packages/chart/src/components/Regions/components/Regions.tsx
+++ b/packages/chart/src/components/Regions/components/Regions.tsx
@@ -437,6 +437,23 @@ const Regions: React.FC<RegionsProps> = ({ xScale, barWidth = 0, totalBarsInGrou
     return Number(lastDatePosition)
   }
 
+  const isRegionInVisibleDomain = (region: Region): boolean => {
+    if (region.toType !== 'Last Date') return true
+    if (region.fromType === 'Previous Days') return true
+    if (xAxis.type !== 'date' && xAxis.type !== 'date-time') return true
+
+    const domain = xScale.domain()
+    if (!domain || domain.length === 0) return true
+
+    const visEnd = Number(domain[domain.length - 1])
+    const fromTime = parseDate(
+      formatDate(config.xAxis.dateParseFormat, new Date(region.from), config.locale)
+    )?.getTime()
+
+    if (isNaN(visEnd) || fromTime === undefined || isNaN(fromTime)) return true
+    return fromTime <= visEnd
+  }
+
   // ============================================
   // MAIN ROUTING FUNCTIONS
   // ============================================
@@ -507,6 +524,8 @@ const Regions: React.FC<RegionsProps> = ({ xScale, barWidth = 0, totalBarsInGrou
   const chartEnd = xMax !== undefined ? xMax : 1000
 
   return regions.map((region: Region) => {
+    if (!isRegionInVisibleDomain(region)) return null
+
     const from = getFromValue(region)
     const to = getToValue(region)
 


### PR DESCRIPTION
## Ticket
[DEV-13106](https://cdc-wcms.atlassian.net/browse/DEV-13106)

## Summary
The bug affects the regions feature when using brush sliders. Users experience issues where the region moves with the brush slider, even if the selection is outside of the region. Only affected Date (Linear Scale)

## Testing Steps
1. Load [reported-pertussis-cases (1).json](https://github.com/user-attachments/files/27718670/reported-pertussis-cases.1.json) or create new chart with brush slider, date (linear scale), and a region that uses "Maximum Region Type: **Last Date**"
2. Make selection that does not include shaded region
3. Confirm shaded region does not move with brush slider
