### PR TITLE
Enhancent [DEV-13112] Region styling

### DIFF
--- a/packages/chart/CONFIG.md
+++ b/packages/chart/CONFIG.md
@@ -79,7 +79,7 @@ Axis settings are chart-owned because their meaning depends on chart family, ori
 | Field | Type | Required | Default | Description | Allowed values / Notes |
 | --- | --- | --- | --- | --- | --- |
 | `xAxis.dataKey`, `yAxis.dataKey` | `string` | Conditionally | `''` | Source field used by the axis. | Required for visible/category axes and most value-axis chart wiring. |
-| `xAxis.type`, `yAxis.type` | `string` | No | Package defaults | Axis scale mode. | Category/date axes commonly use `categorical`, `date`, or `date-time`; current numeric value axes use `linear` or `logarithmic`. Older configs may contain `continuous`. |
+| `xAxis.type`, `yAxis.type` | `string` | No | Package defaults | Axis scale mode. | Category/date axes commonly use `categorical`, `date`, or `date-time`; Scatter Plot x-axes can use `continuous`; current numeric value axes use `linear` or `logarithmic`. |
 | `xAxis.label`, `yAxis.label` | `string` | No | `''` | Axis title shown near the axis. | Optional display label. |
 | `yAxis.titlePlacement` | `side \| top` | No | `top` for new configs; older configs missing this field migrate to `side` | Chooses where the y-axis title renders. | `top` renders the title above the plot and participates in y-axis auto-padding behavior. |
 | `*.hideAxis`, `*.hideTicks`, `*.hideLabel` | `boolean` | No | `false` | Hides axis line, tick marks, or label. | Supported per axis where the renderer exposes these controls. |
@@ -271,7 +271,7 @@ These fields are chart-owned. They are applied by chart number-format helpers fo
 | `table.defaultSort` | `object` | No | Auto-filled for date-axis charts when possible | Initial table sort. | Shared object with `column`, `sortDirection`, and optional `customOrder`; chart can seed the x-axis date column when omitted. |
 | `table.download`, `table.showDownloadImgButton`, `table.showDownloadPdfButton`, `table.showDownloadUrl` | `boolean` | No | `false` | Enables table data, image/PDF, and URL download controls. | See shared `Table` for related labels and download flags. |
 | `table.includeContextInDownload` | `boolean` | No | `false` | Includes chart context in supported downloads. | Used by image/PDF download controls. |
-| `table.customTableConfig` | [`Table`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#table) | No | None | Nested override passed to the shared table renderer. | When present, chart runtime can pass this table config instead of the top-level table block. |
+| `table.customTableConfig` | [`Table`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#table) | No | None | Legacy custom-table marker. | Current chart runtime does not pass this as a nested table config; when truthy for non-Sankey tables, it switches the raw table data source to filtered config data. |
 
 ## Feature-Specific Enhancements
 
@@ -328,9 +328,6 @@ When `yAxis.titlePlacement` is `top`, the leading tile in each row renders that 
 | `forestPlot.radius.scalingColumn` | `string` | No | `''` | Column used to scale point estimate radius. | Leave blank for fixed-size points. |
 | `forestPlot.radius.min`, `forestPlot.radius.max` | `number` | No | `2`, `10` | Minimum and maximum point radius. | Used when `radius.scalingColumn` is set. |
 | `forestPlot.colors.line`, `forestPlot.colors.shape` | CSS color string | No | `''` | Custom colors for the no-effect line and point estimate shape. | Blank values use renderer defaults. |
-| `forestPlot.description.*`, `forestPlot.result.*` | object | No | Package defaults | Column label blocks beside the plot. | Each block stores `show`, `text`, and `location`. |
-| `forestPlot.leftWidthOffset`, `forestPlot.rightWidthOffset` | `number` | No | `0` | Manual horizontal layout offsets. | Advanced layout tuning for dense forest plots. |
-| `forestPlot.leftWidthOffsetMobile`, `forestPlot.rightWidthOffsetMobile` | `number` | No | Package defaults | Mobile-specific horizontal layout offsets. | Advanced layout tuning for dense forest plots. |
 | `forestPlot.regression.showDiamond` | `boolean` | No | Package defaults | Shows a regression diamond when supported. | Only meaningful for regression-style forest plot flows. |
 | `forestPlot.regression.description` | `string` | No | Package defaults | Text label rendered with the regression/diamond summary when present. | Only meaningful for regression-style forest plot flows. |
 | `forestPlot.regression.baseLineColor` | CSS color string | No | Package defaults | Color for the regression baseline and diamond when supported. | Blank values use renderer defaults. |
@@ -351,8 +348,8 @@ Regions are chart-owned shaded ranges or markers.
 | --- | --- | --- | --- | --- | --- |
 | `regions[].from`, `regions[].to` | `string` | Yes | None | Start and end values for the region. | May represent dates, categories, or numeric thresholds. |
 | `regions[].label` | `string` | No | `''` | Region label shown in supported UIs. | Optional. |
-| `regions[].color` | `string` | No | None | Border or line color. | CSS color string. |
-| `regions[].background` | `string` | No | None | Fill color. | CSS color string. |
+| `regions[].color` | `string` | No | App font color (`--cool-gray-90`) | Label text color. | CSS color string. Legacy configs migrated to `red` when this was omitted before `4.26.5`. |
+| `regions[].background` | `string` | No | `--cool-gray-50` | Fill color for the shaded region. | CSS color string. Rendered at 30% opacity. Legacy configs migrated to `red` when this was omitted before `4.26.5`. |
 | `regions[].range` | `string` | No | `Custom` in editor flows | Region mode metadata. | Package-defined values such as `Custom`. |
 | `regions[].fromType`, `regions[].toType` | `string` | No | `Fixed` | Interpretation of the start/end values. | Examples include `Fixed`, `Previous Days`, and `Last Date`. |
 
@@ -404,11 +401,9 @@ Regions are chart-owned shaded ranges or markers.
 
 | Field | Type | Required | Default | Description | Allowed values / Notes |
 | --- | --- | --- | --- | --- | --- |
-| `boxplot.labels.maximum`, `boxplot.labels.minimum` | `string` | No | `Maximum`, `Minimum` | Labels for whisker endpoints. | Display text in tooltips/table/how-to-read areas. |
-| `boxplot.labels.q1`, `boxplot.labels.q2`, `boxplot.labels.q3`, `boxplot.labels.q4` | `string` | No | `Lower Quartile`, `q2`, `Upper Quartile`, `q4` | Labels for quartile entries. | Box plot label entries. |
-| `boxplot.labels.median`, `boxplot.labels.mean` | `string` | No | `Median`, `Mean` | Labels for median and mean values. | Box plot label entries. |
-| `boxplot.labels.sd`, `boxplot.labels.iqr`, `boxplot.labels.count`, `boxplot.labels.outliers`, `boxplot.labels.values` | `string` | No | `Standard Deviation`, `Interquartile Range`, `Count`, `Outliers`, `Values` | Labels for additional box plot measures. | Box plot label entries. |
-| `boxplot.labels.lowerBounds`, `boxplot.labels.upperBounds` | `string` | No | `Lower Bounds`, `Upper Bounds` | Labels for lower and upper bound values. | Box plot label entries. |
+| `boxplot.labels.q1`, `boxplot.labels.q3` | `string` | No | `Lower Quartile`, `Upper Quartile` | Labels for the lower and upper quartile values in box plot tooltips. | Current runtime renders these labels in tooltip output. |
+| `boxplot.labels.median` | `string` | No | `Median` | Label for the median value in box plot tooltips. | Current runtime renders this label in tooltip output. |
+| `boxplot.labels.iqr` | `string` | No | `Interquartile Range` | Label for the interquartile range in box plot tooltips. | Current runtime renders this label in tooltip output. |
 | `boxplot.plotOutlierValues` | `boolean` | No | `false` | Plots outlier values. | Box plot display toggle. |
 | `boxplot.plotNonOutlierValues` | `boolean` | No | `true` | Plots non-outlier values. | Box plot display toggle. |
 | `boxplot.hideOutliers` | `boolean` | No | `false` | Excludes outlier values from the box plot scale/domain calculation. | Runtime-read advanced setting; this is separate from whether outlier points are drawn. |
@@ -421,10 +416,8 @@ Regions are chart-owned shaded ranges or markers.
 | Field | Type | Required | Default | Description | Allowed values / Notes |
 | --- | --- | --- | --- | --- | --- |
 | `horizon.numLayers` | `number` | No | `4` | Number of horizon layers/bands per series. | More layers provide finer gradations but denser rows. |
-| `horizon.mode` | `offset \| mirror` | No | `offset` | Controls how positive/negative values are rendered. | `offset` treats values as positive magnitudes. `mirror` is scaffolded for negative values but is not currently the normal UI path. |
 | `horizon.bandGap` | `number` | No | `15` | Gap between series bands. | Pixel-like value subtracted from available row height. |
 | `horizon.bottomPadding` | `number` | No | `15` | Padding below the bottom band above the x-axis. | Pixel-like value. |
-| `horizon.negativePalette` | [`Palette`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#palette)-like object | No | None | Secondary palette for negative values. | Future-facing field for `mirror` mode; uses the same fields as `general.palette`. |
 
 ## Fields You Can Ignore
 
@@ -452,6 +445,10 @@ These fields sometimes appear in saved configs, copied editor state, or migratio
 | `sankey.title`, `sankey.overallSize`, `sankey.nodeSize.nodeHeight`, `sankey.storyNodeText` | Saved Sankey defaults or legacy/editor artifacts not used by the current renderer. Story-node text that affects rendering lives in `data[0].storyNodeText`. |
 | `runtime.series[].originalDataKey` | Original series key retained on generated runtime series during dynamic-category rendering. |
 | `boxplot.plots`, `boxplot.categories`, `boxplot.tableData` | Runtime-derived box plot structures generated from the active dataset. |
+| `boxplot.labels.maximum`, `boxplot.labels.minimum`, `boxplot.labels.q2`, `boxplot.labels.q4`, `boxplot.labels.mean`, `boxplot.labels.sd`, `boxplot.labels.count`, `boxplot.labels.outliers`, `boxplot.labels.values`, `boxplot.labels.lowerBounds`, `boxplot.labels.upperBounds` | Persisted box plot label defaults that current chart/table output does not render. |
+| `forestPlot.description.*`, `forestPlot.result.*` | Legacy saved defaults for older forest plot side-column labels. Current side-column rendering uses `columns.*.forestPlot` fields instead. |
+| `forestPlot.leftWidthOffset`, `forestPlot.rightWidthOffset`, `forestPlot.leftWidthOffsetMobile`, `forestPlot.rightWidthOffsetMobile` | Legacy saved/editor layout offsets. Current forest plot layout reserves left/right space from measured text and forest-plot column settings. |
+| `horizon.mode`, `horizon.negativePalette` | Scaffolded horizon metadata not used by the current renderer. Current Horizon rendering treats values as positive magnitudes. |
 | `color` | Legacy top-level palette token kept for backward compatibility. |
 | `palette` | Legacy top-level palette token superseded by `general.palette`. |
 | `isPaletteReversed` | Legacy top-level palette reversal flag. Current palette reversal is controlled by `general.palette.isReversed`; two-color charts use `twoColor.isPaletteReversed`. |

--- a/packages/chart/src/_stories/ChartBar.Editor.stories.tsx
+++ b/packages/chart/src/_stories/ChartBar.Editor.stories.tsx
@@ -1584,9 +1584,13 @@ export const BarRegionsSectionTests: Story = {
         const textColors = canvas.queryAllByLabelText(/text color/i)
         const backgrounds = canvas.queryAllByLabelText(/background/i)
         const minRegionTypes = canvas.queryAllByLabelText(/minimum region type/i)
+        const textColor = textColors[0] as HTMLInputElement | undefined
+        const background = backgrounds[0] as HTMLInputElement | undefined
 
         return {
           regionCount: regionLabels.length,
+          textColor: textColor?.placeholder,
+          background: background?.placeholder,
           hasFields:
             regionLabels.length > 0 && textColors.length > 0 && backgrounds.length > 0 && minRegionTypes.length > 0
         }
@@ -1599,6 +1603,10 @@ export const BarRegionsSectionTests: Story = {
         // Should now have 1 region with all fields
         expect(after.regionCount).toBe(1)
         expect(after.hasFields).toBe(true)
+        expect(after.textColor).toBe(
+          getComputedStyle(document.documentElement).getPropertyValue('--cool-gray-90').trim()
+        )
+        expect(after.background).toBe('#71767a')
 
         return true
       }

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Regions.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Regions.tsx
@@ -14,9 +14,12 @@ import { TextField, Select } from '@cdc/core/components/EditorPanel/Inputs'
 import Tooltip from '@cdc/core/components/ui/Tooltip'
 import Icon from '@cdc/core/components/ui/Icon'
 import Button from '@cdc/core/components/elements/Button'
+import { APP_FONT_COLOR } from '@cdc/core/helpers/constants'
 import { type ChartContext } from '../../../../types/ChartContext.js'
 import { type PanelProps } from '../PanelProps.js'
 import ConfigContext from '../../../../ConfigContext.js'
+
+const DEFAULT_REGION_BACKGROUND = getComputedStyle(document.documentElement).getPropertyValue('--cool-gray-50').trim()
 
 const RegionSettings = memo(({ config, updateConfig }: { config: ChartConfig; updateConfig: Function }) => {
   let regionUpdate = (fieldName, value, i) => {
@@ -116,12 +119,14 @@ const RegionSettings = memo(({ config, updateConfig }: { config: ChartConfig; up
                           value={color}
                           label='Text Color'
                           fieldName='color'
+                          placeholder={APP_FONT_COLOR}
                           updateField={(section, subsection, fieldName, value) => regionUpdate(fieldName, value, i)}
                         />
                         <TextField
                           value={background}
                           label='Background'
                           fieldName='background'
+                          placeholder={DEFAULT_REGION_BACKGROUND}
                           updateField={(section, subsection, fieldName, value) => regionUpdate(fieldName, value, i)}
                         />
                       </div>

--- a/packages/chart/src/components/LinearChart.tsx
+++ b/packages/chart/src/components/LinearChart.tsx
@@ -770,18 +770,19 @@ const LinearChart = forwardRef<SVGAElement, LinearChartProps>(({ parentHeight, p
           {/* we are handling regions in bar charts differently, so that we can calculate the bar group into the region space. */}
           {/* prettier-ignore */}
           {config.visualizationType !== 'Bar' && config.visualizationType !== 'Combo' && (
-            <Regions
-              xScale={xScale}
-              handleTooltipClick={handleTooltipClick}
-              handleTooltipMouseOff={handleTooltipMouseOff}
-              handleTooltipMouseOver={handleTooltipMouseOver}
-              showTooltip={showTooltip}
-              hideTooltip={hideTooltip}
-              tooltipData={tooltipData}
-              yMax={yMax}
-              xMax={xMax}
-              yAxisWidth={yAxisWidth}
-            />
+            <Group left={yAxisWidth}>
+              <Regions
+                xScale={xScale}
+                handleTooltipClick={handleTooltipClick}
+                handleTooltipMouseOff={handleTooltipMouseOff}
+                handleTooltipMouseOver={handleTooltipMouseOver}
+                showTooltip={showTooltip}
+                hideTooltip={hideTooltip}
+                tooltipData={tooltipData}
+                yMax={yMax}
+                xMax={xMax}
+              />
+            </Group>
           )}
           {isNoDataAvailable && (
             <Text

--- a/packages/chart/src/components/Regions/components/Regions.tsx
+++ b/packages/chart/src/components/Regions/components/Regions.tsx
@@ -19,6 +19,12 @@ const VIZ_TYPES = {
 const DEFAULT_REGION_BACKGROUND = 'var(--cool-gray-50, #71767a)'
 const TICK_LABEL_FONT_SIZE = 16
 const TICK_LABEL_FONT_SIZE_SMALL = 13
+const REGION_LABEL_HORIZONTAL_PADDING = 8
+const REGION_LABEL_TOP_PADDING = 6
+const REGION_LABEL_MAX_PLOT_WIDTH_RATIO = 1 / 3
+const REGION_LABEL_COMFORTABLE_MIN_WIDTH = 120
+const REGION_LABEL_COMFORTABLE_MIN_WIDTH_SMALL = 96
+const REGION_LABEL_FONT_FAMILY = 'Nunito, sans-serif'
 
 type Region = {
   from: string
@@ -51,9 +57,44 @@ type HighlightedAreaProps = {
   background: string
 }
 
+type RegionLabelLayout = {
+  x: number
+  width: number
+  mode: 'inside' | 'overflow'
+}
+
 const HighlightedArea: React.FC<HighlightedAreaProps> = ({ x, width, yMax, background }) => (
   <rect x={x} y={0} width={width} height={yMax} fill={background || DEFAULT_REGION_BACKGROUND} opacity={0.3} />
 )
+
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max)
+
+const getRegionLabelY = (fontSize: number): number => REGION_LABEL_TOP_PADDING + fontSize * 0.25
+
+const getRegionLabelLayout = (
+  clippedFrom: number,
+  regionWidth: number,
+  plotWidth: number,
+  isMobileViewport: boolean
+): RegionLabelLayout => {
+  const maxPlotLabelWidth = Math.max(1, plotWidth * REGION_LABEL_MAX_PLOT_WIDTH_RATIO)
+  const regionInnerWidth = Math.max(0, regionWidth - REGION_LABEL_HORIZONTAL_PADDING * 2)
+  const comfortableMinWidth = isMobileViewport
+    ? REGION_LABEL_COMFORTABLE_MIN_WIDTH_SMALL
+    : REGION_LABEL_COMFORTABLE_MIN_WIDTH
+
+  const isInsideRegion = regionInnerWidth >= comfortableMinWidth
+  const labelWidth = isInsideRegion
+    ? Math.min(regionInnerWidth, maxPlotLabelWidth)
+    : Math.min(comfortableMinWidth, maxPlotLabelWidth, plotWidth)
+
+  const regionCenter = clippedFrom + regionWidth / 2
+  const halfLabelWidth = labelWidth / 2
+  const labelX =
+    labelWidth >= plotWidth ? plotWidth / 2 : clamp(regionCenter, halfLabelWidth, plotWidth - halfLabelWidth)
+
+  return { x: labelX, width: labelWidth, mode: isInsideRegion ? 'inside' : 'overflow' }
+}
 
 /** Find the closest date in domain to a target date */
 const findClosestDate = <T,>(targetTime: number, domain: T[], getTime: (d: T) => number): T => {
@@ -82,9 +123,8 @@ const Regions: React.FC<RegionsProps> = ({ xScale, barWidth = 0, totalBarsInGrou
   const { parseDate, config, vizViewport } = useContext<ChartContext>(ConfigContext)
 
   const { regions, visualizationType, orientation, xAxis } = config
-  const regionLabelFontSize = isMobileFontViewport(vizViewport || 'lg')
-    ? TICK_LABEL_FONT_SIZE_SMALL
-    : TICK_LABEL_FONT_SIZE
+  const isMobileViewport = isMobileFontViewport(vizViewport || 'lg')
+  const regionLabelFontSize = isMobileViewport ? TICK_LABEL_FONT_SIZE_SMALL : TICK_LABEL_FONT_SIZE
 
   const getBarOffset = (): number => (barWidth * totalBarsInGroup) / 2
 
@@ -415,15 +455,19 @@ const Regions: React.FC<RegionsProps> = ({ xScale, barWidth = 0, totalBarsInGrou
     const width = getWidth(clippedTo, clippedFrom)
 
     if (width <= 0) return null
+    const labelLayout = getRegionLabelLayout(clippedFrom, width, chartEnd, isMobileViewport)
 
     return (
       <Group height={100} className='regions regions-group--line' key={region.label} pointerEvents='none'>
         <HighlightedArea x={clippedFrom} width={width} yMax={yMax} background={region.background} />
         <Text
-          x={clippedFrom + width / 2}
-          y={5}
+          x={labelLayout.x}
+          y={getRegionLabelY(regionLabelFontSize)}
+          width={labelLayout.width}
           fill={region.color || APP_FONT_COLOR}
           fontSize={regionLabelFontSize}
+          style={{ fontFamily: REGION_LABEL_FONT_FAMILY, fontSize: regionLabelFontSize }}
+          lineHeight='1.1em'
           verticalAnchor='start'
           textAnchor='middle'
         >

--- a/packages/chart/src/components/Regions/components/Regions.tsx
+++ b/packages/chart/src/components/Regions/components/Regions.tsx
@@ -3,7 +3,7 @@ import ConfigContext from '../../../ConfigContext'
 import { ChartContext } from '../../../types/ChartContext'
 import { Text, useText } from '@visx/text'
 import { Group } from '@visx/group'
-import { formatDate, isDateScale } from '@cdc/core/helpers/cove/date.js'
+import { formatDate } from '@cdc/core/helpers/cove/date.js'
 import { APP_FONT_COLOR } from '@cdc/core/helpers/constants'
 import { isMobileFontViewport } from '@cdc/core/helpers/viewports'
 
@@ -60,7 +60,6 @@ type HighlightedAreaProps = {
 type RegionLabelLayout = {
   x: number
   width: number
-  mode: 'inside' | 'overflow'
 }
 
 type RegionLabelProps = {
@@ -89,6 +88,9 @@ const getComfortableRegionLabelWidth = (plotWidth: number, isMobileViewport: boo
   return Math.min(comfortableMinWidth, maxPlotLabelWidth, plotWidth)
 }
 
+// Region labels prefer to sit centered inside their highlighted region when the measured text
+// fits with padding. If the visible region is too narrow, keep a readable fixed wrapping width
+// and pin the measured text near the region's right edge, clamped so the text stays inside the plot.
 const getRegionLabelLayout = (
   clippedFrom: number,
   regionWidth: number,
@@ -102,7 +104,6 @@ const getRegionLabelLayout = (
 
   const isInsideRegion = regionInnerWidth >= insideThreshold
   const labelWidth = isInsideRegion ? Math.min(regionInnerWidth, maxPlotLabelWidth) : comfortableLabelWidth
-  const mode = isInsideRegion ? 'inside' : 'overflow'
 
   const regionCenter = clippedFrom + regionWidth / 2
   const halfLabelWidth = labelWidth / 2
@@ -116,7 +117,7 @@ const getRegionLabelLayout = (
   const insideLabelX =
     labelWidth >= plotWidth ? plotWidth / 2 : clamp(regionCenter, halfLabelWidth, plotWidth - halfLabelWidth)
 
-  return { x: mode === 'inside' ? insideLabelX : overflowLabelX, width: labelWidth, mode }
+  return { x: isInsideRegion ? insideLabelX : overflowLabelX, width: labelWidth }
 }
 
 const RegionLabel: React.FC<RegionLabelProps> = ({

--- a/packages/chart/src/components/Regions/components/Regions.tsx
+++ b/packages/chart/src/components/Regions/components/Regions.tsx
@@ -42,7 +42,6 @@ type RegionsProps = {
   barWidth?: number
   totalBarsInGroup?: number
   xMax?: number
-  yAxisWidth?: number
 }
 
 type HighlightedAreaProps = {
@@ -79,14 +78,7 @@ const isLineLike = (type: string): boolean =>
 const isBarLike = (type: string): boolean => type === VIZ_TYPES.BAR || type === VIZ_TYPES.COMBO
 
 // TODO: should regions be removed on categorical axis?
-const Regions: React.FC<RegionsProps> = ({
-  xScale,
-  barWidth = 0,
-  totalBarsInGroup = 1,
-  yMax,
-  xMax,
-  yAxisWidth = 0
-}) => {
+const Regions: React.FC<RegionsProps> = ({ xScale, barWidth = 0, totalBarsInGroup = 1, yMax, xMax }) => {
   const { parseDate, config, vizViewport } = useContext<ChartContext>(ConfigContext)
 
   const { regions, visualizationType, orientation, xAxis } = config
@@ -141,8 +133,8 @@ const Regions: React.FC<RegionsProps> = ({
     } else {
       from = xScale(region.from)
     }
-    // Add left padding (yAxisWidth) + half bandwidth to center on the category
-    let scalePadding = yAxisWidth
+    // Add half bandwidth to center on the category
+    let scalePadding = 0
     if (xScale.bandwidth) {
       scalePadding += xScale.bandwidth() / 2
     }
@@ -154,8 +146,8 @@ const Regions: React.FC<RegionsProps> = ({
       return calculateLineLastDatePosition_Categorical()
     }
     let to = xScale(region.to)
-    // Add left padding (yAxisWidth) + half bandwidth
-    let scalePadding = yAxisWidth
+    // Add half bandwidth to center on the category
+    let scalePadding = 0
     if (xScale.bandwidth) {
       scalePadding += xScale.bandwidth() / 2
     }
@@ -177,8 +169,8 @@ const Regions: React.FC<RegionsProps> = ({
       const closestDate = findClosestDate(parsedDate, domain, d => d)
       from = xScale(closestDate)
     }
-    // Add left padding (yAxisWidth) + half bandwidth
-    let scalePadding = yAxisWidth
+    // Add half bandwidth to center on the date band
+    let scalePadding = 0
     if (xScale.bandwidth) {
       scalePadding += xScale.bandwidth() / 2
     }
@@ -198,8 +190,8 @@ const Regions: React.FC<RegionsProps> = ({
     const closestDate = findClosestDate(parsedDate, domain, d => d)
     let to = xScale(closestDate)
 
-    // Add left padding (yAxisWidth) + half bandwidth
-    let scalePadding = yAxisWidth
+    // Add half bandwidth to center on the date band
+    let scalePadding = 0
     if (xScale.bandwidth) {
       scalePadding += xScale.bandwidth() / 2
     }
@@ -209,13 +201,13 @@ const Regions: React.FC<RegionsProps> = ({
   const getLineFromValue_DateTime = (region: Region): number => {
     if (region.fromType === 'Previous Days') {
       const from = calculatePreviousDaysFrom(region, 'date-time')
-      return from + yAxisWidth
+      return from
     }
     const date = new Date(region.from)
     const parsedDate = parseDate(formatDate(config.xAxis.dateParseFormat, date, config.locale)).getTime()
     let from = xScale(parsedDate)
-    // For date-time, xScale returns correct position (no bandwidth), just add left padding
-    return from + yAxisWidth
+    // For date-time, xScale returns the plot-local position (no bandwidth)
+    return from
   }
 
   const getLineToValue_DateTime = (region: Region): number => {
@@ -223,27 +215,24 @@ const Regions: React.FC<RegionsProps> = ({
       return calculateLineLastDatePosition_DateTime()
     }
     let to = xScale(parseDate(region.to).getTime())
-    return to + yAxisWidth
+    return to
   }
 
   const calculateLineLastDatePosition_Categorical = (): number => {
-    const chartStart = yAxisWidth
     // Extend to the right edge of the chart
-    return chartStart + (xMax || 0)
+    return xMax || 0
   }
 
   const calculateLineLastDatePosition_Date = (): number => {
-    const chartStart = yAxisWidth
     // For date scale line charts with Last Date, extend to the right edge of the chart
-    return chartStart + (xMax || 0)
+    return xMax || 0
   }
 
   const calculateLineLastDatePosition_DateTime = (): number => {
     const domain = xScale.domain()
     const lastDate = domain[domain.length - 1]
     const lastDatePosition = xScale(lastDate)
-    // Match the non-Last Date logic: just add yAxisWidth
-    return Number(lastDatePosition + yAxisWidth)
+    return Number(lastDatePosition)
   }
 
   // ============================================
@@ -408,8 +397,8 @@ const Regions: React.FC<RegionsProps> = ({
 
   if (!regions || orientation !== 'vertical') return null
 
-  const chartStart = yAxisWidth
-  const chartEnd = xMax !== undefined ? chartStart + xMax : chartStart + 1000
+  const chartStart = 0
+  const chartEnd = xMax !== undefined ? xMax : 1000
 
   return regions.map((region: Region) => {
     const from = getFromValue(region)

--- a/packages/chart/src/components/Regions/components/Regions.tsx
+++ b/packages/chart/src/components/Regions/components/Regions.tsx
@@ -102,13 +102,21 @@ const getRegionLabelLayout = (
 
   const isInsideRegion = regionInnerWidth >= insideThreshold
   const labelWidth = isInsideRegion ? Math.min(regionInnerWidth, maxPlotLabelWidth) : comfortableLabelWidth
+  const mode = isInsideRegion ? 'inside' : 'overflow'
 
   const regionCenter = clippedFrom + regionWidth / 2
   const halfLabelWidth = labelWidth / 2
-  const labelX =
+  const measuredTextWidth = Math.min(estimatedWrappedWidth || labelWidth, labelWidth)
+  const halfMeasuredTextWidth = measuredTextWidth / 2
+  const overflowLabelX = clamp(
+    clippedFrom + regionWidth - REGION_LABEL_HORIZONTAL_PADDING - halfMeasuredTextWidth,
+    halfMeasuredTextWidth,
+    plotWidth - halfMeasuredTextWidth
+  )
+  const insideLabelX =
     labelWidth >= plotWidth ? plotWidth / 2 : clamp(regionCenter, halfLabelWidth, plotWidth - halfLabelWidth)
 
-  return { x: labelX, width: labelWidth, mode: isInsideRegion ? 'inside' : 'overflow' }
+  return { x: mode === 'inside' ? insideLabelX : overflowLabelX, width: labelWidth, mode }
 }
 
 const RegionLabel: React.FC<RegionLabelProps> = ({

--- a/packages/chart/src/components/Regions/components/Regions.tsx
+++ b/packages/chart/src/components/Regions/components/Regions.tsx
@@ -5,6 +5,7 @@ import { Text } from '@visx/text'
 import { Group } from '@visx/group'
 import { formatDate, isDateScale } from '@cdc/core/helpers/cove/date.js'
 import { APP_FONT_COLOR } from '@cdc/core/helpers/constants'
+import { isMobileFontViewport } from '@cdc/core/helpers/viewports'
 
 // Constants for visualization types
 const VIZ_TYPES = {
@@ -16,6 +17,8 @@ const VIZ_TYPES = {
 } as const
 
 const DEFAULT_REGION_BACKGROUND = 'var(--cool-gray-50, #71767a)'
+const TICK_LABEL_FONT_SIZE = 16
+const TICK_LABEL_FONT_SIZE_SMALL = 13
 
 type Region = {
   from: string
@@ -84,9 +87,12 @@ const Regions: React.FC<RegionsProps> = ({
   xMax,
   yAxisWidth = 0
 }) => {
-  const { parseDate, config } = useContext<ChartContext>(ConfigContext)
+  const { parseDate, config, vizViewport } = useContext<ChartContext>(ConfigContext)
 
   const { regions, visualizationType, orientation, xAxis } = config
+  const regionLabelFontSize = isMobileFontViewport(vizViewport || 'lg')
+    ? TICK_LABEL_FONT_SIZE_SMALL
+    : TICK_LABEL_FONT_SIZE
 
   const getBarOffset = (): number => (barWidth * totalBarsInGroup) / 2
 
@@ -428,6 +434,7 @@ const Regions: React.FC<RegionsProps> = ({
           x={clippedFrom + width / 2}
           y={5}
           fill={region.color || APP_FONT_COLOR}
+          fontSize={regionLabelFontSize}
           verticalAnchor='start'
           textAnchor='middle'
         >

--- a/packages/chart/src/components/Regions/components/Regions.tsx
+++ b/packages/chart/src/components/Regions/components/Regions.tsx
@@ -4,6 +4,7 @@ import { ChartContext } from '../../../types/ChartContext'
 import { Text } from '@visx/text'
 import { Group } from '@visx/group'
 import { formatDate, isDateScale } from '@cdc/core/helpers/cove/date.js'
+import { APP_FONT_COLOR } from '@cdc/core/helpers/constants'
 
 // Constants for visualization types
 const VIZ_TYPES = {
@@ -13,6 +14,8 @@ const VIZ_TYPES = {
   COMBO: 'Combo',
   HORIZON: 'Horizon Chart'
 } as const
+
+const DEFAULT_REGION_BACKGROUND = 'var(--cool-gray-50, #71767a)'
 
 type Region = {
   from: string
@@ -47,7 +50,7 @@ type HighlightedAreaProps = {
 }
 
 const HighlightedArea: React.FC<HighlightedAreaProps> = ({ x, width, yMax, background }) => (
-  <rect x={x} y={0} width={width} height={yMax} fill={background} opacity={0.3} />
+  <rect x={x} y={0} width={width} height={yMax} fill={background || DEFAULT_REGION_BACKGROUND} opacity={0.3} />
 )
 
 /** Find the closest date in domain to a target date */
@@ -419,9 +422,15 @@ const Regions: React.FC<RegionsProps> = ({
     if (width <= 0) return null
 
     return (
-      <Group height={100} fill='red' className='regions regions-group--line' key={region.label} pointerEvents='none'>
+      <Group height={100} className='regions regions-group--line' key={region.label} pointerEvents='none'>
         <HighlightedArea x={clippedFrom} width={width} yMax={yMax} background={region.background} />
-        <Text x={clippedFrom + width / 2} y={5} fill={region.color} verticalAnchor='start' textAnchor='middle'>
+        <Text
+          x={clippedFrom + width / 2}
+          y={5}
+          fill={region.color || APP_FONT_COLOR}
+          verticalAnchor='start'
+          textAnchor='middle'
+        >
           {region.label}
         </Text>
       </Group>

--- a/packages/chart/src/components/Regions/components/Regions.tsx
+++ b/packages/chart/src/components/Regions/components/Regions.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import ConfigContext from '../../../ConfigContext'
 import { ChartContext } from '../../../types/ChartContext'
-import { Text } from '@visx/text'
+import { Text, useText } from '@visx/text'
 import { Group } from '@visx/group'
 import { formatDate, isDateScale } from '@cdc/core/helpers/cove/date.js'
 import { APP_FONT_COLOR } from '@cdc/core/helpers/constants'
@@ -63,6 +63,16 @@ type RegionLabelLayout = {
   mode: 'inside' | 'overflow'
 }
 
+type RegionLabelProps = {
+  label: string
+  color: string
+  clippedFrom: number
+  regionWidth: number
+  plotWidth: number
+  fontSize: number
+  isMobileViewport: boolean
+}
+
 const HighlightedArea: React.FC<HighlightedAreaProps> = ({ x, width, yMax, background }) => (
   <rect x={x} y={0} width={width} height={yMax} fill={background || DEFAULT_REGION_BACKGROUND} opacity={0.3} />
 )
@@ -71,22 +81,27 @@ const clamp = (value: number, min: number, max: number): number => Math.min(Math
 
 const getRegionLabelY = (fontSize: number): number => REGION_LABEL_TOP_PADDING + fontSize * 0.25
 
+const getComfortableRegionLabelWidth = (plotWidth: number, isMobileViewport: boolean): number => {
+  const maxPlotLabelWidth = Math.max(1, plotWidth * REGION_LABEL_MAX_PLOT_WIDTH_RATIO)
+  const comfortableMinWidth = isMobileViewport
+    ? REGION_LABEL_COMFORTABLE_MIN_WIDTH_SMALL
+    : REGION_LABEL_COMFORTABLE_MIN_WIDTH
+  return Math.min(comfortableMinWidth, maxPlotLabelWidth, plotWidth)
+}
+
 const getRegionLabelLayout = (
   clippedFrom: number,
   regionWidth: number,
   plotWidth: number,
-  isMobileViewport: boolean
+  comfortableLabelWidth: number,
+  estimatedWrappedWidth: number
 ): RegionLabelLayout => {
   const maxPlotLabelWidth = Math.max(1, plotWidth * REGION_LABEL_MAX_PLOT_WIDTH_RATIO)
   const regionInnerWidth = Math.max(0, regionWidth - REGION_LABEL_HORIZONTAL_PADDING * 2)
-  const comfortableMinWidth = isMobileViewport
-    ? REGION_LABEL_COMFORTABLE_MIN_WIDTH_SMALL
-    : REGION_LABEL_COMFORTABLE_MIN_WIDTH
+  const insideThreshold = Math.min(comfortableLabelWidth, estimatedWrappedWidth || comfortableLabelWidth)
 
-  const isInsideRegion = regionInnerWidth >= comfortableMinWidth
-  const labelWidth = isInsideRegion
-    ? Math.min(regionInnerWidth, maxPlotLabelWidth)
-    : Math.min(comfortableMinWidth, maxPlotLabelWidth, plotWidth)
+  const isInsideRegion = regionInnerWidth >= insideThreshold
+  const labelWidth = isInsideRegion ? Math.min(regionInnerWidth, maxPlotLabelWidth) : comfortableLabelWidth
 
   const regionCenter = clippedFrom + regionWidth / 2
   const halfLabelWidth = labelWidth / 2
@@ -94,6 +109,48 @@ const getRegionLabelLayout = (
     labelWidth >= plotWidth ? plotWidth / 2 : clamp(regionCenter, halfLabelWidth, plotWidth - halfLabelWidth)
 
   return { x: labelX, width: labelWidth, mode: isInsideRegion ? 'inside' : 'overflow' }
+}
+
+const RegionLabel: React.FC<RegionLabelProps> = ({
+  label,
+  color,
+  clippedFrom,
+  regionWidth,
+  plotWidth,
+  fontSize,
+  isMobileViewport
+}) => {
+  const style = { fontFamily: REGION_LABEL_FONT_FAMILY, fontSize }
+  const comfortableLabelWidth = getComfortableRegionLabelWidth(plotWidth, isMobileViewport)
+  const { wordsByLines } = useText({
+    children: label,
+    width: comfortableLabelWidth,
+    style
+  })
+  const estimatedWrappedWidth = Math.max(...wordsByLines.map(line => line.width || 0), 0)
+  const labelLayout = getRegionLabelLayout(
+    clippedFrom,
+    regionWidth,
+    plotWidth,
+    comfortableLabelWidth,
+    estimatedWrappedWidth
+  )
+
+  return (
+    <Text
+      x={labelLayout.x}
+      y={getRegionLabelY(fontSize)}
+      width={labelLayout.width}
+      fill={color || APP_FONT_COLOR}
+      fontSize={fontSize}
+      style={style}
+      lineHeight='1.1em'
+      verticalAnchor='start'
+      textAnchor='middle'
+    >
+      {label}
+    </Text>
+  )
 }
 
 /** Find the closest date in domain to a target date */
@@ -455,24 +512,19 @@ const Regions: React.FC<RegionsProps> = ({ xScale, barWidth = 0, totalBarsInGrou
     const width = getWidth(clippedTo, clippedFrom)
 
     if (width <= 0) return null
-    const labelLayout = getRegionLabelLayout(clippedFrom, width, chartEnd, isMobileViewport)
 
     return (
       <Group height={100} className='regions regions-group--line' key={region.label} pointerEvents='none'>
         <HighlightedArea x={clippedFrom} width={width} yMax={yMax} background={region.background} />
-        <Text
-          x={labelLayout.x}
-          y={getRegionLabelY(regionLabelFontSize)}
-          width={labelLayout.width}
-          fill={region.color || APP_FONT_COLOR}
+        <RegionLabel
+          label={region.label}
+          color={region.color}
+          clippedFrom={clippedFrom}
+          regionWidth={width}
+          plotWidth={chartEnd}
           fontSize={regionLabelFontSize}
-          style={{ fontFamily: REGION_LABEL_FONT_FAMILY, fontSize: regionLabelFontSize }}
-          lineHeight='1.1em'
-          verticalAnchor='start'
-          textAnchor='middle'
-        >
-          {region.label}
-        </Text>
+          isMobileViewport={isMobileViewport}
+        />
       </Group>
     )
   })

--- a/packages/core/CONFIG.md
+++ b/packages/core/CONFIG.md
@@ -206,7 +206,7 @@ Packages that support static or data-driven footnotes use this shared structure.
 | `order` | `string` | No | Value ordering strategy. | `asc`, `desc`, `cust`, `column` |
 | `orderColumn` | `string` | No | Column used when ordering by another column. | Used when `order` is `column`. |
 | `orderedValues` | `string[]` | No | Explicit custom order. | Used when `order` is `cust`. |
-| `queryParameter` | `string` | No | Legacy query-string metadata on older configs. | Current URL helpers use `setByQueryParameter` instead. |
+| `queryParameter` | `string` | No | Query-string parameter updated by URL-backed filter data loads. | `setByQueryParameter` is used for browser URL seeding and sync. |
 | `setByQueryParameter` | `string` | No | Query-string parameter used to seed active state and build URLs. | Current URL sync uses this exact value. |
 | `type` | `string` | Yes | Filter implementation mode. | In current shared types this is `url`. |
 | `defaultValue` | `string` | No | Default selection when nothing else is active. | Used by reset flows when present. |
@@ -289,7 +289,6 @@ Shared annotation structures are used by charts and maps that support text or ca
 | `seriesKey` | `string` | No | Series to snap the annotation to. | Optional. |
 | `bezier` | `number` | No | Curve offset for curved connectors. | Only relevant to `connectionType: curve`. |
 | `savedDimensions` | `[number, number]` | No | Original saved SVG dimensions captured by editor/runtime flows. | Optional compatibility metadata. Missing values are supported and may be regenerated; consumers usually do not author this manually. |
-| `displayDropdown` | `boolean` | No | Shows the annotation in dropdown-driven UIs. | Optional. |
 
 ## Tables And Columns
 
@@ -344,7 +343,6 @@ Shared annotation structures are used by charts and maps that support text or ca
 | `sourceType` | `'column' \| 'metadata' \| 'icon'` | No | Explicitly declares where the replacement comes from. | If omitted, COVE infers `metadata` when `metadataKey` is present; otherwise `column`. |
 | `selectionMode` | `'all' \| 'first'` | No | Chooses how a column value variable resolves multiple matching rows after shared filters and conditions are applied. | Omitted or `all` keeps the default multi-value list behavior. `first` uses only the first matching row's cell value. Metadata and icon variables ignore this field. |
 | `addCommas` | `boolean` | No | Adds locale-aware grouping separators when the resolved value is numeric. | `true`, `false` |
-| `hideOnNull` | `boolean` | No | Suppresses the variable output when the resolved value is nullish. | `true`, `false` |
 | `metadataKey` | `string` | No | Metadata key used when `sourceType` is `metadata`. | Reads from `config.dataMetadata`. |
 | `iconId` | `SvgRegistryId` | No | Static shared SVG icon to insert when `sourceType` is `icon`. | Uses the core SVG registry. |
 | `outputType` | `'value' \| 'svg'` | No | Output mode for column-driven variables. | `svg` enables data-driven icon mappings. |
@@ -380,7 +378,7 @@ Packages use this structure to display directional arrows and optional labels al
 | `showNoChangeArrows` | `boolean` | No | Allows a `no-change` arrow when a numeric delta falls within the threshold. | Used only in `numeric` mode. |
 | `upLabel` | `string` | No | Optional text displayed next to or below an up arrow. | Package decides where it renders. |
 | `downLabel` | `string` | No | Optional text displayed next to or below a down arrow. | Package decides where it renders. |
-| `noChangeLabel` | `string` | No | Optional text displayed next to or below a no-change arrow. | Used only when `showNoChangeArrows` is enabled. |
+| `noChangeLabel` | `string` | No | Optional text displayed next to or below a no-change arrow. | Used whenever the resolved arrow type is `no-change`; `showNoChangeArrows` only controls numeric within-threshold no-change arrows. |
 | `trendLabel` | `string` | No | Optional shared footer or caption label for the trend indicator block. | Package decides where it renders. |
 
 ### `TrendIndicatorMapping`
@@ -417,5 +415,7 @@ These fields commonly show up in exported or runtime-hydrated configs, but packa
 - `values`, `active`, `queuedActive`, `id`, and `parents` on `FilterBase`/`VizFilter`
 - `active` on `SubGrouping`, plus runtime-generated `valuesLookup` outside configs that intentionally persist nested-dropdown options
 - `savedDimensions` on `Annotation`, which is editor/runtime geometry metadata
+- `displayDropdown` on `Annotation`, which is legacy per-annotation dropdown metadata. Current chart and map dropdown visibility is controlled by `general.showAnnotationDropdown` and viewport.
+- `hideOnNull` on `MarkupVariable`, which is persisted editor-authored metadata. Current shared processing omits empty/nullish replacements based on resolved output, regardless of this flag.
 - `table.sharedFilterColumns`, which is runtime-added helper state for dashboard/shared-filter flows
 - `general.palette.backups[]`, which is migration/rollback metadata

--- a/packages/core/helpers/ver/4.26.5.ts
+++ b/packages/core/helpers/ver/4.26.5.ts
@@ -114,10 +114,29 @@ const applyLegacyDashboardComponentStyleDefaults = config => {
   }
 }
 
+const hasRegionColorValue = value => value !== undefined && value !== null && String(value).trim() !== ''
+
+const preserveLegacyChartRegionColors = config => {
+  if (config.type !== 'chart' || !Array.isArray(config.regions)) return
+
+  config.regions.forEach(region => {
+    if (!region || typeof region !== 'object') return
+
+    if (!hasRegionColorValue(region.color)) {
+      region.color = 'red'
+    }
+
+    if (!hasRegionColorValue(region.background)) {
+      region.background = 'red'
+    }
+  })
+}
+
 const run_4_26_5_migrations = config => {
   applyYAxisTitlePlacement(config)
   migrateFilteredText(config)
   applyLegacyDashboardComponentStyleDefaults(config)
+  preserveLegacyChartRegionColors(config)
 
   if (config.type === 'dashboard' && config.visualizations) {
     Object.values((config as DashboardConfig).visualizations).forEach(visualization => {
@@ -134,5 +153,10 @@ const update_4_26_5 = config => {
   return newConfig
 }
 
-export { applyYAxisTitlePlacement, applyLegacyDashboardComponentStyleDefaults, migrateFilteredText }
+export {
+  applyYAxisTitlePlacement,
+  applyLegacyDashboardComponentStyleDefaults,
+  migrateFilteredText,
+  preserveLegacyChartRegionColors
+}
 export default update_4_26_5

--- a/packages/core/helpers/ver/tests/4.26.5.test.ts
+++ b/packages/core/helpers/ver/tests/4.26.5.test.ts
@@ -125,6 +125,68 @@ describe('update_4_26_5', () => {
     expect(result.visualizations.waffle1.visualizationType).toBe('TP5 Gauge')
   })
 
+  it('preserves legacy red fallback colors for chart regions with missing colors', () => {
+    const config: any = {
+      type: 'chart',
+      version: '4.26.4',
+      regions: [
+        { label: 'Missing both', from: '2024-01-01', to: '2024-01-08' },
+        { label: 'Missing text', from: '2024-01-01', to: '2024-01-08', background: '#f2f2f2' },
+        { label: 'Missing background', from: '2024-01-01', to: '2024-01-08', color: '#1c1d1f' },
+        { label: 'Explicit colors', from: '2024-01-01', to: '2024-01-08', color: '#111111', background: '#eeeeee' }
+      ]
+    }
+
+    const result = update_4_26_5(config)
+
+    expect(result.regions).toEqual([
+      { label: 'Missing both', from: '2024-01-01', to: '2024-01-08', color: 'red', background: 'red' },
+      { label: 'Missing text', from: '2024-01-01', to: '2024-01-08', color: 'red', background: '#f2f2f2' },
+      { label: 'Missing background', from: '2024-01-01', to: '2024-01-08', color: '#1c1d1f', background: 'red' },
+      {
+        label: 'Explicit colors',
+        from: '2024-01-01',
+        to: '2024-01-08',
+        color: '#111111',
+        background: '#eeeeee'
+      }
+    ])
+    expect(config.regions[0].color).toBeUndefined()
+  })
+
+  it('preserves legacy red fallback colors for chart regions inside dashboard visualizations', () => {
+    const config: any = {
+      type: 'dashboard',
+      version: '4.26.4',
+      visualizations: {
+        chart1: {
+          type: 'chart',
+          regions: [{ label: 'Dashboard chart region', from: 'A', to: 'B' }]
+        }
+      }
+    }
+
+    const result = update_4_26_5(config)
+
+    expect(result.visualizations.chart1.regions[0]).toMatchObject({
+      color: 'red',
+      background: 'red'
+    })
+  })
+
+  it('does not write legacy red region colors for configs already migrated to 4.26.5', () => {
+    const config: any = {
+      type: 'chart',
+      version: '4.26.5',
+      regions: [{ label: 'New default region', from: 'A', to: 'B' }]
+    }
+
+    const result = coveUpdateWorker(config)
+
+    expect(result.regions[0].color).toBeUndefined()
+    expect(result.regions[0].background).toBeUndefined()
+  })
+
   it('migrates a basic filtered-text config into markup-include', () => {
     const config: any = {
       type: 'filtered-text',

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -73,7 +73,6 @@ The following authorable data-loading fields are shared and documented in core: 
 | `general.displayAsHex` | `boolean` | No | `false` | Switches the US map to a hex-style treatment. | Works with `hexMap`. |
 | `general.equalNumberOptIn` | `boolean` | No | `false` | Enables the newer equal-number legend path. | Used when `legend.separateZero` and equal-number classification interact. |
 | `general.allowMapZoom` | `boolean` | No | `true` | Enables zooming on supported map types. | Disabled in some editor flows and unsupported map modes. |
-| `general.convertFipsCodes` | `boolean` | No | `true` | Normalizes FIPS-like geography values. | Helpful for US maps that use mixed FIPS formats. |
 | `general.hideGeoColumnInTooltip` | `boolean` | No | `false` | Hides the geography field name in tooltips. | `true`, `false` |
 | `general.hidePrimaryColumnInTooltip` | `boolean` | No | `false` | Hides the primary data field name in tooltips. | `true`, `false` |
 | `general.showDownloadImgButton` | `boolean` | No | `false` | Enables PNG/image download. | Editor-managed field. |
@@ -259,6 +258,7 @@ These fields may appear in saved configs, editor exports, or runtime state, but 
 | `usingWidgetLoader` | Internal loader flag. |
 | `newViz` | Editor-only preview/confirmation flag. |
 | `general.filterControlsStatePicked` | Legacy singular editor-control artifact; use `general.statesPicked` for authored selected-state config. |
+| `general.convertFipsCodes` | Legacy/editor-authored FIPS conversion flag. Current runtime normalizes FIPS-like values during U.S. and county map load regardless of this value. |
 | `general.showDownloadMediaButton` | Legacy editor control; current rendering uses `general.showDownloadImgButton` and `general.showDownloadPdfButton` directly. |
 | `general.territoriesAlwayShow` | Misspelled legacy artifact from an older migration bug. The runtime repairs this to `general.territoriesAlwaysShow`; do not author it manually. |
 | `map.patterns[].contrastCheck` | Editor validation state for pattern contrast; changing it does not affect rendered pattern matching or styling. |

--- a/packages/markup-include/CONFIG.md
+++ b/packages/markup-include/CONFIG.md
@@ -58,7 +58,7 @@ The package uses several shared config shapes that are documented in `@cdc/core`
 
 | Field | Type | Required | Default | Description | Allowed values / Notes |
 | --- | --- | --- | --- | --- | --- |
-| `enableMarkupVariables` | `boolean` | No | `false` | Turns placeholder replacement on or off. | Shared [`MarkupConfig`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#markupconfig) flag documented in core. |
+| `enableMarkupVariables` | `boolean` | No | `false` | Controls markup-variable processing for the title, footnotes, and editor flows; inline HTML body placeholders are processed whenever `markupVariables` are present. | Shared [`MarkupConfig`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#markupconfig) flag documented in core. |
 | `markupVariables` | [`MarkupVariable[]`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#markupvariable) | No | `[]` | Root-level placeholder definitions available to authored text. | Shared type documented in core. This is the preferred location. |
 | `contentEditor.markupVariables` | [`MarkupVariable[]`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#markupvariable) | No | `[]` | Legacy nested copy of the same variable list. | Accepted for backward compatibility; the migration helper moves it to root level. |
 

--- a/packages/waffle-chart/CONFIG.md
+++ b/packages/waffle-chart/CONFIG.md
@@ -41,9 +41,9 @@ The copy-pasteable minimum config lives in [README.md](./README.md). Its source 
 | `filters` | `{ columnName: string; columnValue: string \| number \| boolean \| null }[]` | No | `[]` | Simple local filter list applied before numerator, denominator, and trend calculations. | This is a waffle-owned filter shape, not shared `VizFilter`; runtime filters rows by exact `row[columnName] === columnValue` when both fields are truthy. |
 | `dataColumn` | `string` | Yes | `''` | Source column for the numerator. | Must exist in the active dataset. |
 | `dataFunction` | `string` | Yes | `''` | Aggregation used to calculate the numerator. | `Count`, `Max`, `Mean (Average)`, `Median`, `Min`, `Mode`, `Sum` |
-| `dataConditionalColumn` | `string` | No | `''` | Optional column used to narrow the numerator rows. | Used with `dataConditionalOperator` and `dataConditionalComparate`. |
-| `dataConditionalOperator` | `string` | No | `''` | Comparison operator for the conditional row filter. | `=`, `≠`, `<`, `>`, `<=`, `>=` |
-| `dataConditionalComparate` | `string` | No | `''` | Value compared against `dataConditionalColumn`. | Numeric comparison operators require a numeric value. |
+| `dataConditionalColumn` | `string` | No | `''` | Optional column used to narrow numerator and trend rows. | Used with `dataConditionalOperator` and `dataConditionalComparate`; if the condition matches no rows, runtime falls back to the filtered dataset. |
+| `dataConditionalOperator` | `string` | No | `''` | Comparison operator for the conditional row filter. | `=`, `≠`, `<`, `>`, `<=`, `>=`. If the condition matches no rows, runtime falls back to the filtered dataset. |
+| `dataConditionalComparate` | `string` | No | `''` | Value compared against `dataConditionalColumn`. | Numeric comparison operators require a numeric value; if the condition matches no rows, runtime falls back to the filtered dataset. |
 | `customDenom` | `boolean` | No | `false` | Switches between a fixed denominator and a denominator calculated from data. | `true` enables `dataDenomColumn` and `dataDenomFunction`. |
 | `dataDenom` | `string \| number` | No | `'100'` | Fixed denominator when `customDenom` is `false`. | Values less than or equal to zero fall back to `100`. |
 | `dataDenomColumn` | `string` | No | `''` | Source column for a calculated denominator. | Used only when `customDenom` is `true`. |


### PR DESCRIPTION
## Summary

Makes a few improvements to chart region labels:

* Matches font size to other chart elements
* Improves positioning and wrapping of labels
* Changes default colors from red to gray

## Testing Steps

Open [dashboard-charts.json](https://github.com/user-attachments/files/27761834/dashboard-charts.json). On this branch, the region label will be contained in the gray region, on `dev` it overflows the region (and the chart on small screen sizes.)
