### PR TITLE
Fix: reduce space at the bottom of dashboards

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -1492,6 +1492,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
                 enableMarkupVariables={config.enableMarkupVariables}
                 data={config.data}
                 dataMetadata={config.dataMetadata}
+                footerClassName='cove-visualization__footnotes'
               />
             }
           >

--- a/packages/core/components/Footnotes/Footnotes.test.tsx
+++ b/packages/core/components/Footnotes/Footnotes.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Footnotes from './Footnotes'
+
+describe('Footnotes', () => {
+  it('does not render a footer when there are no footnotes with text content', () => {
+    const { container } = render(
+      <Footnotes
+        footnotes={[
+          { symbol: '*', text: '' },
+          { symbol: '†', text: '   ' },
+          { symbol: '‡', text: '<br>' }
+        ]}
+      />
+    )
+
+    expect(container.querySelector('footer')).not.toBeInTheDocument()
+  })
+
+  it('renders only footnotes with text content and applies custom footer spacing classes', () => {
+    render(
+      <Footnotes
+        footerClassName='cove-visualization__footnotes'
+        footnotes={[
+          { symbol: '*', text: '' },
+          { symbol: '†', text: 'Rendered note' }
+        ]}
+      />
+    )
+
+    expect(screen.queryByText('*')).not.toBeInTheDocument()
+    expect(screen.getByText('Rendered note')).toBeInTheDocument()
+    expect(screen.getByText('Rendered note').closest('footer')).toHaveClass('cove-visualization__footnotes')
+  })
+})

--- a/packages/core/components/Footnotes/Footnotes.tsx
+++ b/packages/core/components/Footnotes/Footnotes.tsx
@@ -8,7 +8,9 @@ type FootnotesProps = {
 }
 
 const Footnotes: React.FC<FootnotesProps> = ({ footnotes, footerClassName = 'mt-1' }) => {
-  if (!footnotes?.length) return null
+  const footnotesWithContent = footnotes?.filter(note => note.text?.replace(/<[^>]*>/g, '').trim())
+
+  if (!footnotesWithContent?.length) return null
 
   // Convert newlines to <br> tags and parse HTML
   const processFootnoteText = (text: string) => {
@@ -22,7 +24,7 @@ const Footnotes: React.FC<FootnotesProps> = ({ footnotes, footerClassName = 'mt-
   return (
     <footer className={`col-12 ${footerClassName}`}>
       <ul className='cove-footnotes'>
-        {footnotes.map((note, i) => {
+        {footnotesWithContent.map((note, i) => {
           return (
             <li key={`${note.symbol || 'footnote-'}${i}`} className='mb-1 cove-prose'>
               {note.symbol && <span className='cove-footnotes__symbol'>{note.symbol}</span>}

--- a/packages/core/components/Footnotes/footnotes.css
+++ b/packages/core/components/Footnotes/footnotes.css
@@ -7,3 +7,7 @@
     margin-right: 0.25rem;
   }
 }
+
+.cove-visualization__footnotes {
+  margin-top: var(--cove-visualization-section-gap, 1.5rem);
+}

--- a/packages/core/components/Layout/components/Visualization/visualizations.scss
+++ b/packages/core/components/Layout/components/Visualization/visualizations.scss
@@ -234,11 +234,6 @@
     padding-bottom: var(--cove-visualization-section-gap, 1.5rem);
   }
 
-  &.type-chart .cove-visualization__body-wrap,
-  &.type-map .cove-visualization__body-wrap {
-    padding-bottom: var(--cove-visualization-section-gap, 1.5rem);
-  }
-
   .cove-visualization__body.component--has-legacy-border .cove-visualization__content-section,
   .cove-visualization__body.component--has-border-color-theme .cove-visualization__content-section,
   .cove-visualization__body.component--has-background .cove-visualization__content-section {

--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -573,6 +573,7 @@ export default function CdcDashboard({
   } else {
     const { config } = state
     const { title, description } = config.dashboard || {}
+    const hasDashboardDownloadButton = config.table?.downloadImageButton || config.table?.downloadPdfButton
 
     const filteredRows =
       config.rows
@@ -632,30 +633,32 @@ export default function CdcDashboard({
             )}
 
             {/* Image or PDF Inserts */}
-            <section className='download-buttons'>
-              {config.table?.downloadImageButton && (
-                <MediaControls.Button
-                  title='Download Dashboard as Image'
-                  type='image'
-                  state={config}
-                  text='Download Dashboard Image'
-                  elementToCapture={imageId}
-                  interactionLabel={interactionLabel}
-                  appearance={config.table?.downloadImageButtonStyle === 'link' ? 'link' : 'button'}
-                />
-              )}
-              {config.table?.downloadPdfButton && (
-                <MediaControls.Button
-                  title='Download Dashboard as PDF'
-                  type='pdf'
-                  state={config}
-                  text='Download Dashboard PDF'
-                  elementToCapture={imageId}
-                  interactionLabel={interactionLabel}
-                  appearance={config.table?.downloadImageButtonStyle === 'link' ? 'link' : 'button'}
-                />
-              )}
-            </section>
+            {hasDashboardDownloadButton && (
+              <section className='download-buttons'>
+                {config.table?.downloadImageButton && (
+                  <MediaControls.Button
+                    title='Download Dashboard as Image'
+                    type='image'
+                    state={config}
+                    text='Download Dashboard Image'
+                    elementToCapture={imageId}
+                    interactionLabel={interactionLabel}
+                    appearance={config.table?.downloadImageButtonStyle === 'link' ? 'link' : 'button'}
+                  />
+                )}
+                {config.table?.downloadPdfButton && (
+                  <MediaControls.Button
+                    title='Download Dashboard as PDF'
+                    type='pdf'
+                    state={config}
+                    text='Download Dashboard PDF'
+                    elementToCapture={imageId}
+                    interactionLabel={interactionLabel}
+                    appearance={config.table?.downloadImageButtonStyle === 'link' ? 'link' : 'button'}
+                  />
+                )}
+              </section>
+            )}
 
             {/* Data Table */}
             {config.table?.show && config.data && (

--- a/packages/dashboard/src/test/CdcDashboardComponent.test.tsx
+++ b/packages/dashboard/src/test/CdcDashboardComponent.test.tsx
@@ -80,6 +80,56 @@ describe('CdcDashboardComponent', () => {
     expect(shell).not.toHaveClass('is-editor')
   })
 
+  it('only renders the dashboard download button section when a download button is enabled', () => {
+    const baseInitialState = {
+      config: {
+        type: 'dashboard',
+        dashboard: {
+          title: 'Dashboard Title',
+          titleStyle: 'small',
+          theme: 'theme-blue',
+          sharedFilters: []
+        },
+        visualizations: {},
+        rows: [],
+        datasets: {},
+        table: {}
+      },
+      data: {},
+      loading: false,
+      filteredData: {},
+      preview: false,
+      tabSelected: 'Dashboard Preview',
+      filtersApplied: true
+    } as InitialState
+
+    const disabledRender = render(
+      <CdcDashboardComponent initialState={baseInitialState} interactionLabel='dashboard-test' isEditor={false} />
+    )
+
+    expect(disabledRender.container.querySelector('.download-buttons')).not.toBeInTheDocument()
+    disabledRender.unmount()
+
+    const enabledRender = render(
+      <CdcDashboardComponent
+        initialState={{
+          ...baseInitialState,
+          config: {
+            ...baseInitialState.config,
+            table: {
+              downloadImageButton: true
+            }
+          }
+        }}
+        interactionLabel='dashboard-test'
+        isEditor={false}
+      />
+    )
+
+    expect(enabledRender.container.querySelector('.download-buttons')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Download Image' })).toBeInTheDocument()
+  })
+
   it('suppresses rows when row conditions fail and preserves width for condition-hidden components', () => {
     const initialState = {
       config: {

--- a/packages/map/src/CdcMapComponent.tsx
+++ b/packages/map/src/CdcMapComponent.tsx
@@ -755,6 +755,7 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
               enableMarkupVariables={config.enableMarkupVariables}
               data={config.data}
               dataMetadata={config.dataMetadata}
+              footerClassName='cove-visualization__footnotes'
             />
           </VisualizationContainer>
         </MapDispatchContext.Provider>


### PR DESCRIPTION
## Summary

Removes two sources of extra space at the bottom of dashboards:

1) Removes the chart/map body padding that was added by me earlier in this release cycle for footnote spacing, and instead applies spacing only when footnotes render.

2) Stops rendering the dashboard download button container when image/PDF download buttons are disabled. This has been a longstanding bug.

## Testing Steps

Load [dashboard-charts.json](https://github.com/user-attachments/files/28110563/dashboard-charts.json), take a look at the space at the bottom of the dashboard on this branch vs. the `test` branch.