### PR TITLE
Fix [DEV-12960] Limit width of filters when note is present

### DIFF
--- a/packages/core/components/EditorPanel/Inputs.tsx
+++ b/packages/core/components/EditorPanel/Inputs.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useState, useMemo } from 'react'
 import { useDebounce } from 'use-debounce'
-import { DROPDOWN_STYLES } from '../Filters/components/Dropdown'
+import { getDropdownStyles } from '../Filters/components/Dropdown'
 
 export type Input = {
   label: string
@@ -233,7 +233,7 @@ const Select = memo((props: SelectProps) => {
       </span>
       <select
         id={inputId}
-        className={`cove-form-select ${required && !value ? 'warning' : ''} ${DROPDOWN_STYLES}`}
+        className={`cove-form-select ${required && !value ? 'warning' : ''} ${getDropdownStyles()}`}
         name={fieldName}
         value={value}
         disabled={disabled}

--- a/packages/core/components/Filters/Filters.test.tsx
+++ b/packages/core/components/Filters/Filters.test.tsx
@@ -49,6 +49,8 @@ describe('Filters filter notes', () => {
     expect(note?.querySelector('strong')).toHaveTextContent('state')
     expect(label.compareDocumentPosition(note as Element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(note?.compareDocumentPosition(select) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(select).toHaveClass('filters-section__select--fit-content')
+    expect(select).not.toHaveClass('w-100')
   })
 
   it('renders notes for tab-simple filters above the tab control', () => {
@@ -64,8 +66,11 @@ describe('Filters filter notes', () => {
 
   it('does not render note markup for empty notes', () => {
     const { container } = renderFilters([createFilter('dropdown', '   ')])
+    const select = screen.getByLabelText('Filter by State')
 
     expect(container.querySelector('.filters-section__note-text')).not.toBeInTheDocument()
+    expect(select).toHaveClass('w-100')
+    expect(select).not.toHaveClass('filters-section__select--fit-content')
   })
 
   it('marks the wrapper as single-filter layout when only one filter is visible', () => {

--- a/packages/core/components/Filters/components/Dropdown.tsx
+++ b/packages/core/components/Filters/components/Dropdown.tsx
@@ -1,6 +1,7 @@
 import { VizFilter } from '../../../types/VizFilter'
 
-export const DROPDOWN_STYLES = 'py-2 ps-2 w-100 d-block'
+export const getDropdownStyles = (hasNote?: boolean) =>
+  ['py-2', 'ps-2', 'd-block', hasNote ? 'filters-section__select--fit-content' : 'w-100'].join(' ')
 
 type DropdownProps = {
   index: number
@@ -11,13 +12,14 @@ type DropdownProps = {
 
 const Dropdown: React.FC<DropdownProps> = ({ index: outerIndex, label, filter, changeFilterActive }) => {
   const { active, queuedActive, resetLabel } = filter
+  const dropdownStyles = getDropdownStyles(Boolean(filter.note?.trim()))
 
   return (
     <select
       id={`filter-${outerIndex}`}
       name={label}
       aria-label={`Filter by ${label}`}
-      className={`cove-form-select ${DROPDOWN_STYLES}`}
+      className={`cove-form-select ${dropdownStyles}`}
       style={{ backgroundColor: 'white' }}
       data-index='0'
       value={queuedActive || active}

--- a/packages/core/components/Filters/components/filter-note.css
+++ b/packages/core/components/Filters/components/filter-note.css
@@ -13,3 +13,8 @@
 .filters-section__wrapper--multiple .filters-section__note-text {
   max-width: 18rem;
 }
+
+.filters-section__select--fit-content {
+  max-width: 100%;
+  width: fit-content;
+}

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.test.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.test.tsx
@@ -210,6 +210,8 @@ describe('DashboardFilters filter notes', () => {
     expect(note?.querySelector('strong')).toHaveTextContent('state')
     expect(label.compareDocumentPosition(note as Element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(note?.compareDocumentPosition(select) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(select).toHaveClass('filters-section__select--fit-content')
+    expect(select).not.toHaveClass('w-100')
   })
 
   it('renders notes for tab-simple filters above the tab control', () => {
@@ -231,8 +233,11 @@ describe('DashboardFilters filter notes', () => {
 
   it('does not render note markup for empty notes', () => {
     const { container } = renderDashboardFilters(createDropdownFilter('   '))
+    const select = screen.getByLabelText('State')
 
     expect(container.querySelector('.filters-section__note-text')).not.toBeInTheDocument()
+    expect(select).toHaveClass('w-100')
+    expect(select).not.toHaveClass('filters-section__select--fit-content')
   })
 
   it('marks the form as single-filter layout when only one dashboard filter is visible', () => {

--- a/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/DashboardFilters.tsx
@@ -11,7 +11,7 @@ import { MouseEventHandler } from 'react'
 import Loader from '@cdc/core/components/Loader'
 import Button from '@cdc/core/components/elements/Button'
 import _ from 'lodash'
-import { DROPDOWN_STYLES } from '@cdc/core/components/Filters/components/Dropdown'
+import { getDropdownStyles } from '@cdc/core/components/Filters/components/Dropdown'
 import Tabs from '@cdc/core/components/Filters/components/Tabs'
 import FilterNote from '@cdc/core/components/Filters/components/FilterNote'
 import parse from 'html-react-parser'
@@ -143,6 +143,7 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
           }
 
           const isTabSimple = filter.filterStyle === FILTER_STYLE.tabSimple
+          const dropdownStyles = getDropdownStyles(Boolean(filter.note?.trim()))
           const formGroupClass = [
             'dashboard-filters__field',
             'form-group',
@@ -201,7 +202,7 @@ const DashboardFilters: React.FC<DashboardFilterProps> = ({
                 <>
                   <select
                     id={`filter-${filterIndex}`}
-                    className={`cove-form-select ${DROPDOWN_STYLES}`}
+                    className={`cove-form-select ${dropdownStyles}`}
                     data-index='0'
                     value={loading ? 'Loading...' : filter.queuedActive || filter.active}
                     onChange={val => {


### PR DESCRIPTION
## Summary

Limits the width of filters when a note is present.

## Testing Steps

Open [filter-section-styling.json](https://github.com/user-attachments/files/27961459/filter-section-styling.json) as a dashboard config. The note should be wider than the filter.