### PR TITLE
DEV-11560 Dashboard filter apply with defaults bug

### DIFF
--- a/packages/dashboard/examples/us-map-filter-example.json
+++ b/packages/dashboard/examples/us-map-filter-example.json
@@ -1,0 +1,1074 @@
+{
+    "dashboard": {
+        "theme": "theme-blue",
+        "titleStyle": "small",
+        "sharedFilters": [
+            {
+                "key": "New Dashboard Filter 1",
+                "showDropdown": true,
+                "values": [
+                    "Alabama",
+                    "Alaska",
+                    "American Samoa",
+                    "Arizona",
+                    "Arkansas",
+                    "California",
+                    "Colorado",
+                    "Connecticut",
+                    "DC",
+                    "Delaware",
+                    "Florida",
+                    "Georgia",
+                    "Guam",
+                    "Hawaii",
+                    "Idaho",
+                    "Illinois",
+                    "Indiana",
+                    "Iowa",
+                    "Kansas",
+                    "Kentucky",
+                    "Louisiana",
+                    "Maine",
+                    "Marshall Islands",
+                    "Maryland",
+                    "Massachusetts",
+                    "Michigan",
+                    "Micronesia",
+                    "Minnesota",
+                    "Mississippi",
+                    "Montana",
+                    "Nebraska",
+                    "Nevada",
+                    "New Hampshire",
+                    "New Jersey",
+                    "New Mexico",
+                    "New York",
+                    "North Carolina",
+                    "North Dakota",
+                    "Northern Mariana Islands",
+                    "Ohio",
+                    "Oklahoma",
+                    "Oregon",
+                    "Overall",
+                    "Palau",
+                    "Pennsylvania",
+                    "Puerto Rico",
+                    "Rhode Island",
+                    "South Carolina",
+                    "South Dakota",
+                    "Tennessee",
+                    "Texas",
+                    "Utah",
+                    "Vermont",
+                    "Virgin Islands",
+                    "Virginia",
+                    "Washington",
+                    "West Virginia",
+                    "Wyoming"
+                ],
+                "type": "datafilter",
+                "orderedValues": [
+                    "Alabama",
+                    "Alaska",
+                    "American Samoa",
+                    "Arizona",
+                    "Arkansas",
+                    "California",
+                    "Colorado",
+                    "Connecticut",
+                    "DC",
+                    "Delaware",
+                    "Florida",
+                    "Georgia",
+                    "Guam",
+                    "Hawaii",
+                    "Idaho",
+                    "Illinois",
+                    "Indiana",
+                    "Iowa",
+                    "Kansas",
+                    "Kentucky",
+                    "Louisiana",
+                    "Maine",
+                    "Marshall Islands",
+                    "Maryland",
+                    "Massachusetts",
+                    "Michigan",
+                    "Micronesia",
+                    "Minnesota",
+                    "Mississippi",
+                    "Montana",
+                    "Nebraska",
+                    "Nevada",
+                    "New Hampshire",
+                    "New Jersey",
+                    "New Mexico",
+                    "New York",
+                    "North Carolina",
+                    "North Dakota",
+                    "Northern Mariana Islands",
+                    "Ohio",
+                    "Oklahoma",
+                    "Oregon",
+                    "Overall",
+                    "Palau",
+                    "Pennsylvania",
+                    "Puerto Rico",
+                    "Rhode Island",
+                    "South Carolina",
+                    "South Dakota",
+                    "Tennessee",
+                    "Texas",
+                    "Utah",
+                    "Vermont",
+                    "Virgin Islands",
+                    "Virginia",
+                    "Washington",
+                    "West Virginia",
+                    "Wyoming"
+                ],
+                "columnName": "STATE",
+                "defaultValue": "Overall",
+                "tier": 1,
+                "setBy": "map1777995471040",
+                "usedBy": [
+                    "data-bite1777995487417"
+                ]
+            }
+        ]
+    },
+    "rows": [
+        {
+            "columns": [
+                {
+                    "width": 12,
+                    "widget": "data-bite1777995487417"
+                }
+            ],
+            "uuid": "row-pp0v3qzq"
+        },
+        {
+            "columns": [
+                {
+                    "width": 12,
+                    "widget": "dashboardFilters1777995447009"
+                }
+            ],
+            "uuid": "row-bi6feaxu"
+        },
+        {
+            "columns": [
+                {
+                    "width": 12,
+                    "widget": "map1777995471040"
+                }
+            ],
+            "uuid": "row-lflllmwn"
+        }
+    ],
+    "visualizations": {
+        "dashboardFilters1777995447009": {
+            "filters": [],
+            "filterBehavior": "Apply Button",
+            "newViz": true,
+            "openModal": true,
+            "uid": "dashboardFilters1777995447009",
+            "type": "dashboardFilters",
+            "sharedFilterIndexes": [
+                0
+            ],
+            "visualizationType": "dashboardFilters",
+            "showEditorPanel": false,
+            "dataMetadata": {},
+            "dashboardFilters": [
+                {
+                    "columnName": "STATE",
+                    "active": "Overall",
+                    "values": [
+                        "Alabama",
+                        "Alaska",
+                        "American Samoa",
+                        "Arizona",
+                        "Arkansas",
+                        "California",
+                        "Colorado",
+                        "Connecticut",
+                        "DC",
+                        "Delaware",
+                        "Florida",
+                        "Georgia",
+                        "Guam",
+                        "Hawaii",
+                        "Idaho",
+                        "Illinois",
+                        "Indiana",
+                        "Iowa",
+                        "Kansas",
+                        "Kentucky",
+                        "Louisiana",
+                        "Maine",
+                        "Marshall Islands",
+                        "Maryland",
+                        "Massachusetts",
+                        "Michigan",
+                        "Micronesia",
+                        "Minnesota",
+                        "Mississippi",
+                        "Montana",
+                        "Nebraska",
+                        "Nevada",
+                        "New Hampshire",
+                        "New Jersey",
+                        "New Mexico",
+                        "New York",
+                        "North Carolina",
+                        "North Dakota",
+                        "Northern Mariana Islands",
+                        "Ohio",
+                        "Oklahoma",
+                        "Oregon",
+                        "Overall",
+                        "Palau",
+                        "Pennsylvania",
+                        "Puerto Rico",
+                        "Rhode Island",
+                        "South Carolina",
+                        "South Dakota",
+                        "Tennessee",
+                        "Texas",
+                        "Utah",
+                        "Vermont",
+                        "Virgin Islands",
+                        "Virginia",
+                        "Washington",
+                        "West Virginia",
+                        "Wyoming"
+                    ]
+                }
+            ],
+            "filterIntro": "Choose a state:",
+            "applyFiltersButtonText": "Apply"
+        },
+        "map1777995471040": {
+            "annotations": [],
+            "general": {
+                "navigationTarget": "_self",
+                "annotationDropdownText": "Annotations",
+                "geoBorderColor": "darkGray",
+                "headerColor": "theme-blue",
+                "title": "",
+                "showTitle": true,
+                "titleStyle": "small",
+                "showSidebar": true,
+                "showDownloadMediaButton": false,
+                "displayAsHex": false,
+                "displayStateLabels": true,
+                "territoriesAlwaysShow": false,
+                "language": "en",
+                "geoType": "us",
+                "geoLabelOverride": "",
+                "hasRegions": false,
+                "fullBorder": false,
+                "type": "data",
+                "convertFipsCodes": true,
+                "palette": {
+                    "isReversed": false,
+                    "name": "sequential_blue",
+                    "version": "2.0"
+                },
+                "allowMapZoom": true,
+                "hideGeoColumnInTooltip": false,
+                "hidePrimaryColumnInTooltip": false,
+                "hideUnselectedStates": true,
+                "statesPicked": []
+            },
+            "type": "map",
+            "columns": {
+                "geo": {
+                    "name": "STATE",
+                    "label": "Location",
+                    "tooltip": false,
+                    "dataTable": true,
+                    "displayColumn": ""
+                },
+                "primary": {
+                    "dataTable": true,
+                    "tooltip": true,
+                    "prefix": "",
+                    "suffix": "",
+                    "name": "Rate",
+                    "label": "Rate",
+                    "roundToPlace": 0
+                },
+                "navigate": {
+                    "name": ""
+                },
+                "latitude": {
+                    "name": ""
+                },
+                "longitude": {
+                    "name": ""
+                }
+            },
+            "legend": {
+                "descriptions": {},
+                "specialClasses": [],
+                "unified": false,
+                "singleColumn": false,
+                "singleRow": false,
+                "verticalSorted": false,
+                "showSpecialClassesLast": false,
+                "dynamicDescription": false,
+                "type": "equalnumber",
+                "numberOfItems": 5,
+                "position": "top",
+                "title": "",
+                "style": "gradient",
+                "subStyle": "linear blocks",
+                "tickRotation": "",
+                "singleColumnLegend": false,
+                "hideBorder": true,
+                "groupBy": ""
+            },
+            "filters": [],
+            "table": {
+                "wrapColumns": false,
+                "label": "Data Table",
+                "expanded": false,
+                "limitHeight": false,
+                "height": "",
+                "caption": "",
+                "showDownloadUrl": false,
+                "downloadUrlLabel": "",
+                "showDataTableLink": true,
+                "showDownloadLinkBelow": true,
+                "showFullGeoNameInCSV": false,
+                "forceDisplay": true,
+                "download": false,
+                "indexLabel": "",
+                "cellMinWidth": "0",
+                "collapsible": true,
+                "sharedFilterColumns": [
+                    "STATE"
+                ]
+            },
+            "tooltips": {
+                "appearanceType": "hover",
+                "linkLabel": "Learn More",
+                "opacity": 90
+            },
+            "visual": {
+                "border": false,
+                "borderColorTheme": false,
+                "accent": false,
+                "background": false,
+                "hideBackgroundColor": false,
+                "tp5Treatment": false,
+                "tp5Background": false,
+                "minBubbleSize": 1,
+                "maxBubbleSize": 20,
+                "extraBubbleBorder": false,
+                "cityStyle": "circle",
+                "cityStyleLabel": "",
+                "showBubbleZeros": false,
+                "additionalCityStyles": [],
+                "geoCodeCircleSize": 8
+            },
+            "mapPosition": {
+                "coordinates": [
+                    0,
+                    30
+                ],
+                "zoom": 1
+            },
+            "map": {
+                "layers": [],
+                "patterns": []
+            },
+            "hexMap": {
+                "type": "",
+                "shapeGroups": [
+                    {
+                        "legendTitle": "",
+                        "legendDescription": "",
+                        "items": [
+                            {
+                                "key": "",
+                                "shape": "Arrow Up",
+                                "column": "",
+                                "operator": "=",
+                                "value": ""
+                            }
+                        ]
+                    }
+                ]
+            },
+            "filterBehavior": "Filter Change",
+            "filterIntro": "",
+            "smallMultiples": {
+                "mode": "",
+                "tileColumn": "",
+                "tilesPerRowDesktop": 2,
+                "tilesPerRowMobile": 1,
+                "tileOrderType": "asc",
+                "tileOrder": [],
+                "tileTitles": {},
+                "synchronizedTooltips": true
+            },
+            "markupVariables": [],
+            "enableMarkupVariables": false,
+            "openModal": true,
+            "uid": "map1777995471040",
+            "dataDescription": {
+                "horizontal": false,
+                "series": false
+            },
+            "dataKey": "valid-data-map.csv",
+            "showEditorPanel": false,
+            "dashboardFilters": [
+                {
+                    "columnName": "STATE",
+                    "active": "Overall",
+                    "values": [
+                        "Alabama",
+                        "Alaska",
+                        "American Samoa",
+                        "Arizona",
+                        "Arkansas",
+                        "California",
+                        "Colorado",
+                        "Connecticut",
+                        "DC",
+                        "Delaware",
+                        "Florida",
+                        "Georgia",
+                        "Guam",
+                        "Hawaii",
+                        "Idaho",
+                        "Illinois",
+                        "Indiana",
+                        "Iowa",
+                        "Kansas",
+                        "Kentucky",
+                        "Louisiana",
+                        "Maine",
+                        "Marshall Islands",
+                        "Maryland",
+                        "Massachusetts",
+                        "Michigan",
+                        "Micronesia",
+                        "Minnesota",
+                        "Mississippi",
+                        "Montana",
+                        "Nebraska",
+                        "Nevada",
+                        "New Hampshire",
+                        "New Jersey",
+                        "New Mexico",
+                        "New York",
+                        "North Carolina",
+                        "North Dakota",
+                        "Northern Mariana Islands",
+                        "Ohio",
+                        "Oklahoma",
+                        "Oregon",
+                        "Overall",
+                        "Palau",
+                        "Pennsylvania",
+                        "Puerto Rico",
+                        "Rhode Island",
+                        "South Carolina",
+                        "South Dakota",
+                        "Tennessee",
+                        "Texas",
+                        "Utah",
+                        "Vermont",
+                        "Virgin Islands",
+                        "Virginia",
+                        "Washington",
+                        "West Virginia",
+                        "Wyoming"
+                    ]
+                }
+            ],
+            "dataMetadata": {}
+        },
+        "data-bite1777995487417": {
+            "type": "data-bite",
+            "dataBite": "",
+            "dataFunction": "Median",
+            "dataColumn": "Rate",
+            "bitePosition": "Left",
+            "biteFontSize": 24,
+            "fontSize": "medium",
+            "biteBody": "This is data for {{state}}",
+            "imageData": {
+                "display": "none",
+                "url": "",
+                "alt": "",
+                "options": []
+            },
+            "dataFormat": {
+                "roundToPlace": 0,
+                "commas": true,
+                "prefix": "",
+                "suffix": "%"
+            },
+            "biteStyle": "tp5",
+            "filters": [],
+            "subtext": "",
+            "title": "",
+            "theme": "theme-blue",
+            "shadow": false,
+            "visual": {
+                "border": true,
+                "accent": false,
+                "background": false,
+                "hideBackgroundColor": false,
+                "borderColorTheme": false,
+                "showTitle": true,
+                "useWrap": false,
+                "whiteBackground": true
+            },
+            "general": {
+                "palette": {
+                    "version": "1.0",
+                    "backups": [
+                        {
+                            "version": "1.0"
+                        },
+                        {
+                            "version": "1.0"
+                        }
+                    ]
+                },
+                "isCompactStyle": false
+            },
+            "trendIndicator": {
+                "mode": null,
+                "column": "",
+                "numericThreshold": 0,
+                "mappings": [],
+                "showNoChangeArrows": false,
+                "upLabel": "",
+                "downLabel": "",
+                "noChangeLabel": "",
+                "trendLabel": ""
+            },
+            "dataColors": {
+                "column": "",
+                "mappings": []
+            },
+            "markupVariables": [
+                {
+                    "sourceType": "column",
+                    "name": "STATE",
+                    "tag": "{{state}}",
+                    "columnName": "STATE",
+                    "conditions": [],
+                    "addCommas": false,
+                    "hideOnNull": false,
+                    "outputType": "value"
+                }
+            ],
+            "enableMarkupVariables": true,
+            "filterBehavior": "Filter Change",
+            "openModal": true,
+            "uid": "data-bite1777995487417",
+            "visualizationType": "data-bite",
+            "dataDescription": {
+                "horizontal": false,
+                "series": false
+            },
+            "dataKey": "valid-data-map.csv",
+            "showEditorPanel": false,
+            "dashboardFilters": [
+                {
+                    "columnName": "STATE",
+                    "active": "North Dakota",
+                    "values": [
+                        "Alabama",
+                        "Alaska",
+                        "American Samoa",
+                        "Arizona",
+                        "Arkansas",
+                        "California",
+                        "Colorado",
+                        "Connecticut",
+                        "DC",
+                        "Delaware",
+                        "Florida",
+                        "Georgia",
+                        "Guam",
+                        "Hawaii",
+                        "Idaho",
+                        "Illinois",
+                        "Indiana",
+                        "Iowa",
+                        "Kansas",
+                        "Kentucky",
+                        "Louisiana",
+                        "Maine",
+                        "Marshall Islands",
+                        "Maryland",
+                        "Massachusetts",
+                        "Michigan",
+                        "Micronesia",
+                        "Minnesota",
+                        "Mississippi",
+                        "Montana",
+                        "Nebraska",
+                        "Nevada",
+                        "New Hampshire",
+                        "New Jersey",
+                        "New Mexico",
+                        "New York",
+                        "North Carolina",
+                        "North Dakota",
+                        "Northern Mariana Islands",
+                        "Ohio",
+                        "Oklahoma",
+                        "Oregon",
+                        "Overall",
+                        "Palau",
+                        "Pennsylvania",
+                        "Puerto Rico",
+                        "Rhode Island",
+                        "South Carolina",
+                        "South Dakota",
+                        "Tennessee",
+                        "Texas",
+                        "Utah",
+                        "Vermont",
+                        "Virgin Islands",
+                        "Virginia",
+                        "Washington",
+                        "West Virginia",
+                        "Wyoming"
+                    ]
+                }
+            ],
+            "dataMetadata": {},
+            "version": "4.26.4-1",
+            "migrations": {
+                "addColorMigration": true
+            },
+            "locale": "en-US"
+        }
+    },
+    "table": {
+        "label": "Data Table",
+        "show": true,
+        "showDownloadUrl": false,
+        "downloadUrlLabel": "",
+        "showDownloadLinkBelow": true,
+        "showVertical": true
+    },
+    "errors": [],
+    "currentViewport": "lg",
+    "id": 15,
+    "category": "General",
+    "label": "Dashboard",
+    "type": "dashboard",
+    "subType": null,
+    "orientation": null,
+    "icon": {
+        "type": {},
+        "key": null,
+        "ref": null,
+        "props": {},
+        "_owner": null
+    },
+    "content": "Present multiple data visualizations with shared filter controls.",
+    "visualizationType": null,
+    "activeVizButtonID": 15,
+    "version": "4.26.5",
+    "migrations": {
+        "addColorMigration": true
+    },
+    "general": {
+        "palette": {
+            "version": "1.0",
+            "backups": [
+                {
+                    "version": "1.0"
+                },
+                {
+                    "version": "1.0"
+                },
+                {
+                    "version": "1.0"
+                }
+            ]
+        }
+    },
+    "locale": "en-US",
+    "uuid": 1777995474896,
+    "runtime": {},
+    "datasets": {
+        "valid-data-map.csv": {
+            "data": [
+                {
+                    "STATE": "Overall",
+                    "Rate": "55",
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov"
+                },
+                {
+                    "STATE": "Alabama",
+                    "Rate": 130,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Alaska",
+                    "Rate": 40,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "American Samoa",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Arizona",
+                    "Rate": 57,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Arkansas",
+                    "Rate": 60,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "California",
+                    "Rate": 30,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Colorado",
+                    "Rate": 40,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Connecticut",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Delaware",
+                    "Rate": 57,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "DC",
+                    "Rate": 60,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Florida",
+                    "Rate": 30,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Georgia",
+                    "Rate": 40,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Guam",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Hawaii",
+                    "Rate": 57,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Idaho",
+                    "Rate": 60,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Illinois",
+                    "Rate": 30,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Indiana",
+                    "Rate": 40,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Iowa",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Kansas",
+                    "Rate": 57,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Kentucky",
+                    "Rate": 60,
+                    "Location": "NA",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Louisiana",
+                    "Rate": 30,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Maine",
+                    "Rate": 40,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Marshall Islands",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Maryland",
+                    "Rate": 57,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Massachusetts",
+                    "Rate": 60,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Michigan",
+                    "Rate": 12,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Micronesia",
+                    "Rate": 65,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Minnesota",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Mississippi",
+                    "Rate": 57,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Montana",
+                    "Rate": 60,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Montana",
+                    "Rate": 30,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Nebraska",
+                    "Rate": 40,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Nevada",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "New Hampshire",
+                    "Rate": 57,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "New Jersey",
+                    "Rate": 60,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "New Mexico",
+                    "Rate": 12,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "New York",
+                    "Rate": 40,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "North Carolina",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "North Dakota",
+                    "Rate": 57,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Northern Mariana Islands",
+                    "Rate": 60,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Ohio",
+                    "Rate": 88,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Oklahoma",
+                    "Rate": 40,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Oregon",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Palau",
+                    "Rate": 15,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Pennsylvania",
+                    "Rate": 60,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Puerto Rico",
+                    "Rate": 30,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Rhode Island",
+                    "Rate": 40,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "South Carolina",
+                    "Rate": 55,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "South Dakota",
+                    "Rate": 86,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Tennessee",
+                    "Rate": 60,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Texas",
+                    "Rate": 30,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Utah",
+                    "Rate": 54,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Vermont",
+                    "Rate": 40,
+                    "Location": "Home",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Virgin Islands",
+                    "Rate": 55,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Virginia",
+                    "Rate": 57,
+                    "Location": "School",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Washington",
+                    "Rate": 62,
+                    "Location": "Work",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "West Virginia",
+                    "Rate": 25,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                },
+                {
+                    "STATE": "Wyoming",
+                    "Rate": 43,
+                    "Location": "Vehicle",
+                    "URL": "https://www.cdc.gov/"
+                }
+            ],
+            "dataMetadata": {},
+            "dataFileSize": 2434,
+            "dataFileName": "valid-data-map.csv",
+            "dataFileSourceType": "file",
+            "dataFileFormat": "CSV",
+            "preview": true
+        }
+    }
+}

--- a/packages/dashboard/src/helpers/addValuesToDashboardFilters.ts
+++ b/packages/dashboard/src/helpers/addValuesToDashboardFilters.ts
@@ -58,11 +58,9 @@ export const addValuesToDashboardFilters = (
         const active: string[] = Array.isArray(filterCopy.active) ? filterCopy.active : [filterCopy.active]
         filterCopy.active = active.filter(val => defaultValues.includes(val))
       } else {
-        // Use defaultValue if set, otherwise keep existing active or use first value
-        if (filterCopy.defaultValue) {
-          filterCopy.active = filterCopy.defaultValue
-        } else if (!filterCopy.active) {
-          filterCopy.active = filterCopy.resetLabel || filterCopy.values[0]
+        // Only set active when it is not already set; prefer defaultValue, then resetLabel, then first value
+        if (!filterCopy.active) {
+          filterCopy.active = filterCopy.defaultValue || filterCopy.resetLabel || filterCopy.values[0]
         }
       }
     }


### PR DESCRIPTION
## Summary
When showing the dashboard filter dropdowns with the apply button and setting a default value, there was sometimes a bug where it'd get stuck on the default value and wouldn't change. This should fix that and appears to play well with the other filter changes on the map.

## Testing Steps
- Added the "us-map-filter-example.json" to the dashboard examples and it's proving to be useful for testing out these bugs. Using the dropdown with the apply button should work changing states, and it didn't before (it only worked without the apply button)