### PR TITLE
Fix: Display zeroes in markup variables

### DIFF
--- a/packages/core/helpers/markupProcessor.ts
+++ b/packages/core/helpers/markupProcessor.ts
@@ -219,7 +219,7 @@ export const processMarkupVariables = (
 
               return workingVariable.addCommas && !isNaN(parseFloat(dataObjectValue))
                 ? parseFloat(dataObjectValue).toLocaleString(locale, { useGrouping: true })
-                : String(dataObjectValue || '')
+                : String(dataObjectValue === 0 ? dataObjectValue : dataObjectValue || '')
             } catch (error) {
               console.error(`Error processing data value for ${variableTag}:`, error)
               return ''

--- a/packages/core/helpers/tests/markupProcessor.test.ts
+++ b/packages/core/helpers/tests/markupProcessor.test.ts
@@ -96,6 +96,38 @@ describe('processMarkupVariables', () => {
       expect(result.processedContent).toContain('39538223')
       expect(result.processedContent).not.toContain('39,538,223')
     })
+
+    it('should render numeric zero when addCommas is false', () => {
+      const variables: MarkupVariable[] = [
+        {
+          name: 'Value',
+          tag: '{{value}}',
+          columnName: 'value',
+          conditions: [],
+          addCommas: false
+        }
+      ]
+
+      const result = processMarkupVariables('Value: {{value}}', [{ value: 0 }], variables, { locale: 'en-US' })
+
+      expect(result.processedContent).toBe('Value: 0')
+    })
+
+    it('should continue rendering string zero', () => {
+      const variables: MarkupVariable[] = [
+        {
+          name: 'Value',
+          tag: '{{value}}',
+          columnName: 'value',
+          conditions: [],
+          addCommas: false
+        }
+      ]
+
+      const result = processMarkupVariables('Value: {{value}}', [{ value: '0' }], variables, { locale: 'en-US' })
+
+      expect(result.processedContent).toBe('Value: 0')
+    })
   })
 
   describe('Conditional Filtering', () => {
@@ -247,6 +279,22 @@ describe('processMarkupVariables', () => {
       expect(result.processedContent).toBe('State: ')
       expect(result.shouldShowNoDataMessage).toBe(true)
     })
+
+    it('preserves numeric zero when selectionMode is first', () => {
+      const variables: MarkupVariable[] = [
+        {
+          name: 'Value',
+          tag: '{{value}}',
+          columnName: 'value',
+          conditions: [],
+          selectionMode: 'first'
+        }
+      ]
+
+      const result = processMarkupVariables('{{value}}', [{ value: 0 }], variables, { locale: 'en-US' })
+
+      expect(result.processedContent).toBe('0')
+    })
   })
 
   describe('Empty Values and Null Handling', () => {
@@ -292,6 +340,35 @@ describe('processMarkupVariables', () => {
       const result = processMarkupVariables(content, dataEmpty, variables, { locale: 'en-US' })
 
       expect(result.processedContent).toBe('Values: ')
+    })
+
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['empty string', ''],
+      ['boolean false', false],
+      ['NaN', NaN]
+    ])('should render %s as blank', (_label, value) => {
+      const variables: MarkupVariable[] = [{ name: 'Value', tag: '{{value}}', columnName: 'value', conditions: [] }]
+
+      const result = processMarkupVariables('Value: {{value}}', [{ value }], variables, { locale: 'en-US' })
+
+      expect(result.processedContent).toBe('Value: ')
+    })
+
+    it('should not hide section or show no-data message for numeric zero', () => {
+      const variables: MarkupVariable[] = [{ name: 'Value', tag: '{{value}}', columnName: 'value', conditions: [] }]
+
+      const result = processMarkupVariables('{{value}}', [{ value: 0 }], variables, {
+        allowHideSection: true,
+        showNoDataMessage: true,
+        isEditor: false,
+        locale: 'en-US'
+      })
+
+      expect(result.processedContent).toBe('0')
+      expect(result.shouldHideSection).toBe(false)
+      expect(result.shouldShowNoDataMessage).toBe(false)
     })
   })
 

--- a/packages/data-bite/src/test/CdcDataBite.test.jsx
+++ b/packages/data-bite/src/test/CdcDataBite.test.jsx
@@ -169,6 +169,32 @@ describe('Data Bite', () => {
     expect(image).toHaveAttribute('src', veryLowImageUrl)
   })
 
+  it('renders a bite body markup variable backed by numeric zero', async () => {
+    render(
+      <CdcDataBite
+        config={{
+          type: 'data-bite',
+          theme: 'theme-blue',
+          title: 'Test title',
+          biteBody: 'Percent positive: {{percent}}%',
+          enableMarkupVariables: true,
+          markupVariables: [
+            {
+              name: 'Percent',
+              tag: '{{percent}}',
+              columnName: 'percent',
+              conditions: [],
+              addCommas: false
+            }
+          ],
+          data: [{ percent: 0 }]
+        }}
+      />
+    )
+
+    expect(await screen.findByText('Percent positive: 0%')).toBeInTheDocument()
+  })
+
   it.each(['Mean (Average)', 'Median'])('renders an empty value when %s has no numeric values', dataFunction => {
     const { container } = render(<CdcDataBite config={dynamicImageConfig(' ', dataFunction)} />)
 


### PR DESCRIPTION
## Summary

Zeroes are falsy and weren't being displayed in markup variables. The issue was introduced in 88657fbe0. This preserves zeroes so they are displayed but does not changes any other falsy values.

## Testing Steps

Load a markup variable with a zero and make sure it displays.