### PR TITLE
Enhancement [DEV-13136] Dashboard image download link

### DIFF
--- a/packages/core/CONFIG.md
+++ b/packages/core/CONFIG.md
@@ -320,6 +320,7 @@ Shared annotation structures are used by charts and maps that support text or ca
 | `includeContextInDownload` | `boolean` | No | Includes surrounding context in supported downloads. | Optional. |
 | `downloadDataLabel`, `downloadImageLabel`, `downloadUrlLabel` | `string` | No | Labels for download actions. | Optional. |
 | `downloadImageButton`, `downloadPdfButton` | `boolean` | No | Shows image or PDF download buttons. | Optional. |
+| `downloadImageButtonStyle` | `'button' \| 'link'` | No | Controls dashboard image download button presentation when supported by the package. | Missing value defaults to legacy button styling. |
 | `showDownloadImgButton`, `showDownloadPdfButton`, `showDownloadUrl`, `showDownloadLinkBelow`, `showDataTableLink` | `boolean` | No | Legacy or package-specific download/link toggles. | Optional. |
 
 ## Markup Variables

--- a/packages/core/components/MediaControls.test.tsx
+++ b/packages/core/components/MediaControls.test.tsx
@@ -90,3 +90,54 @@ describe('MediaControls.Link', () => {
     )
   })
 })
+
+describe('MediaControls.Button', () => {
+  it('renders dashboard image downloads as native buttons with the default image label', () => {
+    render(
+      <MediaControls.Button
+        state={{ type: 'dashboard', table: {} }}
+        type='image'
+        title='Download Dashboard as Image'
+        elementToCapture='dashboard-download'
+      />
+    )
+
+    const button = screen.getByRole('button', { name: 'Download Image' })
+
+    expect(button).toHaveAttribute('type', 'button')
+    expect(button).toHaveAttribute('title', 'Download Dashboard as Image')
+    expect(screen.queryByRole('link', { name: 'Download Image' })).not.toBeInTheDocument()
+  })
+
+  it('uses a custom dashboard image download label when configured', () => {
+    render(
+      <MediaControls.Button
+        state={{ type: 'dashboard', table: { downloadImageLabel: 'Save Dashboard PNG' } }}
+        type='image'
+        title='Download Dashboard as Image'
+        elementToCapture='dashboard-download'
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Save Dashboard PNG' })).toBeInTheDocument()
+  })
+
+  it('can render dashboard media buttons with link styling while preserving button semantics', () => {
+    render(
+      <MediaControls.Button
+        state={{ type: 'dashboard', table: {} }}
+        type='image'
+        title='Download Dashboard as Image'
+        elementToCapture='dashboard-download'
+        appearance='link'
+      />
+    )
+
+    const button = screen.getByRole('button', { name: 'Download Image' })
+
+    expect(button).toHaveClass('download-button-link')
+    expect(button).toHaveClass('no-border')
+    expect(button).not.toHaveClass('btn-primary')
+    expect(screen.queryByRole('link', { name: 'Download Image' })).not.toBeInTheDocument()
+  })
+})

--- a/packages/core/components/MediaControls.tsx
+++ b/packages/core/components/MediaControls.tsx
@@ -171,9 +171,11 @@ const Button = ({
   title,
   elementToCapture,
   interactionLabel = '',
-  includeContextInDownload = false
+  includeContextInDownload = false,
+  appearance = 'button'
 }) => {
-  const buttonClasses = ['btn', 'btn-primary']
+  const buttonClasses =
+    appearance === 'link' ? ['download-button-link', 'no-border'] : ['btn', 'btn-primary']
 
   const label =
     type === 'csv'
@@ -184,6 +186,7 @@ const Button = ({
 
   return (
     <button
+      type='button'
       className={buttonClasses.join(' ')}
       title={title}
       onClick={() => generateMedia(state, type, elementToCapture, interactionLabel, includeContextInDownload)}

--- a/packages/core/styles/_button-section.scss
+++ b/packages/core/styles/_button-section.scss
@@ -10,6 +10,19 @@
   .btn-download {
     float: unset;
   }
+  .download-button-link {
+    background: transparent;
+    border: 0;
+    color: var(--colors-link-blue, var(--colors-blue-vivid-60));
+    cursor: pointer;
+    font-size: var(--download-link-font-size);
+    padding: 0;
+    text-decoration: underline;
+    text-underline-offset: 6px;
+  }
+  .download-button-link:not(:last-child) {
+    margin-right: 10px;
+  }
 }
 
 // links that appear above data tables

--- a/packages/core/styles/_button-section.scss
+++ b/packages/core/styles/_button-section.scss
@@ -18,7 +18,7 @@
     font-size: var(--download-link-font-size);
     padding: 0;
     text-decoration: underline;
-    text-underline-offset: 6px;
+    text-underline-offset: 0.25rem;
   }
   .download-button-link:not(:last-child) {
     margin-right: 10px;

--- a/packages/core/types/Table.ts
+++ b/packages/core/types/Table.ts
@@ -21,6 +21,7 @@ export type Table = {
   downloadUrlLabel?: string
   downloadVisibleDataOnly?: boolean
   downloadImageButton?: boolean
+  downloadImageButtonStyle?: 'button' | 'link'
   downloadPdfButton?: boolean
   excludeColumns?: string[]
   expanded?: boolean

--- a/packages/dashboard/CONFIG.md
+++ b/packages/dashboard/CONFIG.md
@@ -187,7 +187,7 @@ Dashboard nested-dropdown filters use the shared [`SubGrouping`](https://github.
 
 ## Table And Download Controls
 
-`@cdc/dashboard` uses the shared `Table` structure from the core reference. In this package, the dashboard shell honors the shared table flags plus `table.downloadImageButton` for image downloads. `table.downloadPdfButton` can render a PDF action, but the shared media handler currently reports PDF downloads as disabled.
+`@cdc/dashboard` uses the shared `Table` structure from the core reference. In this package, the dashboard shell honors the shared table flags plus `table.downloadImageButton` for image downloads. When image downloads are enabled, `table.downloadImageButtonStyle` may be `button` or `link`; omitted values use legacy button styling. `table.downloadPdfButton` can render a PDF action, but the shared media handler currently reports PDF downloads as disabled.
 
 The runtime defaults are the dashboard shell table settings from `packages/dashboard/src/data/initial-state.js`: `label: 'Data Table'`, `show: true`, `showDownloadUrl: false`, `downloadUrlLabel: ''`, `showDownloadLinkBelow: true`, and `showVertical: true`.
 

--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -590,6 +590,7 @@ export default function CdcDashboard({
                   text='Download Dashboard Image'
                   elementToCapture={imageId}
                   interactionLabel={interactionLabel}
+                  appearance={config.table?.downloadImageButtonStyle === 'link' ? 'link' : 'button'}
                 />
               )}
               {config.table?.downloadPdfButton && (
@@ -600,6 +601,7 @@ export default function CdcDashboard({
                   text='Download Dashboard PDF'
                   elementToCapture={imageId}
                   interactionLabel={interactionLabel}
+                  appearance={config.table?.downloadImageButtonStyle === 'link' ? 'link' : 'button'}
                 />
               )}
             </section>

--- a/packages/dashboard/src/components/Header/Header.tsx
+++ b/packages/dashboard/src/components/Header/Header.tsx
@@ -245,25 +245,29 @@ const Header = (props: HeaderProps) => {
                     />
                     Show URL to Automatically Updated Data
                   </label>
-                  <select
-                    aria-label='Download image display'
-                    className='download-image-mode-select'
-                    value={getDownloadImageMode()}
-                    onChange={e => changeDownloadImageMode(e.target.value as DownloadImageMode)}
-                  >
-                    <option value='off'>Download Image Off</option>
-                    <option value='button'>Download Image Button</option>
-                    <option value='link'>Download Image Link</option>
-                  </select>
-                  {getDownloadImageMode() !== 'off' && (
-                    <input
-                      className='download-image-label-input'
-                      type='text'
-                      placeholder='Customize label'
-                      defaultValue={config.table.downloadImageLabel}
-                      onChange={e => changeConfigValue('table', 'downloadImageLabel', e.target.value)}
-                    />
-                  )}
+                  <div className='download-image-controls'>
+                    <select
+                      aria-label='Download image display'
+                      className='download-image-mode-select'
+                      value={getDownloadImageMode()}
+                      onChange={e => changeDownloadImageMode(e.target.value as DownloadImageMode)}
+                    >
+                      <option value='off'>Download Image Off</option>
+                      <option value='button'>Download Image Button</option>
+                      <option value='link'>Download Image Link</option>
+                    </select>
+                    <div className='download-image-label-slot'>
+                      {getDownloadImageMode() !== 'off' && (
+                        <input
+                          className='download-image-label-input'
+                          type='text'
+                          placeholder='Customize label'
+                          defaultValue={config.table.downloadImageLabel}
+                          onChange={e => changeConfigValue('table', 'downloadImageLabel', e.target.value)}
+                        />
+                      )}
+                    </div>
+                  </div>
                 </div>
               </>
             )}

--- a/packages/dashboard/src/components/Header/Header.tsx
+++ b/packages/dashboard/src/components/Header/Header.tsx
@@ -256,17 +256,15 @@ const Header = (props: HeaderProps) => {
                       <option value='button'>Download Image Button</option>
                       <option value='link'>Download Image Link</option>
                     </select>
-                    <div className='download-image-label-slot'>
-                      {getDownloadImageMode() !== 'off' && (
-                        <input
-                          className='download-image-label-input'
-                          type='text'
-                          placeholder='Customize label'
-                          defaultValue={config.table.downloadImageLabel}
-                          onChange={e => changeConfigValue('table', 'downloadImageLabel', e.target.value)}
-                        />
-                      )}
-                    </div>
+                    {getDownloadImageMode() !== 'off' && (
+                      <input
+                        className='download-image-label-input'
+                        type='text'
+                        placeholder='Customize label'
+                        defaultValue={config.table.downloadImageLabel}
+                        onChange={e => changeConfigValue('table', 'downloadImageLabel', e.target.value)}
+                      />
+                    )}
                   </div>
                 </div>
               </>

--- a/packages/dashboard/src/components/Header/Header.tsx
+++ b/packages/dashboard/src/components/Header/Header.tsx
@@ -13,6 +13,8 @@ type HeaderProps = {
   visualizationKey?: string
 }
 
+type DownloadImageMode = 'off' | 'button' | 'link'
+
 const Header = (props: HeaderProps) => {
   const tabs: Tab[] = ['Dashboard Description', 'Data Table Settings', 'Dashboard Preview']
   const { visualizationKey, subEditor } = props
@@ -59,6 +61,18 @@ const Header = (props: HeaderProps) => {
     let newConfig = { ...config }
     if (!newConfig[parentObj]) newConfig[parentObj] = {}
     newConfig[parentObj][key] = value
+    dispatch({ type: 'UPDATE_CONFIG', payload: [newConfig] })
+  }
+
+  const getDownloadImageMode = (): DownloadImageMode => {
+    if (!config.table?.downloadImageButton) return 'off'
+    return config.table.downloadImageButtonStyle === 'link' ? 'link' : 'button'
+  }
+
+  const changeDownloadImageMode = (mode: DownloadImageMode) => {
+    const newConfig = { ...config, table: { ...(config.table || {}) } }
+    newConfig.table.downloadImageButton = mode !== 'off'
+    if (mode !== 'off') newConfig.table.downloadImageButtonStyle = mode
     dispatch({ type: 'UPDATE_CONFIG', payload: [newConfig] })
   }
 
@@ -231,16 +245,19 @@ const Header = (props: HeaderProps) => {
                     />
                     Show URL to Automatically Updated Data
                   </label>
-                  <label>
+                  <select
+                    aria-label='Download image display'
+                    className='download-image-mode-select'
+                    value={getDownloadImageMode()}
+                    onChange={e => changeDownloadImageMode(e.target.value as DownloadImageMode)}
+                  >
+                    <option value='off'>Download Image Off</option>
+                    <option value='button'>Download Image Button</option>
+                    <option value='link'>Download Image Link</option>
+                  </select>
+                  {getDownloadImageMode() !== 'off' && (
                     <input
-                      type='checkbox'
-                      defaultChecked={config.table.downloadImageButton}
-                      onChange={e => changeConfigValue('table', 'downloadImageButton', e.target.checked)}
-                    />
-                    Show Download Image Button
-                  </label>
-                  {config.table.downloadImageButton && (
-                    <input
+                      className='download-image-label-input'
                       type='text'
                       placeholder='Customize label'
                       defaultValue={config.table.downloadImageLabel}

--- a/packages/dashboard/src/scss/main.scss
+++ b/packages/dashboard/src/scss/main.scss
@@ -78,19 +78,17 @@ button.row-menu__btn[title*='Equal Height Rows'] {
           flex-basis: 100%;
         }
 
-        .download-image-mode-select,
-        .download-image-label-input {
+        .download-image-mode-select {
           width: 14em;
           max-width: 100%;
           height: 25px;
         }
 
-        .download-image-label-slot {
-          height: 30px;
-        }
-
         .download-image-label-input {
+          width: 14em;
+          max-width: 14em;
           margin-top: 5px;
+          height: 25px;
         }
 
         label {

--- a/packages/dashboard/src/scss/main.scss
+++ b/packages/dashboard/src/scss/main.scss
@@ -71,18 +71,26 @@ button.row-menu__btn[title*='Equal Height Rows'] {
           height: 25px;
         }
 
-        .download-image-mode-select {
+        .download-image-controls {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          flex-basis: 100%;
+        }
+
+        .download-image-mode-select,
+        .download-image-label-input {
           width: 14em;
           max-width: 100%;
           height: 25px;
         }
 
+        .download-image-label-slot {
+          height: 30px;
+        }
+
         .download-image-label-input {
-          flex-basis: 100%;
-          width: 14em;
-          max-width: 14em;
           margin-top: 5px;
-          height: 25px;
         }
 
         label {

--- a/packages/dashboard/src/scss/main.scss
+++ b/packages/dashboard/src/scss/main.scss
@@ -71,6 +71,20 @@ button.row-menu__btn[title*='Equal Height Rows'] {
           height: 25px;
         }
 
+        .download-image-mode-select {
+          width: 14em;
+          max-width: 100%;
+          height: 25px;
+        }
+
+        .download-image-label-input {
+          flex-basis: 100%;
+          width: 14em;
+          max-width: 14em;
+          margin-top: 5px;
+          height: 25px;
+        }
+
         label {
           display: block;
           width: 100%;


### PR DESCRIPTION
## Summary

Adds a new link styling for dashboard "Download Image" buttons.

## Testing Steps

Load a dashboard config or create a new one. Experiment with the new Download Image dropdown in the dashboard editor, under the "Data Table Settings" section.

* Existing dashboards without a download image button should still not have a button.
* Existing dashboards with the button turned on should continue to show a button.
* New dashboards should default to having no download image control.
* It should be possible to change any dashboard to use the link styling.