### PR TITLE
DEV-9267 Add map filter clear selection control

### DIFF
--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -84,6 +84,18 @@ export default function CdcDashboard({
   const [allExpanded, setAllExpanded] = useState(true)
   const [apiLoading, setAPILoading] = useState(false)
 
+  // Capture initial filter values at mount (before user interactions mutate filter.active)
+  const initialFilterValues = useMemo(() => {
+    const values: Record<string, string> = {}
+    for (const filter of initialState.config.dashboard?.sharedFilters || []) {
+      if (filter.setBy) {
+        const active = Array.isArray(filter.active) ? filter.active[0] : filter.active
+        values[filter.setBy] = filter.defaultValue || active || filter.values?.[0] || ''
+      }
+    }
+    return values
+  }, [])
+
   const isPreview = state.tabSelected === 'Dashboard Preview'
 
   const hasFiltersIncompleteCondition = useMemo(
@@ -333,6 +345,41 @@ export default function CdcDashboard({
     dispatch({ type: 'SET_SHARED_FILTERS', payload: newConfig.dashboard.sharedFilters })
   }
 
+  // Get the initial/reset value for a filter (captured at mount to avoid reading mutated state)
+  const getFilterInitialValue = (filter: SharedFilter): string => {
+    const key = filter.setBy || ''
+    return initialFilterValues[key] ?? filter.defaultValue ?? filter.values?.[0] ?? ''
+  }
+
+  const clearSharedFilter = (key: string) => {
+    const { config: newConfig, filteredData } = cloneDeep(state)
+
+    for (let i = 0; i < newConfig.dashboard.sharedFilters.length; i++) {
+      const filter = newConfig.dashboard.sharedFilters[i]
+      if (filter.setBy === key) {
+        filter.active = getFilterInitialValue(filter)
+        break
+      }
+    }
+
+    const newFilteredData = getFilteredData({ ...state, config: newConfig }, filteredData)
+
+    dispatch({ type: 'SET_FILTERED_DATA', payload: { filteredData: newFilteredData } })
+    dispatch({ type: 'SET_CONFIG', payload: newConfig })
+    dispatch({ type: 'SET_SHARED_FILTERS', payload: newConfig.dashboard.sharedFilters })
+  }
+
+  const hasActiveSharedFilter = (key: string): boolean => {
+    const filter = state.config.dashboard?.sharedFilters?.find(f => f.setBy === key)
+    if (!filter) return false
+
+    // Get the initial/default value for this filter
+    const initialValue = getFilterInitialValue(filter)
+
+    // Filter is "user-active" only if active differs from the initial value
+    return filter.active !== undefined && filter.active !== '' && filter.active !== initialValue
+  }
+
   const setEventData = ({ detail }, data, filteredData) => {
     try {
       const newDatasets = Object.keys(detail).reduce((acc, key) => {
@@ -495,6 +542,8 @@ export default function CdcDashboard({
               _updateConfig={_updateConfig}
               isDebug={isDebug}
               setSharedFilter={setSharedFilter}
+              clearSharedFilter={clearSharedFilter}
+              hasActiveSharedFilter={hasActiveSharedFilter}
               apiFilterDropdowns={apiFilterDropdowns}
               state={state}
               interactionLabel={interactionLabel}
@@ -563,6 +612,8 @@ export default function CdcDashboard({
                   row={row}
                   rowIndex={index}
                   setSharedFilter={setSharedFilter}
+                  clearSharedFilter={clearSharedFilter}
+                  hasActiveSharedFilter={hasActiveSharedFilter}
                   setAllExpanded={setAllExpanded}
                   updateChildConfig={updateChildConfig}
                   apiFilterDropdowns={apiFilterDropdowns}

--- a/packages/dashboard/src/components/DashboardEditors.tsx
+++ b/packages/dashboard/src/components/DashboardEditors.tsx
@@ -17,6 +17,8 @@ type DashboardEditorProps = {
   _updateConfig: (config: any) => void
   isDebug?: boolean
   setSharedFilter?: Function
+  clearSharedFilter?: (key: string) => void
+  hasActiveSharedFilter?: (key: string) => boolean
   apiFilterDropdowns?: APIFilterDropdowns
   state: DashboardState
   interactionLabel: string
@@ -28,6 +30,8 @@ const DashboardEditors: React.FC<DashboardEditorProps> = ({
   _updateConfig,
   isDebug,
   setSharedFilter,
+  clearSharedFilter,
+  hasActiveSharedFilter,
   apiFilterDropdowns,
   state,
   interactionLabel = ''
@@ -63,6 +67,10 @@ const DashboardEditors: React.FC<DashboardEditorProps> = ({
           isDebug={isDebug}
           setConfig={_updateConfig}
           setSharedFilter={setsSharedFilter ? setSharedFilter : undefined}
+          clearSharedFilter={setsSharedFilter ? clearSharedFilter : undefined}
+          hasActiveSharedFilter={
+            setsSharedFilter && hasActiveSharedFilter ? hasActiveSharedFilter(visualizationKey) : false
+          }
           setSharedFilterValue={setSharedFilterValue}
           isDashboard={true}
           showLoader={false}

--- a/packages/dashboard/src/components/VisualizationRow.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.tsx
@@ -70,6 +70,8 @@ type VizRowProps = {
   rowIndex: number
   inNoDataState: boolean
   setSharedFilter: Function
+  clearSharedFilter: (key: string) => void
+  hasActiveSharedFilter: (key: string) => boolean
   updateChildConfig: Function
   apiFilterDropdowns: APIFilterDropdowns
   currentViewport: ViewPort
@@ -86,6 +88,8 @@ const VisualizationRow: React.FC<VizRowProps> = ({
   rowIndex: index,
   inNoDataState,
   setSharedFilter,
+  clearSharedFilter,
+  hasActiveSharedFilter,
   updateChildConfig,
   apiFilterDropdowns,
   currentViewport,
@@ -462,6 +466,8 @@ const VisualizationRow: React.FC<VizRowProps> = ({
                   }}
                   showLoader={false}
                   setSharedFilter={setsSharedFilter ? setSharedFilter : undefined}
+                  clearSharedFilter={setsSharedFilter ? clearSharedFilter : undefined}
+                  hasActiveSharedFilter={setsSharedFilter ? hasActiveSharedFilter(resolvedWidget) : false}
                   setSharedFilterValue={setSharedFilterValue}
                   isDashboard={true}
                   link={link}

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -73,6 +73,7 @@ The following authorable data-loading fields are shared and documented in core: 
 | `general.displayAsHex` | `boolean` | No | `false` | Switches the US map to a hex-style treatment. | Works with `hexMap`. |
 | `general.equalNumberOptIn` | `boolean` | No | `false` | Enables the newer equal-number legend path. | Used when `legend.separateZero` and equal-number classification interact. |
 | `general.allowMapZoom` | `boolean` | No | `true` | Enables zooming on supported map types. | Disabled in some editor flows and unsupported map modes. |
+| `general.showClearSelectionButton` | `boolean` | No | `true` | Shows a Clear Selection control for dashboard maps that set a shared filter. | Only meaningful when the map is used inside a dashboard as a `setBy` control and a selection is currently active. Current runtime support is implemented for the U.S. map and other `ZoomControls`-backed map layouts. |
 | `general.hideGeoColumnInTooltip` | `boolean` | No | `false` | Hides the geography field name in tooltips. | `true`, `false` |
 | `general.hidePrimaryColumnInTooltip` | `boolean` | No | `false` | Hides the primary data field name in tooltips. | `true`, `false` |
 | `general.showDownloadImgButton` | `boolean` | No | `false` | Enables PNG/image download. | Editor-managed field. |

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -73,7 +73,7 @@ The following authorable data-loading fields are shared and documented in core: 
 | `general.displayAsHex` | `boolean` | No | `false` | Switches the US map to a hex-style treatment. | Works with `hexMap`. |
 | `general.equalNumberOptIn` | `boolean` | No | `false` | Enables the newer equal-number legend path. | Used when `legend.separateZero` and equal-number classification interact. |
 | `general.allowMapZoom` | `boolean` | No | `true` | Enables zooming on supported map types. | Disabled in some editor flows and unsupported map modes. |
-| `general.showClearSelectionButton` | `boolean` | No | `true` | Shows a Clear Selection control for dashboard maps that set a shared filter. | Only meaningful when the map is used inside a dashboard as a `setBy` control and a selection is currently active. Current runtime support is implemented for the U.S. map and other `ZoomControls`-backed map layouts. |
+| `general.showClearSelectionButton` | `boolean` | No | `true` | Shows a Clear Selection control for dashboard maps that set a shared filter. | Only meaningful when the map is used inside a dashboard as a `setBy` control and a selection is currently active. Current runtime support is implemented for the U.S. map. |
 | `general.hideGeoColumnInTooltip` | `boolean` | No | `false` | Hides the geography field name in tooltips. | `true`, `false` |
 | `general.hidePrimaryColumnInTooltip` | `boolean` | No | `false` | Hides the primary data field name in tooltips. | `true`, `false` |
 | `general.showDownloadImgButton` | `boolean` | No | `false` | Enables PNG/image download. | Editor-managed field. |

--- a/packages/map/src/CdcMapComponent.tsx
+++ b/packages/map/src/CdcMapComponent.tsx
@@ -95,6 +95,8 @@ type CdcMapComponent = {
   logo?: string
   navigationHandler: Function
   setSharedFilter: Function
+  clearSharedFilter?: (key: string) => void
+  hasActiveSharedFilter?: boolean
   setSharedFilterValue: Function
   setConfig?: Function
   loadConfig?: Function
@@ -109,6 +111,8 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
   isEditor = false,
   logo = '',
   setSharedFilter,
+  clearSharedFilter,
+  hasActiveSharedFilter = false,
   setSharedFilterValue,
   link,
   setConfig: setParentConfig,
@@ -434,6 +438,8 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
     setConfig,
     setFilteredStateCountyCode,
     setSharedFilter,
+    clearSharedFilter,
+    hasActiveSharedFilter,
     setSharedFilterValue,
     config,
     statesToShow,

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -3855,10 +3855,7 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                         <span className='edit-label'>Allow Map Zooming</span>
                       </label>
                     )}
-                    {(config.general.geoType === 'world' ||
-                      config.general.geoType === 'single-state' ||
-                      config.general.geoType === 'us-county' ||
-                      config.general.geoType === 'us') && (
+                    {config.general.geoType === 'us' && (
                       <label className='checkbox'>
                         <input
                           type='checkbox'

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -3855,6 +3855,23 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                         <span className='edit-label'>Allow Map Zooming</span>
                       </label>
                     )}
+                    {(config.general.geoType === 'world' ||
+                      config.general.geoType === 'single-state' ||
+                      config.general.geoType === 'us-county' ||
+                      config.general.geoType === 'us') && (
+                      <label className='checkbox'>
+                        <input
+                          type='checkbox'
+                          checked={config.general.showClearSelectionButton !== false}
+                          onChange={event => {
+                            const _newConfig = cloneConfig(config)
+                            _newConfig.general.showClearSelectionButton = event.target.checked
+                            setConfig(_newConfig)
+                          }}
+                        />
+                        <span className='edit-label'>Show Clear Selection Button</span>
+                      </label>
+                    )}
                     {config.general.type === 'bubble' && (
                       <label className='checkbox'>
                         <input

--- a/packages/map/src/components/FilterControls.tsx
+++ b/packages/map/src/components/FilterControls.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import ConfigContext from '../context'
 import { MapContext } from '../types/MapContext'
-import './zoomControls.styles.css'
+import './filterControls.styles.css'
 
 const FilterControls: React.FC = () => {
   const { config, clearSharedFilter, hasActiveSharedFilter } = useContext<MapContext>(ConfigContext)
@@ -10,8 +10,8 @@ const FilterControls: React.FC = () => {
   if (!hasActiveSharedFilter || !clearSharedFilter) return null
 
   return (
-    <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
-      <button onClick={() => clearSharedFilter(config.uid)} className='reset' aria-label='Clear Selection'>
+    <div className='filter-controls' data-html2canvas-ignore='true'>
+      <button className='cove-button' onClick={() => clearSharedFilter(config.uid)} aria-label='Clear Selection'>
         Clear Selection
       </button>
     </div>

--- a/packages/map/src/components/FilterControls.tsx
+++ b/packages/map/src/components/FilterControls.tsx
@@ -1,0 +1,21 @@
+import React, { useContext } from 'react'
+import ConfigContext from '../context'
+import { MapContext } from '../types/MapContext'
+import './zoomControls.styles.css'
+
+const FilterControls: React.FC = () => {
+  const { config, clearSharedFilter, hasActiveSharedFilter } = useContext<MapContext>(ConfigContext)
+
+  if (config.general.showClearSelectionButton === false) return null
+  if (!hasActiveSharedFilter || !clearSharedFilter) return null
+
+  return (
+    <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
+      <button onClick={() => clearSharedFilter(config.uid)} className='reset' aria-label='Clear Selection'>
+        Clear Selection
+      </button>
+    </div>
+  )
+}
+
+export default FilterControls

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -20,6 +20,7 @@ import HexIcon from './HexIcon'
 import { patternSizes } from '../helpers/patternSizes'
 import Annotation from '../../Annotation'
 import Territory from './Territory'
+import ZoomControls from '../../ZoomControls'
 
 import ConfigContext, { MapDispatchContext } from '../../../context'
 import { useLegendMemoContext } from '../../../context/LegendMemoContext'
@@ -88,7 +89,9 @@ const UsaMap = () => {
     dimensions,
     translate,
     runtimeLegend,
-    interactionLabel
+    interactionLabel,
+    clearSharedFilter,
+    hasActiveSharedFilter
   } = useContext<MapContext>(ConfigContext)
 
   const a11y = handleMapAriaLabels(config)
@@ -682,6 +685,8 @@ const UsaMap = () => {
         )}
         {annotations?.length > 0 && <Annotation.Draggable onDragStateChange={handleDragStateChange} />}
       </svg>
+
+      <ZoomControls clearSelectionOnly />
 
       <TerritoriesSection territories={territories} logo={logo} config={config} territoriesData={territoriesData} />
     </ErrorBoundary>

--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -20,7 +20,7 @@ import HexIcon from './HexIcon'
 import { patternSizes } from '../helpers/patternSizes'
 import Annotation from '../../Annotation'
 import Territory from './Territory'
-import ZoomControls from '../../ZoomControls'
+import FilterControls from '../../FilterControls'
 
 import ConfigContext, { MapDispatchContext } from '../../../context'
 import { useLegendMemoContext } from '../../../context/LegendMemoContext'
@@ -686,7 +686,7 @@ const UsaMap = () => {
         {annotations?.length > 0 && <Annotation.Draggable onDragStateChange={handleDragStateChange} />}
       </svg>
 
-      <ZoomControls clearSelectionOnly />
+      <FilterControls />
 
       <TerritoriesSection territories={territories} logo={logo} config={config} territoriesData={territoriesData} />
     </ErrorBoundary>

--- a/packages/map/src/components/ZoomControls.tsx
+++ b/packages/map/src/components/ZoomControls.tsx
@@ -1,18 +1,60 @@
 import React, { useContext } from 'react'
 import ConfigContext from '../context'
-import { type MapConfig } from '../types/MapConfig'
 import { MapContext } from '../types/MapContext'
 import './zoomControls.styles.css'
 
 type ZoomControlsProps = {
-  handleZoomIn: (coordinates: [Number, Number]) => void
-  handleZoomOut: (coordinates: [Number, Number]) => void
-  handleZoomReset: (setRuntimeData: Function) => void
+  handleZoomIn?: (coordinates: [Number, Number]) => void
+  handleZoomOut?: (coordinates: [Number, Number]) => void
+  handleZoomReset?: (setRuntimeData: Function) => void
+  /** When true, only renders the Clear Selection button (no zoom controls) */
+  clearSelectionOnly?: boolean
 }
 
-const ZoomControls: React.FC<ZoomControlsProps> = ({ handleZoomIn, handleZoomOut, handleZoomReset }) => {
-  const { config, setRuntimeData, position } = useContext<MapContext>(ConfigContext)
-  if (!config.general.allowMapZoom) return
+const ZoomControls: React.FC<ZoomControlsProps> = ({
+  handleZoomIn,
+  handleZoomOut,
+  handleZoomReset,
+  clearSelectionOnly = false
+}) => {
+  const { config, setRuntimeData, position, clearSharedFilter, hasActiveSharedFilter } =
+    useContext<MapContext>(ConfigContext)
+
+  const handleClearSelection = () => {
+    if (clearSharedFilter && config.uid) {
+      clearSharedFilter(config.uid)
+    }
+  }
+
+  // Respect the showClearSelectionButton editor setting (defaults to true)
+  const showClearSelection =
+    config.general.showClearSelectionButton !== false && hasActiveSharedFilter && clearSharedFilter
+
+  // When clearSelectionOnly mode, only show clear selection button (no zoom needed)
+  if (clearSelectionOnly) {
+    if (!showClearSelection) return null
+    return (
+      <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
+        <button onClick={handleClearSelection} className='reset' aria-label='Clear Selection'>
+          Clear Selection
+        </button>
+      </div>
+    )
+  }
+
+  // Below this point, zoom handlers are required
+  if (!handleZoomIn || !handleZoomOut) return null
+
+  if (!config.general.allowMapZoom) {
+    if (!showClearSelection) return null
+    return (
+      <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
+        <button onClick={handleClearSelection} className='reset' aria-label='Clear Selection'>
+          Clear Selection
+        </button>
+      </div>
+    )
+  }
 
   const isUsGeocodeMap = config.general.type === 'us-geocode'
   const shouldShowUsGeocodeReset = isUsGeocodeMap && position.zoom > 1
@@ -20,24 +62,33 @@ const ZoomControls: React.FC<ZoomControlsProps> = ({ handleZoomIn, handleZoomOut
 
   if (!isUsGeocodeMap) {
     return (
-      <div className='zoom-controls' data-html2canvas-ignore='true'>
-        <button onClick={() => handleZoomIn(position)} aria-label='Zoom In'>
-          <svg viewBox='0 0 24 24' stroke='currentColor' strokeWidth='3'>
-            <line x1='12' y1='5' x2='12' y2='19' />
-            <line x1='5' y1='12' x2='19' y2='12' />
-          </svg>
-        </button>
-        <button onClick={() => handleZoomOut(position)} aria-label='Zoom Out'>
-          <svg viewBox='0 0 24 24' stroke='currentColor' strokeWidth='3'>
-            <line x1='5' y1='12' x2='19' y2='12' />
-          </svg>
-        </button>
-        {shouldShowBottomReset && (
-          <button onClick={() => handleZoomReset(setRuntimeData)} className='reset' aria-label='Reset Zoom'>
-            Reset Zoom
+      <>
+        <div className='zoom-controls' data-html2canvas-ignore='true'>
+          <button onClick={() => handleZoomIn(position)} aria-label='Zoom In'>
+            <svg viewBox='0 0 24 24' stroke='currentColor' strokeWidth='3'>
+              <line x1='12' y1='5' x2='12' y2='19' />
+              <line x1='5' y1='12' x2='19' y2='12' />
+            </svg>
           </button>
+          <button onClick={() => handleZoomOut(position)} aria-label='Zoom Out'>
+            <svg viewBox='0 0 24 24' stroke='currentColor' strokeWidth='3'>
+              <line x1='5' y1='12' x2='19' y2='12' />
+            </svg>
+          </button>
+          {shouldShowBottomReset && handleZoomReset && (
+            <button onClick={() => handleZoomReset(setRuntimeData)} className='reset' aria-label='Reset Zoom'>
+              Reset Zoom
+            </button>
+          )}
+        </div>
+        {showClearSelection && (
+          <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
+            <button onClick={handleClearSelection} className='reset' aria-label='Clear Selection'>
+              Clear Selection
+            </button>
+          </div>
         )}
-      </div>
+      </>
     )
   }
 
@@ -57,13 +108,18 @@ const ZoomControls: React.FC<ZoomControlsProps> = ({ handleZoomIn, handleZoomOut
         </button>
       </div>
 
-      {shouldShowUsGeocodeReset && (
-        <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
+      <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
+        {shouldShowUsGeocodeReset && handleZoomReset && (
           <button onClick={() => handleZoomReset(setRuntimeData)} className='reset' aria-label='Reset Zoom'>
             Reset Zoom
           </button>
-        </div>
-      )}
+        )}
+        {showClearSelection && (
+          <button onClick={handleClearSelection} className='reset' aria-label='Clear Selection'>
+            Clear Selection
+          </button>
+        )}
+      </div>
     </>
   )
 }

--- a/packages/map/src/components/ZoomControls.tsx
+++ b/packages/map/src/components/ZoomControls.tsx
@@ -1,60 +1,18 @@
 import React, { useContext } from 'react'
 import ConfigContext from '../context'
+import { type MapConfig } from '../types/MapConfig'
 import { MapContext } from '../types/MapContext'
 import './zoomControls.styles.css'
 
 type ZoomControlsProps = {
-  handleZoomIn?: (coordinates: [Number, Number]) => void
-  handleZoomOut?: (coordinates: [Number, Number]) => void
-  handleZoomReset?: (setRuntimeData: Function) => void
-  /** When true, only renders the Clear Selection button (no zoom controls) */
-  clearSelectionOnly?: boolean
+  handleZoomIn: (coordinates: [Number, Number]) => void
+  handleZoomOut: (coordinates: [Number, Number]) => void
+  handleZoomReset: (setRuntimeData: Function) => void
 }
 
-const ZoomControls: React.FC<ZoomControlsProps> = ({
-  handleZoomIn,
-  handleZoomOut,
-  handleZoomReset,
-  clearSelectionOnly = false
-}) => {
-  const { config, setRuntimeData, position, clearSharedFilter, hasActiveSharedFilter } =
-    useContext<MapContext>(ConfigContext)
-
-  const handleClearSelection = () => {
-    if (clearSharedFilter && config.uid) {
-      clearSharedFilter(config.uid)
-    }
-  }
-
-  // Respect the showClearSelectionButton editor setting (defaults to true)
-  const showClearSelection =
-    config.general.showClearSelectionButton !== false && hasActiveSharedFilter && clearSharedFilter
-
-  // When clearSelectionOnly mode, only show clear selection button (no zoom needed)
-  if (clearSelectionOnly) {
-    if (!showClearSelection) return null
-    return (
-      <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
-        <button onClick={handleClearSelection} className='reset' aria-label='Clear Selection'>
-          Clear Selection
-        </button>
-      </div>
-    )
-  }
-
-  // Below this point, zoom handlers are required
-  if (!handleZoomIn || !handleZoomOut) return null
-
-  if (!config.general.allowMapZoom) {
-    if (!showClearSelection) return null
-    return (
-      <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
-        <button onClick={handleClearSelection} className='reset' aria-label='Clear Selection'>
-          Clear Selection
-        </button>
-      </div>
-    )
-  }
+const ZoomControls: React.FC<ZoomControlsProps> = ({ handleZoomIn, handleZoomOut, handleZoomReset }) => {
+  const { config, setRuntimeData, position } = useContext<MapContext>(ConfigContext)
+  if (!config.general.allowMapZoom) return
 
   const isUsGeocodeMap = config.general.type === 'us-geocode'
   const shouldShowUsGeocodeReset = isUsGeocodeMap && position.zoom > 1
@@ -62,33 +20,24 @@ const ZoomControls: React.FC<ZoomControlsProps> = ({
 
   if (!isUsGeocodeMap) {
     return (
-      <>
-        <div className='zoom-controls' data-html2canvas-ignore='true'>
-          <button onClick={() => handleZoomIn(position)} aria-label='Zoom In'>
-            <svg viewBox='0 0 24 24' stroke='currentColor' strokeWidth='3'>
-              <line x1='12' y1='5' x2='12' y2='19' />
-              <line x1='5' y1='12' x2='19' y2='12' />
-            </svg>
+      <div className='zoom-controls' data-html2canvas-ignore='true'>
+        <button onClick={() => handleZoomIn(position)} aria-label='Zoom In'>
+          <svg viewBox='0 0 24 24' stroke='currentColor' strokeWidth='3'>
+            <line x1='12' y1='5' x2='12' y2='19' />
+            <line x1='5' y1='12' x2='19' y2='12' />
+          </svg>
+        </button>
+        <button onClick={() => handleZoomOut(position)} aria-label='Zoom Out'>
+          <svg viewBox='0 0 24 24' stroke='currentColor' strokeWidth='3'>
+            <line x1='5' y1='12' x2='19' y2='12' />
+          </svg>
+        </button>
+        {shouldShowBottomReset && (
+          <button onClick={() => handleZoomReset(setRuntimeData)} className='reset' aria-label='Reset Zoom'>
+            Reset Zoom
           </button>
-          <button onClick={() => handleZoomOut(position)} aria-label='Zoom Out'>
-            <svg viewBox='0 0 24 24' stroke='currentColor' strokeWidth='3'>
-              <line x1='5' y1='12' x2='19' y2='12' />
-            </svg>
-          </button>
-          {shouldShowBottomReset && handleZoomReset && (
-            <button onClick={() => handleZoomReset(setRuntimeData)} className='reset' aria-label='Reset Zoom'>
-              Reset Zoom
-            </button>
-          )}
-        </div>
-        {showClearSelection && (
-          <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
-            <button onClick={handleClearSelection} className='reset' aria-label='Clear Selection'>
-              Clear Selection
-            </button>
-          </div>
         )}
-      </>
+      </div>
     )
   }
 
@@ -108,18 +57,13 @@ const ZoomControls: React.FC<ZoomControlsProps> = ({
         </button>
       </div>
 
-      <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
-        {shouldShowUsGeocodeReset && handleZoomReset && (
+      {shouldShowUsGeocodeReset && (
+        <div className='zoom-controls zoom-controls--top-right' data-html2canvas-ignore='true'>
           <button onClick={() => handleZoomReset(setRuntimeData)} className='reset' aria-label='Reset Zoom'>
             Reset Zoom
           </button>
-        )}
-        {showClearSelection && (
-          <button onClick={handleClearSelection} className='reset' aria-label='Clear Selection'>
-            Clear Selection
-          </button>
-        )}
-      </div>
+        </div>
+      )}
     </>
   )
 }

--- a/packages/map/src/components/filterControls.styles.css
+++ b/packages/map/src/components/filterControls.styles.css
@@ -1,0 +1,6 @@
+.filter-controls {
+  bottom: 1em;
+  position: absolute;
+  right: 1em;
+  z-index: 4;
+}

--- a/packages/map/src/hooks/useGeoClickHandler.ts
+++ b/packages/map/src/hooks/useGeoClickHandler.ts
@@ -9,6 +9,9 @@ const useGeoClickHandler = () => {
     config: state,
     setConfig,
     setSharedFilter,
+    clearSharedFilter,
+    hasActiveSharedFilter,
+    setSharedFilterValue,
     customNavigationHandler,
     interactionLabel
   } = useContext(ConfigContext)
@@ -16,7 +19,16 @@ const useGeoClickHandler = () => {
 
   const geoClickHandler = (geoDisplayName: string, geoData: object): void => {
     if (setSharedFilter) {
-      setSharedFilter(state.uid, geoData)
+      // Get the column name for the filter (from dashboardFilters config)
+      const filterColumnName = state.dashboardFilters?.[0]?.columnName || state.columns?.geo?.name
+      const clickedValue = filterColumnName ? geoData[filterColumnName] : geoDisplayName
+
+      // Toggle behavior: if the clicked value matches the current filter value, clear it
+      if (hasActiveSharedFilter && setSharedFilterValue === clickedValue && clearSharedFilter) {
+        clearSharedFilter(state.uid)
+      } else {
+        setSharedFilter(state.uid, geoData)
+      }
     }
 
     // If world-geocode map zoom to geo point

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -134,6 +134,7 @@ export type MapConfig = Visualization & {
     subtext: string
     introText: string
     allowMapZoom: boolean
+    showClearSelectionButton?: boolean
     convertFipsCodes: boolean
     displayAsHex: boolean
     displayStateLabels: boolean

--- a/packages/map/src/types/MapContext.ts
+++ b/packages/map/src/types/MapContext.ts
@@ -40,6 +40,9 @@ export type MapContext = {
   setParentConfig: Function
   setRuntimeData: Function
   setFilteredStateCountyCode: (stateCode: string, countyCode?: string) => void
+  setSharedFilter?: Function
+  clearSharedFilter?: (key: string) => void
+  hasActiveSharedFilter?: boolean
   setSharedFilterValue: Function
   setConfig: (newState: MapConfig) => MapConfig
   config: MapConfig


### PR DESCRIPTION
## Summary
When the US map is used for filtering a dashboard, user is now able to select and deselect the same state to clear a selection. In addition, utilizes the zoom controls "clear selection" button as an optional button thats on by default that also clears the selection.

## Testing Steps
Dashboard with us map as filter (a config is available on the DEV-9267 ticket)
