### PR TITLE
Enhancement [DEV-13230] Add feature to associate colors with series

### DIFF
--- a/packages/chart/CONFIG.md
+++ b/packages/chart/CONFIG.md
@@ -200,6 +200,8 @@ Axis settings are chart-owned because their meaning depends on chart family, ori
 | `twoColor.palette` | `string` | No | `monochrome-1` | Palette used for two-color chart variants. | Used when the chart switches to a paired/deviation bar color treatment. |
 | `twoColor.isPaletteReversed` | `boolean` | No | `false` | Reverses the two-color palette variant. | Current active reversal flag for two-color palettes. |
 | `general.palette.isReversed` | `boolean` | No | `true` for current chart defaults | Reverses the active palette order. | Current active reversal flag for the main palette. The top-level `isPaletteReversed` field is legacy. |
+| `general.palette.colorAssignmentMode` | `ordered \| by-value` | No | `ordered` when omitted | Enables authored by-series color assignment. | `by-value` is required before `colorAssignments` affects chart colors; assignment presence alone does not activate it. |
+| `general.palette.colorAssignments` | `{ key: string; color: string }[]` | No | `[]` | Assigns colors to stable authored chart series keys. | Supported for regular Line, Bar, Combo, Area Chart, Scatter Plot, and by-series Small Multiples. `key` should match `series[].dataKey`; stale keys are ignored and may be removed by editor updates. |
 | `pieType` | `Regular \| Donut` | No | `Regular` | Chooses between a full pie and a donut chart. | Only meaningful for `Pie` charts. |
 | `showAreaUnderLine` | `boolean` | No | `false` | Fills the area below line series. | Primarily used by line and small-multiple line charts. |
 | `showLineSeriesLabels` | `boolean` | No | `false` | Appends the series name at the end of line and combo series. | Only meaningful for line-capable charts. |

--- a/packages/chart/src/_stories/Chart.SeriesColorAssignments.stories.tsx
+++ b/packages/chart/src/_stories/Chart.SeriesColorAssignments.stories.tsx
@@ -1,0 +1,183 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import Chart from '../CdcChartComponent'
+import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
+
+const meta: Meta<typeof Chart> = {
+  title: 'Components/Templates/Chart/Series Color Assignments',
+  component: Chart
+}
+
+type Story = StoryObj<typeof Chart>
+
+const assignedColors = {
+  alpha: '#0057B7',
+  bravo: '#D94E5F',
+  charlie: '#5A8E3F'
+}
+
+const normalizeColor = (color: string) => {
+  const swatch = document.createElement('div')
+  swatch.style.color = color
+  document.body.appendChild(swatch)
+  const normalized = getComputedStyle(swatch).color
+  swatch.remove()
+  return normalized
+}
+
+const getVisiblePointColorsBySeries = (canvasElement: HTMLElement) => {
+  const groups = Array.from(canvasElement.querySelectorAll('.line-chart-group .visx-glyph-group')) as SVGGElement[]
+  const colorsBySeries = new Map<string, Set<string>>()
+
+  groups.forEach(group => {
+    const seriesIndex = group.getAttribute('data-seriesindex')
+    const glyph = group.querySelector('[fill]') as SVGElement | null
+    const fill = glyph?.getAttribute('fill')
+
+    if (!seriesIndex || !fill || fill === 'transparent') return
+
+    const seriesColors = colorsBySeries.get(seriesIndex) || new Set<string>()
+    seriesColors.add(normalizeColor(fill))
+    colorsBySeries.set(seriesIndex, seriesColors)
+  })
+
+  return colorsBySeries
+}
+
+const expectVisibleSeriesColors = async (
+  canvasElement: HTMLElement,
+  expected: Array<[seriesIndex: string, color: string]>
+) => {
+  await waitFor(() => {
+    const colorsBySeries = getVisiblePointColorsBySeries(canvasElement)
+    const expectedSeries = expected.map(([seriesIndex]) => seriesIndex)
+
+    expect(Array.from(colorsBySeries.keys()).sort()).toEqual(expectedSeries.sort())
+
+    expected.forEach(([seriesIndex, color]) => {
+      expect(Array.from(colorsBySeries.get(seriesIndex) || [])).toEqual([normalizeColor(color)])
+    })
+  })
+}
+
+const expectLegendLabels = async (canvasElement: HTMLElement, expectedLabels: string[]) => {
+  await waitFor(() => {
+    const labels = Array.from(canvasElement.querySelectorAll('.legend-container [role="button"]')).map(item =>
+      item.textContent?.trim()
+    )
+
+    expect(labels).toEqual(expectedLabels)
+  })
+}
+
+const config = {
+  type: 'chart',
+  version: '4.26.5',
+  title: 'Series Color Assignments With Filtered Series',
+  visualizationType: 'Line',
+  visualizationSubType: 'regular',
+  orientation: 'vertical',
+  filterBehavior: 'Filter Change',
+  lineDatapointStyle: 'always show',
+  lineDatapointColor: 'Same as Line',
+  general: {
+    palette: {
+      name: 'qualitative_standard',
+      version: '2.0',
+      colorAssignmentMode: 'by-value',
+      colorAssignments: [
+        { key: 'alpha', color: assignedColors.alpha },
+        { key: 'bravo', color: assignedColors.bravo },
+        { key: 'charlie', color: assignedColors.charlie }
+      ]
+    }
+  },
+  legend: {
+    hide: false,
+    behavior: 'isolate',
+    dynamicLegend: false,
+    position: 'top',
+    style: 'circles',
+    unified: false
+  },
+  xAxis: {
+    dataKey: 'week',
+    type: 'date-time',
+    dateParseFormat: '%Y-%m-%d',
+    dateDisplayFormat: '%b. %-d',
+    label: 'Week',
+    sortDates: false
+  },
+  yAxis: {
+    label: 'Rate',
+    min: '0',
+    max: '50',
+    numTicks: '5',
+    gridLines: true
+  },
+  visual: {
+    lineDatapointSymbol: 'none',
+    verticalHoverLine: false,
+    horizontalHoverLine: false
+  },
+  tooltips: {
+    singleSeries: false
+  },
+  series: [
+    { dataKey: 'alpha', name: 'Alpha', type: 'Line', axis: 'Left', tooltip: true },
+    { dataKey: 'bravo', name: 'Bravo', type: 'Line', axis: 'Left', tooltip: true },
+    { dataKey: 'charlie', name: 'Charlie', type: 'Line', axis: 'Left', tooltip: true }
+  ],
+  filters: [
+    {
+      values: ['Alpha + Bravo', 'Bravo + Charlie'],
+      filterStyle: 'dropdown',
+      id: 1726688167657,
+      columnName: 'view',
+      active: 'Alpha + Bravo',
+      label: 'Visible series'
+    }
+  ],
+  data: [
+    { week: '2024-01-01', view: 'Alpha + Bravo', alpha: 12, bravo: 20, charlie: null },
+    { week: '2024-01-08', view: 'Alpha + Bravo', alpha: 16, bravo: 23, charlie: null },
+    { week: '2024-01-15', view: 'Alpha + Bravo', alpha: 21, bravo: 28, charlie: null },
+    { week: '2024-01-22', view: 'Alpha + Bravo', alpha: 26, bravo: 31, charlie: null },
+    { week: '2024-01-01', view: 'Bravo + Charlie', alpha: null, bravo: 20, charlie: 30 },
+    { week: '2024-01-08', view: 'Bravo + Charlie', alpha: null, bravo: 23, charlie: 34 },
+    { week: '2024-01-15', view: 'Bravo + Charlie', alpha: null, bravo: 28, charlie: 39 },
+    { week: '2024-01-22', view: 'Bravo + Charlie', alpha: null, bravo: 31, charlie: 43 }
+  ],
+  dataDescription: {
+    horizontal: false,
+    series: false
+  }
+}
+
+export const FilteredSeriesKeepAssignedColors: Story = {
+  args: {
+    config,
+    isEditor: false
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    await expectVisibleSeriesColors(canvasElement, [
+      ['0', assignedColors.alpha],
+      ['1', assignedColors.bravo]
+    ])
+    await expectLegendLabels(canvasElement, ['Alpha', 'Bravo'])
+
+    const canvas = within(canvasElement)
+    const filter = canvas.getByLabelText(/filter by visible series/i) as HTMLSelectElement
+    await userEvent.selectOptions(filter, 'Bravo + Charlie')
+
+    await expectVisibleSeriesColors(canvasElement, [
+      ['1', assignedColors.bravo],
+      ['2', assignedColors.charlie]
+    ])
+    await expectLegendLabels(canvasElement, ['Bravo', 'Charlie'])
+  }
+}
+
+export default meta

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.SmallMultiples.test.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.SmallMultiples.test.tsx
@@ -74,4 +74,25 @@ describe('PanelSmallMultiples color assignments warning', () => {
 
     expect(screen.queryByText(/Color assignments are enabled/)).not.toBeInTheDocument()
   })
+
+  it('does not show the override warning when assignments only contain stale keys', () => {
+    const config = createMockConfig({
+      visualizationType: 'Line',
+      general: {
+        palette: {
+          colorAssignmentMode: 'by-value',
+          colorAssignments: [{ key: 'removed_series', color: '#123456' }]
+        }
+      } as any,
+      smallMultiples: {
+        mode: 'by-series',
+        colorMode: 'same'
+      },
+      series: [{ dataKey: 'series_a', name: 'Alpha', type: 'Line' }] as any
+    })
+
+    renderPanel(config)
+
+    expect(screen.queryByText(/Color assignments are enabled/)).not.toBeInTheDocument()
+  })
 })

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.SmallMultiples.test.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.SmallMultiples.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { Accordion } from 'react-accessible-accordion'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ConfigContext from '../../../../ConfigContext'
+import EditorPanelContext from '../../EditorPanelContext'
+import PanelSmallMultiples from './Panel.SmallMultiples'
+import { createMockChartContext, createMockConfig } from '../../../LinearChart/tests/mockConfigContext'
+
+vi.mock('@cdc/core/components/ui/Icon', () => ({
+  default: () => <span data-testid='icon' />
+}))
+
+const renderPanel = config => {
+  const context = createMockChartContext(config, {
+    rawData: [{ Date: '2024-01-01', series_a: 1, series_b: 2 }]
+  } as any)
+
+  render(
+    <ConfigContext.Provider value={context}>
+      <EditorPanelContext.Provider value={{ updateField: vi.fn() }}>
+        <Accordion allowZeroExpanded>
+          <PanelSmallMultiples name='Small Multiples' />
+        </Accordion>
+      </EditorPanelContext.Provider>
+    </ConfigContext.Provider>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'Small Multiples' }))
+}
+
+describe('PanelSmallMultiples color assignments warning', () => {
+  it('shows the by-series same-color override warning only when assignments are active', () => {
+    const config = createMockConfig({
+      visualizationType: 'Line',
+      general: {
+        palette: {
+          colorAssignmentMode: 'by-value',
+          colorAssignments: [{ key: 'series_a', color: '#123456' }]
+        }
+      } as any,
+      smallMultiples: {
+        mode: 'by-series',
+        colorMode: 'same'
+      },
+      series: [
+        { dataKey: 'series_a', name: 'Alpha', type: 'Line' },
+        { dataKey: 'series_b', name: 'Beta', type: 'Line' }
+      ] as any
+    })
+
+    renderPanel(config)
+
+    expect(screen.queryByText(/Color assignments are enabled/)).toBeInTheDocument()
+  })
+
+  it('does not show the override warning when assignment mode is ordered', () => {
+    const config = createMockConfig({
+      visualizationType: 'Line',
+      general: {
+        palette: {
+          colorAssignmentMode: 'ordered',
+          colorAssignments: [{ key: 'series_a', color: '#123456' }]
+        }
+      } as any,
+      smallMultiples: {
+        mode: 'by-series',
+        colorMode: 'same'
+      },
+      series: [{ dataKey: 'series_a', name: 'Alpha', type: 'Line' }] as any
+    })
+
+    renderPanel(config)
+
+    expect(screen.queryByText(/Color assignments are enabled/)).not.toBeInTheDocument()
+  })
+})

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.SmallMultiples.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.SmallMultiples.tsx
@@ -20,6 +20,10 @@ import { useEditorPanelContext } from '../../EditorPanelContext.js'
 import ConfigContext from '../../../../ConfigContext.js'
 import { PanelProps } from '../PanelProps'
 import { getTileKeys } from '../../../../helpers/smallMultiplesHelpers'
+import {
+  getSeriesColorAssignments,
+  isSeriesColorAssignmentModeByValue
+} from '../../../../helpers/colorAssignmentHelpers'
 
 const PanelSmallMultiples: FC<PanelProps> = props => {
   const { config, rawData, updateConfig } = useContext<ChartContext>(ConfigContext)
@@ -272,6 +276,16 @@ const PanelSmallMultiples: FC<PanelProps> = props => {
                     </Tooltip>
                   }
                 />
+
+                {config.smallMultiples?.mode === 'by-series' &&
+                  config.smallMultiples?.colorMode === 'same' &&
+                  isSeriesColorAssignmentModeByValue(config) &&
+                  getSeriesColorAssignments(config).length > 0 && (
+                    <p className='small-multiples-color-assignment-warning mt-1'>
+                      Color assignments are enabled in the Visual section, so tiles will use their assigned series
+                      colors instead of the &lsquo;Same Color&rsquo; setting.
+                    </p>
+                  )}
 
                 {/* Custom Tile Titles - only show for by-column mode */}
                 {config.smallMultiples?.mode === 'by-column' && (

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.SmallMultiples.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.SmallMultiples.tsx
@@ -20,10 +20,7 @@ import { useEditorPanelContext } from '../../EditorPanelContext.js'
 import ConfigContext from '../../../../ConfigContext.js'
 import { PanelProps } from '../PanelProps'
 import { getTileKeys } from '../../../../helpers/smallMultiplesHelpers'
-import {
-  getSeriesColorAssignments,
-  isSeriesColorAssignmentModeByValue
-} from '../../../../helpers/colorAssignmentHelpers'
+import { hasSeriesColorAssignmentOverrides } from '../../../../helpers/colorAssignmentHelpers'
 
 const PanelSmallMultiples: FC<PanelProps> = props => {
   const { config, rawData, updateConfig } = useContext<ChartContext>(ConfigContext)
@@ -279,8 +276,7 @@ const PanelSmallMultiples: FC<PanelProps> = props => {
 
                 {config.smallMultiples?.mode === 'by-series' &&
                   config.smallMultiples?.colorMode === 'same' &&
-                  isSeriesColorAssignmentModeByValue(config) &&
-                  getSeriesColorAssignments(config).length > 0 && (
+                  hasSeriesColorAssignmentOverrides(config) && (
                     <p className='small-multiples-color-assignment-warning mt-1'>
                       Color assignments are enabled in the Visual section, so tiles will use their assigned series
                       colors instead of the &lsquo;Same Color&rsquo; setting.

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.test.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Accordion } from 'react-accessible-accordion'
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import ConfigContext from '../../../../ConfigContext'
 import EditorPanelContext from '../../EditorPanelContext'
@@ -122,6 +122,86 @@ describe('PanelVisual series color assignments', () => {
         })
       })
     )
+  })
+
+  it('syncs missing current series assignments while by-value mode is active', async () => {
+    const { updateConfig } = renderPanel(
+      buildConfig({
+        general: {
+          palette: {
+            customColors: ['#111111', '#222222'],
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [{ key: 'series_a', color: '#111111' }]
+          }
+        } as any
+      })
+    )
+
+    await waitFor(() => {
+      expect(updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          general: expect.objectContaining({
+            palette: expect.objectContaining({
+              colorAssignmentMode: 'by-value',
+              colorAssignments: [
+                { key: 'series_a', color: '#111111' },
+                { key: 'series_b', color: '#222222' }
+              ]
+            })
+          })
+        })
+      )
+    })
+  })
+
+  it('syncs assignments when a new series is added while by-value mode is active', async () => {
+    const initialConfig = buildConfig({
+      general: {
+        palette: {
+          customColors: ['#111111', '#222222'],
+          colorAssignmentMode: 'by-value',
+          colorAssignments: [{ key: 'series_a', color: '#111111' }]
+        }
+      } as any,
+      series: [{ dataKey: 'series_a', name: 'Alpha', type: 'Line' }] as any,
+      runtime: {
+        ...createMockConfig().runtime,
+        seriesKeys: ['series_a'],
+        seriesLabels: {
+          series_a: 'Alpha'
+        },
+        seriesLabelsAll: ['Alpha']
+      } as any
+    })
+    const { updateConfig, rerenderPanel } = renderPanel(initialConfig)
+
+    updateConfig.mockClear()
+    rerenderPanel(
+      buildConfig({
+        general: {
+          palette: {
+            customColors: ['#111111', '#222222'],
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [{ key: 'series_a', color: '#111111' }]
+          }
+        } as any
+      })
+    )
+
+    await waitFor(() => {
+      expect(updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          general: expect.objectContaining({
+            palette: expect.objectContaining({
+              colorAssignments: [
+                { key: 'series_a', color: '#111111' },
+                { key: 'series_b', color: '#222222' }
+              ]
+            })
+          })
+        })
+      )
+    })
   })
 
   it('updates the color for the matching assignment key and drops stale assignment keys', () => {

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.test.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.test.tsx
@@ -1,0 +1,404 @@
+import React from 'react'
+import { Accordion } from 'react-accessible-accordion'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ConfigContext from '../../../../ConfigContext'
+import EditorPanelContext from '../../EditorPanelContext'
+import PanelVisual from './Panel.Visual'
+import { createMockChartContext, createMockConfig } from '../../../LinearChart/tests/mockConfigContext'
+import { ChartConfig } from '../../../../types/ChartConfig'
+
+vi.mock('@cdc/core/hooks/useColorPalette', () => ({
+  useColorPalette: () => ({
+    twoColorPalettes: [],
+    sequential: [],
+    nonSequential: [],
+    accessibleColors: []
+  })
+}))
+
+vi.mock('@cdc/core/components/PaletteSelector', () => ({
+  PaletteSelector: () => <div data-testid='palette-selector' />,
+  DeveloperPaletteRollback: () => null
+}))
+
+vi.mock('@cdc/core/components/HeaderThemeSelector', () => ({
+  HeaderThemeSelector: () => null
+}))
+
+vi.mock('@cdc/core/components/ui/Icon', () => ({
+  default: () => <span data-testid='icon' />
+}))
+
+const buildConfig = (overrides: Partial<ChartConfig> = {}) =>
+  createMockConfig({
+    visualizationType: 'Line',
+    visualizationSubType: 'regular',
+    general: {
+      palette: {
+        customColors: ['#111111', '#222222']
+      }
+    } as any,
+    series: [
+      { dataKey: 'series_a', name: 'Alpha', type: 'Line' },
+      { dataKey: 'series_b', name: 'Beta', type: 'Line' }
+    ] as any,
+    runtime: {
+      ...createMockConfig().runtime,
+      seriesKeys: ['series_a', 'series_b'],
+      seriesLabels: {
+        series_a: 'Alpha',
+        series_b: 'Beta'
+      },
+      seriesLabelsAll: ['Alpha', 'Beta']
+    } as any,
+    visual: {
+      lineDatapointSymbol: 'none',
+      verticalHoverLine: false,
+      horizontalHoverLine: false
+    } as any,
+    ...overrides
+  })
+
+const renderPanel = (
+  config: ChartConfig,
+  colorPalettes = {
+    qualitative_standard: ['#111111', '#222222']
+  }
+) => {
+  const updateConfig = vi.fn()
+  const renderTree = (panelConfig: ChartConfig) => {
+    const context = createMockChartContext(panelConfig, {
+      updateConfig,
+      colorPalettes,
+      twoColorPalette: {
+        v2: {}
+      }
+    } as any)
+
+    return (
+      <ConfigContext.Provider value={context}>
+        <EditorPanelContext.Provider
+          value={{
+            updateField: vi.fn(),
+            setLollipopShape: vi.fn(),
+            handlePaletteSelection: vi.fn(),
+            handleTwoColorPaletteSelection: vi.fn()
+          }}
+        >
+          <Accordion allowZeroExpanded>
+            <PanelVisual name='Visual' />
+          </Accordion>
+        </EditorPanelContext.Provider>
+      </ConfigContext.Provider>
+    )
+  }
+
+  const view = render(renderTree(config))
+
+  fireEvent.click(screen.getByRole('button', { name: 'Visual' }))
+  return {
+    updateConfig,
+    rerenderPanel: (newConfig: ChartConfig) => view.rerender(renderTree(newConfig))
+  }
+}
+
+describe('PanelVisual series color assignments', () => {
+  it('seeds assignment rows from current colors when by-value mode is enabled', () => {
+    const { updateConfig } = renderPanel(buildConfig())
+
+    fireEvent.change(screen.getByLabelText('Color Assignment Mode'), { target: { value: 'by-value' } })
+
+    expect(updateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        general: expect.objectContaining({
+          palette: expect.objectContaining({
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [
+              { key: 'series_a', color: '#111111' },
+              { key: 'series_b', color: '#222222' }
+            ]
+          })
+        })
+      })
+    )
+  })
+
+  it('updates the color for the matching assignment key and drops stale assignment keys', () => {
+    const { updateConfig } = renderPanel(
+      buildConfig({
+        general: {
+          palette: {
+            customColors: ['#111111', '#222222'],
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [
+              { key: 'series_a', color: '#111111' },
+              { key: 'series_b', color: '#222222' },
+              { key: 'stale_series', color: '#333333' }
+            ]
+          }
+        } as any
+      })
+    )
+
+    const alphaRow = screen.getByText('Alpha').closest('.series-color-assignments__row') as HTMLElement
+    fireEvent.click(within(alphaRow).getByRole('button', { name: 'Color for Alpha' }))
+    fireEvent.click(screen.getAllByTitle('#222222').find(element => element.getAttribute('role') === 'option')!)
+
+    expect(updateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        general: expect.objectContaining({
+          palette: expect.objectContaining({
+            colorAssignmentMode: 'by-value',
+            colorAssignments: expect.arrayContaining([
+              { key: 'series_a', color: '#222222' },
+              { key: 'series_b', color: '#222222' }
+            ])
+          })
+        })
+      })
+    )
+    expect(updateConfig.mock.calls[0][0].general.palette.colorAssignments).toHaveLength(2)
+  })
+
+  it('lets assignments choose from the full active palette, not only distributed series colors', () => {
+    const fullPalette = [
+      '#0057B7',
+      '#722161',
+      '#00B1CE',
+      '#D94E5F',
+      '#5A8E3F',
+      '#FFB24D',
+      '#FB7E38',
+      '#032659',
+      '#975722'
+    ]
+    const { updateConfig } = renderPanel(
+      buildConfig({
+        general: {
+          palette: {
+            name: 'qualitative_standard',
+            version: '2.0',
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [
+              { key: 'series_a', color: '#0057B7' },
+              { key: 'series_b', color: '#00B1CE' },
+              { key: 'series_c', color: '#5A8E3F' }
+            ]
+          }
+        } as any,
+        series: [
+          { dataKey: 'series_a', name: 'Alpha', type: 'Line' },
+          { dataKey: 'series_b', name: 'Beta', type: 'Line' },
+          { dataKey: 'series_c', name: 'Gamma', type: 'Line' }
+        ] as any,
+        runtime: {
+          ...createMockConfig().runtime,
+          seriesKeys: ['series_a', 'series_b', 'series_c'],
+          seriesLabels: {
+            series_a: 'Alpha',
+            series_b: 'Beta',
+            series_c: 'Gamma'
+          },
+          seriesLabelsAll: ['Alpha', 'Beta', 'Gamma']
+        } as any
+      }),
+      {
+        qualitative_standard: fullPalette
+      }
+    )
+
+    const alphaRow = screen.getByText('Alpha').closest('.series-color-assignments__row') as HTMLElement
+    fireEvent.click(within(alphaRow).getByRole('button', { name: 'Color for Alpha' }))
+    fireEvent.click(screen.getAllByTitle('#722161').find(element => element.getAttribute('role') === 'option')!)
+
+    expect(updateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        general: expect.objectContaining({
+          palette: expect.objectContaining({
+            colorAssignments: expect.arrayContaining([{ key: 'series_a', color: '#722161' }])
+          })
+        })
+      })
+    )
+  })
+
+  it('resets assignments when the selected palette changes without custom colors', () => {
+    const initialConfig = buildConfig({
+      general: {
+        palette: {
+          name: 'qualitative_standard',
+          version: '2.0',
+          colorAssignmentMode: 'by-value',
+          colorAssignments: [
+            { key: 'series_a', color: '#0057B7' },
+            { key: 'series_b', color: '#00B1CE' },
+            { key: 'stale_series', color: '#333333' }
+          ]
+        }
+      } as any
+    })
+    const { updateConfig, rerenderPanel } = renderPanel(initialConfig, {
+      qualitative_standard: [
+        '#0057B7',
+        '#722161',
+        '#00B1CE',
+        '#D94E5F',
+        '#5A8E3F',
+        '#FFB24D',
+        '#FB7E38',
+        '#032659',
+        '#975722'
+      ],
+      sequential_blue: [
+        '#DBE8F7',
+        '#BED5ED',
+        '#99BCE1',
+        '#73A1D5',
+        '#4E88C7',
+        '#1E6BC0',
+        '#0057B7',
+        '#01418D',
+        '#032659'
+      ]
+    })
+
+    updateConfig.mockClear()
+    rerenderPanel(
+      buildConfig({
+        general: {
+          palette: {
+            name: 'sequential_blue',
+            version: '2.0',
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [
+              { key: 'series_a', color: '#0057B7' },
+              { key: 'series_b', color: '#00B1CE' },
+              { key: 'stale_series', color: '#333333' }
+            ]
+          }
+        } as any
+      })
+    )
+
+    expect(updateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        general: expect.objectContaining({
+          palette: expect.objectContaining({
+            colorAssignments: [
+              { key: 'series_a', color: '#DBE8F7' },
+              { key: 'series_b', color: '#032659' }
+            ]
+          })
+        })
+      })
+    )
+  })
+
+  it('does not reset assignments when custom colors change', () => {
+    const initialConfig = buildConfig({
+      general: {
+        palette: {
+          customColors: ['#111111', '#222222'],
+          colorAssignmentMode: 'by-value',
+          colorAssignments: [
+            { key: 'series_a', color: '#111111' },
+            { key: 'series_b', color: '#222222' }
+          ]
+        }
+      } as any
+    })
+    const { updateConfig, rerenderPanel } = renderPanel(initialConfig)
+
+    updateConfig.mockClear()
+    rerenderPanel(
+      buildConfig({
+        general: {
+          palette: {
+            customColors: ['#aaaaaa', '#bbbbbb'],
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [
+              { key: 'series_a', color: '#111111' },
+              { key: 'series_b', color: '#222222' }
+            ]
+          }
+        } as any
+      })
+    )
+
+    expect(updateConfig).not.toHaveBeenCalled()
+  })
+
+  it('resets assignments when custom colors are removed while by-value mode is active', () => {
+    const initialConfig = buildConfig({
+      general: {
+        palette: {
+          name: 'qualitative_standard',
+          version: '2.0',
+          customColors: ['#111111', '#222222'],
+          colorAssignmentMode: 'by-value',
+          colorAssignments: [
+            { key: 'series_a', color: '#111111' },
+            { key: 'series_b', color: '#222222' }
+          ]
+        }
+      } as any
+    })
+    const { updateConfig, rerenderPanel } = renderPanel(initialConfig, {
+      qualitative_standard: [
+        '#0057B7',
+        '#722161',
+        '#00B1CE',
+        '#D94E5F',
+        '#5A8E3F',
+        '#FFB24D',
+        '#FB7E38',
+        '#032659',
+        '#975722'
+      ]
+    })
+
+    updateConfig.mockClear()
+    rerenderPanel(
+      buildConfig({
+        general: {
+          palette: {
+            name: 'qualitative_standard',
+            version: '2.0',
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [
+              { key: 'series_a', color: '#111111' },
+              { key: 'series_b', color: '#222222' }
+            ]
+          }
+        } as any
+      })
+    )
+
+    expect(updateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        general: expect.objectContaining({
+          palette: expect.objectContaining({
+            colorAssignments: [
+              { key: 'series_a', color: '#0057B7' },
+              { key: 'series_b', color: '#5A8E3F' }
+            ]
+          })
+        })
+      })
+    )
+  })
+
+  it('hides assignments for single-series bars colored by category', () => {
+    renderPanel(
+      buildConfig({
+        visualizationType: 'Bar',
+        visualizationSubType: 'regular',
+        legend: { colorCode: 'category' } as any,
+        series: [{ dataKey: 'series_a', name: 'Alpha', type: 'Bar' }] as any
+      })
+    )
+
+    expect(screen.queryByLabelText('Color Assignment Mode')).not.toBeInTheDocument()
+  })
+})

--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
@@ -32,6 +32,7 @@ import { HeaderThemeSelector } from '@cdc/core/components/HeaderThemeSelector'
 import { CustomColorsEditor } from '@cdc/core/components/CustomColorsEditor'
 import StyleTreatmentSection from '@cdc/core/components/EditorPanel/sections/StyleTreatmentSection'
 import { getColorScale } from '../../../../helpers/getColorScale'
+import SeriesColorAssignments from './SeriesColorAssignments'
 import { ENABLE_CHART_MAP_TP5_TREATMENT_SELECTION, ENABLE_CHART_VISUAL_SETTINGS } from '@cdc/core/helpers/constants'
 import '@cdc/core/components/EditorPanel/editor.scss'
 import './panelVisual.styles.css'
@@ -457,6 +458,8 @@ const PanelVisual: FC<PanelProps> = props => {
                 )}
               </>
             )}
+
+            <SeriesColorAssignments config={config} updateConfig={updateConfig} colorPalettes={colorPalettes} />
           </>
         )}
         {config.visualizationType === 'Sankey' && (

--- a/packages/chart/src/components/EditorPanel/components/Panels/SeriesColorAssignments.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/SeriesColorAssignments.tsx
@@ -14,7 +14,8 @@ import {
   getSeriesColorAssignments,
   isSeriesColorAssignmentModeByValue,
   supportsSeriesColorAssignments,
-  type SeriesColorAssignment
+  type SeriesColorAssignment,
+  type SeriesColorAssignmentItem
 } from '../../../../helpers/colorAssignmentHelpers'
 
 type SeriesColorAssignmentsProps = {
@@ -30,6 +31,10 @@ const SeriesColorAssignments = ({ config, updateConfig, colorPalettes }: SeriesC
     () => new Map(seriesColorAssignments.map(assignment => [assignment.key, assignment.color])),
     [seriesColorAssignments]
   )
+  const seriesColorAssignmentItemsFingerprint = seriesColorAssignmentItems
+    .map(({ key, label }) => `${key}:${label}`)
+    .join('|')
+  const seriesColorAssignmentsFingerprint = seriesColorAssignments.map(({ key, color }) => `${key}:${color}`).join('|')
   const seriesColorAssignmentSupported = supportsSeriesColorAssignments(config)
   const seriesColorAssignmentMode = config.general?.palette?.colorAssignmentMode || 'ordered'
   const isSeriesColorAssignmentByValue = isSeriesColorAssignmentModeByValue(config)
@@ -72,17 +77,39 @@ const SeriesColorAssignments = ({ config, updateConfig, colorPalettes }: SeriesC
     : `${currentPaletteName}|${paletteColorOptions.join('|')}`
   const previousPaletteSource = useRef<{ hasCustomColors: boolean; fingerprint: string } | null>(null)
 
-  const getAssignmentsFromCurrentColors = (): SeriesColorAssignment[] => {
-    return seriesColorAssignmentItems.map(({ key, label }, index) => {
-      const orderedColor = orderedColorScale(label)
-      const color = paletteColorOptions.includes(orderedColor)
-        ? orderedColor
-        : distributedPaletteColorOptions[index % distributedPaletteColorOptions.length] ||
+  const getColorForAssignmentItem = ({ label }: SeriesColorAssignmentItem, index: number): string => {
+    const orderedColor = orderedColorScale(label)
+    return paletteColorOptions.includes(orderedColor)
+      ? orderedColor
+      : distributedPaletteColorOptions[index % distributedPaletteColorOptions.length] ||
           paletteColorOptions[index % paletteColorOptions.length] ||
           '#000000'
+  }
 
-      return { key, color }
+  const getAssignmentsFromCurrentColors = (): SeriesColorAssignment[] =>
+    seriesColorAssignmentItems.map((item, index) => ({
+      key: item.key,
+      color: getColorForAssignmentItem(item, index)
+    }))
+
+  const getAssignmentsWithMissingCurrentColors = (): SeriesColorAssignment[] | null => {
+    const assignments = [...seriesColorAssignments]
+    let hasMissingAssignment = false
+
+    seriesColorAssignmentItems.forEach((item, index) => {
+      const existingIndex = assignments.findIndex(assignment => assignment.key === item.key)
+      const nextAssignment = { key: item.key, color: getColorForAssignmentItem(item, index) }
+
+      if (existingIndex === -1) {
+        assignments.push(nextAssignment)
+        hasMissingAssignment = true
+      } else if (!assignments[existingIndex]?.color) {
+        assignments[existingIndex] = nextAssignment
+        hasMissingAssignment = true
+      }
     })
+
+    return hasMissingAssignment ? assignments : null
   }
 
   const updateSeriesColorAssignmentMode = (mode: 'ordered' | 'by-value') => {
@@ -138,12 +165,8 @@ const SeriesColorAssignments = ({ config, updateConfig, colorPalettes }: SeriesC
       return
     }
 
-    if (previousPaletteSource.current === null) {
-      previousPaletteSource.current = currentSource
-      return
-    }
-
     const shouldResetFromPalette =
+      previousPaletteSource.current !== null &&
       !hasCustomColors &&
       paletteColorOptions.length > 0 &&
       (previousPaletteSource.current.hasCustomColors ||
@@ -153,8 +176,28 @@ const SeriesColorAssignments = ({ config, updateConfig, colorPalettes }: SeriesC
 
     if (shouldResetFromPalette) {
       resetSeriesColorAssignmentsToCurrentColors()
+      return
     }
-  }, [hasCustomColors, isSeriesColorAssignmentByValue, paletteSourceFingerprint, seriesColorAssignmentSupported])
+
+    const assignmentsWithMissingCurrentColors = getAssignmentsWithMissingCurrentColors()
+    if (assignmentsWithMissingCurrentColors) {
+      const _state = cloneConfig(config)
+      if (!_state.general.palette) {
+        _state.general.palette = {}
+      }
+
+      _state.general.palette.colorAssignmentMode = 'by-value'
+      _state.general.palette.colorAssignments = assignmentsWithMissingCurrentColors
+      updateConfig(_state)
+    }
+  }, [
+    hasCustomColors,
+    isSeriesColorAssignmentByValue,
+    paletteSourceFingerprint,
+    seriesColorAssignmentItemsFingerprint,
+    seriesColorAssignmentsFingerprint,
+    seriesColorAssignmentSupported
+  ])
 
   if (!seriesColorAssignmentSupported) return null
 

--- a/packages/chart/src/components/EditorPanel/components/Panels/SeriesColorAssignments.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/SeriesColorAssignments.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useRef } from 'react'
+import cloneConfig from '@cdc/core/helpers/cloneConfig'
+import { Select } from '@cdc/core/components/EditorPanel/Inputs'
+import Tooltip from '@cdc/core/components/ui/Tooltip'
+import Icon from '@cdc/core/components/ui/Icon'
+import { DataColorSelector } from '@cdc/core/components/DataColorSelector'
+import { getColorPaletteVersion } from '@cdc/core/helpers/getColorPaletteVersion'
+import { getCurrentPaletteName, migratePaletteWithMap } from '@cdc/core/helpers/palettes/utils'
+import { paletteMigrationMap } from '@cdc/core/helpers/palettes/migratePaletteName'
+import { getColorScale } from '../../../../helpers/getColorScale'
+import { ChartConfig } from '../../../../types/ChartConfig'
+import {
+  getSeriesColorAssignmentItems,
+  getSeriesColorAssignments,
+  isSeriesColorAssignmentModeByValue,
+  supportsSeriesColorAssignments,
+  type SeriesColorAssignment
+} from '../../../../helpers/colorAssignmentHelpers'
+
+type SeriesColorAssignmentsProps = {
+  config: ChartConfig
+  updateConfig: (config: ChartConfig) => void
+  colorPalettes: Record<string, any>
+}
+
+const SeriesColorAssignments = ({ config, updateConfig, colorPalettes }: SeriesColorAssignmentsProps) => {
+  const seriesColorAssignmentItems = useMemo(() => getSeriesColorAssignmentItems(config), [config])
+  const seriesColorAssignments = getSeriesColorAssignments(config)
+  const seriesColorAssignmentMap = useMemo(
+    () => new Map(seriesColorAssignments.map(assignment => [assignment.key, assignment.color])),
+    [seriesColorAssignments]
+  )
+  const seriesColorAssignmentSupported = supportsSeriesColorAssignments(config)
+  const seriesColorAssignmentMode = config.general?.palette?.colorAssignmentMode || 'ordered'
+  const isSeriesColorAssignmentByValue = isSeriesColorAssignmentModeByValue(config)
+  const currentPaletteName = getCurrentPaletteName(config)
+  const customColors = config.general?.palette?.customColorsOrdered || config.general?.palette?.customColors
+  const hasCustomColors = Array.isArray(customColors) && customColors.length > 0
+
+  const getOrderedColorScaleConfig = () => ({
+    ...config,
+    general: {
+      ...config.general,
+      palette: {
+        ...config.general?.palette,
+        colorAssignmentMode: 'ordered' as const
+      }
+    }
+  })
+
+  const orderedColorScaleConfig = useMemo(getOrderedColorScaleConfig, [config])
+  const orderedColorScale = useMemo(() => getColorScale(orderedColorScaleConfig), [orderedColorScaleConfig])
+  const distributedPaletteColorOptions = useMemo(() => {
+    const colors = (orderedColorScale as any)?.range?.() || []
+    return Array.from(new Set(colors.filter(Boolean)))
+  }, [orderedColorScale])
+  const paletteColorOptions = useMemo(() => {
+    if (hasCustomColors) {
+      return Array.from(new Set(customColors.filter(Boolean)))
+    }
+
+    const version = getColorPaletteVersion(config)
+    const versionedPalettes = colorPalettes?.[`v${version}`] || colorPalettes?.v2 || colorPalettes || {}
+    const paletteName = migratePaletteWithMap(currentPaletteName, paletteMigrationMap, false)
+    const colors =
+      versionedPalettes[paletteName] || versionedPalettes[currentPaletteName] || distributedPaletteColorOptions
+
+    return Array.from(new Set(colors.filter(Boolean)))
+  }, [colorPalettes, config, customColors, hasCustomColors, currentPaletteName, distributedPaletteColorOptions])
+  const paletteSourceFingerprint = hasCustomColors
+    ? 'custom-colors'
+    : `${currentPaletteName}|${paletteColorOptions.join('|')}`
+  const previousPaletteSource = useRef<{ hasCustomColors: boolean; fingerprint: string } | null>(null)
+
+  const getAssignmentsFromCurrentColors = (): SeriesColorAssignment[] => {
+    return seriesColorAssignmentItems.map(({ key, label }, index) => {
+      const orderedColor = orderedColorScale(label)
+      const color = paletteColorOptions.includes(orderedColor)
+        ? orderedColor
+        : distributedPaletteColorOptions[index % distributedPaletteColorOptions.length] ||
+          paletteColorOptions[index % paletteColorOptions.length] ||
+          '#000000'
+
+      return { key, color }
+    })
+  }
+
+  const updateSeriesColorAssignmentMode = (mode: 'ordered' | 'by-value') => {
+    const _state = cloneConfig(config)
+    if (!_state.general.palette) {
+      _state.general.palette = {}
+    }
+
+    _state.general.palette.colorAssignmentMode = mode
+    if (mode === 'by-value') {
+      _state.general.palette.colorAssignments = getAssignmentsFromCurrentColors()
+    }
+
+    updateConfig(_state)
+  }
+
+  const resetSeriesColorAssignmentsToCurrentColors = () => {
+    const _state = cloneConfig(config)
+    if (!_state.general.palette) {
+      _state.general.palette = {}
+    }
+
+    _state.general.palette.colorAssignmentMode = 'by-value'
+    _state.general.palette.colorAssignments = getAssignmentsFromCurrentColors()
+    updateConfig(_state)
+  }
+
+  const updateSeriesColorAssignment = (key: string, color: string) => {
+    const _state = cloneConfig(config)
+    if (!_state.general.palette) {
+      _state.general.palette = {}
+    }
+
+    const currentSeriesKeys = new Set(seriesColorAssignmentItems.map(({ key }) => key))
+    const assignments = seriesColorAssignments.filter(assignment => currentSeriesKeys.has(assignment.key))
+    const existingIndex = assignments.findIndex(assignment => assignment.key === key)
+    if (existingIndex === -1) {
+      assignments.push({ key, color })
+    } else {
+      assignments[existingIndex] = { key, color }
+    }
+
+    _state.general.palette.colorAssignmentMode = 'by-value'
+    _state.general.palette.colorAssignments = assignments
+    updateConfig(_state)
+  }
+
+  useEffect(() => {
+    const currentSource = { hasCustomColors, fingerprint: paletteSourceFingerprint }
+
+    if (!seriesColorAssignmentSupported || !isSeriesColorAssignmentByValue) {
+      previousPaletteSource.current = currentSource
+      return
+    }
+
+    if (previousPaletteSource.current === null) {
+      previousPaletteSource.current = currentSource
+      return
+    }
+
+    const shouldResetFromPalette =
+      !hasCustomColors &&
+      paletteColorOptions.length > 0 &&
+      (previousPaletteSource.current.hasCustomColors ||
+        previousPaletteSource.current.fingerprint !== paletteSourceFingerprint)
+
+    previousPaletteSource.current = currentSource
+
+    if (shouldResetFromPalette) {
+      resetSeriesColorAssignmentsToCurrentColors()
+    }
+  }, [hasCustomColors, isSeriesColorAssignmentByValue, paletteSourceFingerprint, seriesColorAssignmentSupported])
+
+  if (!seriesColorAssignmentSupported) return null
+
+  return (
+    <fieldset className='series-color-assignments'>
+      <Select
+        value={seriesColorAssignmentMode}
+        label='Color Assignment Mode'
+        tooltip={
+          <Tooltip style={{ textTransform: 'none' }}>
+            <Tooltip.Target>
+              <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+            </Tooltip.Target>
+            <Tooltip.Content>
+              <p>
+                Toggling this determines how colors in the palette are assigned. Colors can be assigned in order or can
+                be associated with specific series.
+              </p>
+            </Tooltip.Content>
+          </Tooltip>
+        }
+        fieldName='colorAssignmentMode'
+        section='general'
+        subsection='palette'
+        updateField={(_section, _subsection, _fieldName, value) => {
+          updateSeriesColorAssignmentMode(value as 'ordered' | 'by-value')
+        }}
+        options={[
+          { label: 'Use palette order', value: 'ordered' },
+          { label: 'Assign colors to series', value: 'by-value' }
+        ]}
+      />
+      {isSeriesColorAssignmentByValue && (
+        <div className='series-color-assignments__rows'>
+          {seriesColorAssignmentItems.map(({ key, label }) => {
+            const assignedColor = seriesColorAssignmentMap.get(key)
+            const color = assignedColor || orderedColorScale(label) || paletteColorOptions[0] || '#000000'
+
+            return (
+              <div className='series-color-assignments__row' key={key}>
+                <label className='series-color-assignments__label' title={`Series key: ${key}`}>
+                  {label}
+                </label>
+                <DataColorSelector
+                  aria-label={`Color for ${label}`}
+                  value={color}
+                  colors={paletteColorOptions}
+                  allowNone={false}
+                  allowCustom={false}
+                  showCustomValue={false}
+                  onChange={nextColor => updateSeriesColorAssignment(key, nextColor)}
+                />
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </fieldset>
+  )
+}
+
+export default SeriesColorAssignments

--- a/packages/chart/src/components/EditorPanel/components/Panels/panelVisual.styles.css
+++ b/packages/chart/src/components/EditorPanel/components/Panels/panelVisual.styles.css
@@ -1,0 +1,32 @@
+.series-color-assignments {
+  border: 1px solid #d6d7d9;
+  border-radius: 4px;
+  margin-top: 1rem;
+  padding: 0.875rem;
+}
+
+.series-color-assignments__rows {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.series-color-assignments__row {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.series-color-assignments__label {
+  color: #222;
+  display: block;
+  font-size: 0.875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.series-color-assignments__row .data-color-selector__trigger {
+  justify-self: end;
+}

--- a/packages/chart/src/components/EditorPanel/components/panels.scss
+++ b/packages/chart/src/components/EditorPanel/components/panels.scss
@@ -83,3 +83,13 @@
 .annotation-group {
   border: 1px solid black;
 }
+
+.small-multiples-color-assignment-warning {
+  background: #fff7e6;
+  border-left: 3px solid #a65f00;
+  color: #3d2a00;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  margin: 0.75rem 0 1rem;
+  padding: 0.5rem 0.75rem;
+}

--- a/packages/chart/src/components/EditorPanel/useEditorPermissions.test.tsx
+++ b/packages/chart/src/components/EditorPanel/useEditorPermissions.test.tsx
@@ -67,4 +67,20 @@ describe('useEditorPermissions', () => {
 
     expect(result.current.visSupportsYPadding()).toBe(true)
   })
+
+  it('supports series color assignments only for eligible authored-series charts', () => {
+    const supported = renderUseEditorPermissions({
+      visualizationType: 'Line',
+      series: [{ dataKey: 'cases', type: 'Line' }] as any
+    })
+
+    expect(supported.result.current.visSupportsSeriesColorAssignments()).toBe(true)
+
+    const unsupported = renderUseEditorPermissions({
+      visualizationType: 'Pie',
+      series: [{ dataKey: 'cases', type: 'Pie' }] as any
+    })
+
+    expect(unsupported.result.current.visSupportsSeriesColorAssignments()).toBe(false)
+  })
 })

--- a/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
+++ b/packages/chart/src/components/EditorPanel/useEditorPermissions.ts
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import ConfigContext from '../../ConfigContext'
 import { getYAxisAutoPaddingMode } from '../../helpers/getYAxisAutoPaddingMode'
+import { supportsSeriesColorAssignments } from '../../helpers/colorAssignmentHelpers'
 
 export const useEditorPermissions = () => {
   const { config } = useContext(ConfigContext)
@@ -426,6 +427,8 @@ export const useEditorPermissions = () => {
     return false
   }
 
+  const visSupportsSeriesColorAssignments = () => supportsSeriesColorAssignments(config)
+
   const visSupportsYPadding = () => {
     return getYAxisAutoPaddingMode(config) === 'none'
   }
@@ -497,6 +500,7 @@ export const useEditorPermissions = () => {
     visSupportsResponsiveTicks,
     visSupportsReverseColorPalette,
     visSupportsSequentialPallete,
+    visSupportsSeriesColorAssignments,
     visSupportsSmallMultiples,
     visSupportsSuperTitle,
     visSupportsTooltipLines,

--- a/packages/chart/src/components/Legend/helpers/createFormatLabels.test.ts
+++ b/packages/chart/src/components/Legend/helpers/createFormatLabels.test.ts
@@ -1,0 +1,73 @@
+import { scaleOrdinal } from '@visx/scale'
+import { describe, expect, it, vi } from 'vitest'
+import { createFormatLabels } from './createFormatLabels'
+import { ChartConfig } from '../../../types/ChartConfig'
+import { Label } from '../../../types/Label'
+
+const defaultLabels: Label[] = [
+  { datum: 'Series A', index: 0, text: 'Series A', value: '#aa0000' },
+  { datum: 'Series B', index: 1, text: 'Series B', value: '#00bb00' }
+]
+
+const buildConfig = (overrides: Partial<ChartConfig> = {}): ChartConfig =>
+  ({
+    visualizationType: 'Line',
+    visualizationSubType: 'regular',
+    general: {
+      palette: {
+        colorAssignmentMode: 'ordered'
+      }
+    },
+    legend: {},
+    smallMultiples: {
+      mode: 'by-series',
+      colorMode: 'same'
+    },
+    series: [
+      { dataKey: 'series_a', name: 'Series A', type: 'Line' },
+      { dataKey: 'series_b', name: 'Series B', type: 'Line' }
+    ],
+    runtime: {
+      seriesKeys: ['series_a', 'series_b'],
+      seriesLabels: {
+        series_a: 'Series A',
+        series_b: 'Series B'
+      },
+      seriesLabelsAll: ['Series A', 'Series B']
+    },
+    ...overrides
+  } as ChartConfig)
+
+const colorScale = scaleOrdinal({
+  domain: ['Series A', 'Series B'],
+  range: ['#aa0000', '#00bb00'],
+  unknown: null
+})
+
+const formatLabels = (config: ChartConfig) => createFormatLabels(config, [], [], colorScale, vi.fn())(defaultLabels)
+
+describe('createFormatLabels small multiples legend colors', () => {
+  it('uses the first color for by-series same-color legends by default', () => {
+    const labels = formatLabels(buildConfig())
+
+    expect(labels.map(label => label.value)).toEqual(['#aa0000', '#aa0000'])
+  })
+
+  it('preserves assigned series colors for by-series same-color legends', () => {
+    const labels = formatLabels(
+      buildConfig({
+        general: {
+          palette: {
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [
+              { key: 'series_a', color: '#aa0000' },
+              { key: 'series_b', color: '#00bb00' }
+            ]
+          }
+        } as any
+      })
+    )
+
+    expect(labels.map(label => label.value)).toEqual(['#aa0000', '#00bb00'])
+  })
+})

--- a/packages/chart/src/components/Legend/helpers/createFormatLabels.test.ts
+++ b/packages/chart/src/components/Legend/helpers/createFormatLabels.test.ts
@@ -70,4 +70,19 @@ describe('createFormatLabels small multiples legend colors', () => {
 
     expect(labels.map(label => label.value)).toEqual(['#aa0000', '#00bb00'])
   })
+
+  it('ignores stale assignments for by-series same-color legends', () => {
+    const labels = formatLabels(
+      buildConfig({
+        general: {
+          palette: {
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [{ key: 'removed_series', color: '#00bb00' }]
+          }
+        } as any
+      })
+    )
+
+    expect(labels.map(label => label.value)).toEqual(['#aa0000', '#aa0000'])
+  })
 })

--- a/packages/chart/src/components/Legend/helpers/createFormatLabels.tsx
+++ b/packages/chart/src/components/Legend/helpers/createFormatLabels.tsx
@@ -13,6 +13,7 @@ import { v2ColorDistribution } from '@cdc/core/helpers/palettes/colorDistributio
 import { updatePaletteNames } from '@cdc/core/helpers/updatePaletteNames'
 import { buildForecastPaletteMappings } from '../../../helpers/buildForecastPaletteMappings'
 import { getFullColorPalette } from '../../../helpers/smallMultiplesHelpers'
+import { hasSeriesColorAssignmentOverrides } from '../../../helpers/colorAssignmentHelpers'
 import { FaStar } from 'react-icons/fa'
 import { Label } from '../../../types/Label'
 import { ColorScale, TransformedData } from '../../../types/ChartContext'
@@ -36,7 +37,11 @@ export const createFormatLabels =
 
     // Handle small multiples legend adjustments
     // by-series + same: all tiles use same color, legend should show one color
-    if (config.smallMultiples?.mode === 'by-series' && config.smallMultiples?.colorMode === 'same') {
+    if (
+      config.smallMultiples?.mode === 'by-series' &&
+      config.smallMultiples?.colorMode === 'same' &&
+      !hasSeriesColorAssignmentOverrides(config)
+    ) {
       const baseColor = colorScale?.range()?.[0]
       return defaultLabels.map((label, i) => ({
         ...label,

--- a/packages/chart/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/packages/chart/src/components/ScatterPlot/ScatterPlot.jsx
@@ -61,7 +61,7 @@ const ScatterPlot = ({ xScale, yScale, yAxisWidth }) => {
         return config.runtime.seriesKeys.map((s, index) => {
           const transparentArea = config.legend.behavior === 'highlight' && seriesHighlight.length > 0 && seriesHighlight.indexOf(s) === -1
           const displayArea = config.legend.behavior === 'highlight' || seriesHighlight.length === 0 || seriesHighlight.indexOf(s) !== -1
-          const seriesColor = config?.general?.palette?.customColors ? config.general.palette.customColors[index] : colorScale(config.runtime.seriesLabels?.[s] || s)
+          const seriesColor = colorScale(config.runtime.seriesLabels?.[s] || s)
 
           let pointStyles = {
             filter: 'unset',

--- a/packages/chart/src/helpers/colorAssignmentHelpers.ts
+++ b/packages/chart/src/helpers/colorAssignmentHelpers.ts
@@ -1,0 +1,95 @@
+import { type ChartConfig, type VisualizationType } from '../types/ChartConfig'
+
+export type SeriesColorAssignment = {
+  key: string
+  color: string
+}
+
+export type SeriesColorAssignmentItem = {
+  key: string
+  label: string
+}
+
+export const SERIES_COLOR_ASSIGNMENT_TYPES: VisualizationType[] = ['Line', 'Bar', 'Combo', 'Area Chart', 'Scatter Plot']
+
+export const hasDynamicCategorySeries = (config: ChartConfig): boolean =>
+  Array.isArray(config.series) && config.series.some(series => Boolean(series?.dynamicCategory))
+
+export const isColorByCategoryBarChart = (config: ChartConfig): boolean =>
+  config.visualizationType === 'Bar' &&
+  config.visualizationSubType === 'regular' &&
+  Boolean(config.legend?.colorCode) &&
+  (config.series?.length || 0) === 1
+
+export const supportsSeriesColorAssignments = (config: ChartConfig): boolean =>
+  SERIES_COLOR_ASSIGNMENT_TYPES.includes(config.visualizationType) &&
+  !hasDynamicCategorySeries(config) &&
+  !isColorByCategoryBarChart(config)
+
+export const isSeriesColorAssignmentModeByValue = (config: ChartConfig): boolean =>
+  config.general?.palette?.colorAssignmentMode === 'by-value'
+
+export const getSeriesColorAssignments = (config: ChartConfig): SeriesColorAssignment[] =>
+  Array.isArray(config.general?.palette?.colorAssignments) ? config.general.palette.colorAssignments : []
+
+export const hasSeriesColorAssignmentOverrides = (config: ChartConfig): boolean =>
+  supportsSeriesColorAssignments(config) &&
+  isSeriesColorAssignmentModeByValue(config) &&
+  getSeriesColorAssignments(config).length > 0
+
+export const getSeriesDisplayLabel = (config: ChartConfig, key: string): string => {
+  const series = config.series?.find(item => item?.dataKey === key)
+  return String(config.runtime?.seriesLabels?.[key] || series?.name || (series as any)?.label || key)
+}
+
+export const getSeriesColorAssignmentItems = (config: ChartConfig): SeriesColorAssignmentItem[] => {
+  if (!supportsSeriesColorAssignments(config) || !Array.isArray(config.series)) return []
+
+  return config.series
+    .filter(series => series?.dataKey && !series.dynamicCategory)
+    .map(series => ({
+      key: series.dataKey,
+      label: getSeriesDisplayLabel(config, series.dataKey)
+    }))
+}
+
+export const getSeriesKeyByColorScaleLabel = (config: ChartConfig): Map<string, string> => {
+  const labelToKey = new Map<string, string>()
+  const runtimeKeys = Array.isArray(config.runtime?.seriesKeys) ? config.runtime.seriesKeys : []
+
+  runtimeKeys.forEach(key => {
+    labelToKey.set(String(key), key)
+    labelToKey.set(getSeriesDisplayLabel(config, key), key)
+  })
+
+  getSeriesColorAssignmentItems(config).forEach(({ key, label }) => {
+    labelToKey.set(String(key), key)
+    labelToKey.set(label, key)
+  })
+
+  return labelToKey
+}
+
+export const applySeriesColorAssignmentsToRange = (
+  config: ChartConfig,
+  domain: string[] = [],
+  range: string[] = []
+): string[] => {
+  if (!supportsSeriesColorAssignments(config) || !isSeriesColorAssignmentModeByValue(config)) return range
+
+  const assignmentMap = new Map(
+    getSeriesColorAssignments(config)
+      .filter(assignment => assignment?.key && assignment?.color)
+      .map(assignment => [assignment.key, assignment.color])
+  )
+
+  if (!assignmentMap.size || !range.length) return range
+
+  const labelToKey = getSeriesKeyByColorScaleLabel(config)
+
+  return domain.map((label, index) => {
+    const key = labelToKey.get(String(label))
+    const assignedColor = key ? assignmentMap.get(key) : undefined
+    return assignedColor || range[index % range.length]
+  })
+}

--- a/packages/chart/src/helpers/colorAssignmentHelpers.ts
+++ b/packages/chart/src/helpers/colorAssignmentHelpers.ts
@@ -32,10 +32,17 @@ export const isSeriesColorAssignmentModeByValue = (config: ChartConfig): boolean
 export const getSeriesColorAssignments = (config: ChartConfig): SeriesColorAssignment[] =>
   Array.isArray(config.general?.palette?.colorAssignments) ? config.general.palette.colorAssignments : []
 
-export const hasSeriesColorAssignmentOverrides = (config: ChartConfig): boolean =>
-  supportsSeriesColorAssignments(config) &&
-  isSeriesColorAssignmentModeByValue(config) &&
-  getSeriesColorAssignments(config).length > 0
+export const hasSeriesColorAssignmentOverrides = (config: ChartConfig): boolean => {
+  if (!supportsSeriesColorAssignments(config) || !isSeriesColorAssignmentModeByValue(config)) return false
+
+  const currentSeriesKeys = new Set(getSeriesColorAssignmentItems(config).map(({ key }) => key))
+
+  return getSeriesColorAssignments(config).some(assignment => {
+    if (!assignment?.key || !assignment?.color) return false
+
+    return currentSeriesKeys.has(assignment.key)
+  })
+}
 
 export const getSeriesDisplayLabel = (config: ChartConfig, key: string): string => {
   const series = config.series?.find(item => item?.dataKey === key)

--- a/packages/chart/src/helpers/getColorScale.ts
+++ b/packages/chart/src/helpers/getColorScale.ts
@@ -10,6 +10,7 @@ import {
   divergentColorDistribution,
   colorblindColorDistribution
 } from '@cdc/core/helpers/palettes/colorDistributions'
+import { applySeriesColorAssignmentsToRange } from './colorAssignmentHelpers'
 
 export const getColorScale = (config: ChartConfig): ((value: string) => string) => {
   const configPalette = ['Paired Bar', 'Deviation Bar'].includes(config.visualizationType)
@@ -32,16 +33,20 @@ export const getColorScale = (config: ChartConfig): ((value: string) => string) 
   // Migrate old palette name if needed
   const migratedPaletteName = configPalette ? configPalette : getFallbackColorPalette(config)
 
+  const domain = config.runtime.seriesLabelsAll
+
   // Check for customColorsOrdered first (direct 1-to-1 mapping, no distribution needed)
   if (config.general?.palette?.customColorsOrdered && Array.isArray(config.general.palette.customColorsOrdered)) {
     const customColorsOrdered = config.general.palette.customColorsOrdered
+    const range = applySeriesColorAssignmentsToRange(config, domain, customColorsOrdered)
     return scaleOrdinal({
-      domain: config.runtime.seriesLabelsAll,
-      range: customColorsOrdered,
+      domain,
+      range,
       unknown: null
     })
   }
 
+  const isUsingCustomColors = Boolean(config.general?.palette?.customColors)
   let palette =
     config.general?.palette?.customColors ||
     palettesSource[migratePaletteWithMap(migratedPaletteName, paletteMigrationMap, false)] ||
@@ -58,8 +63,8 @@ export const getColorScale = (config: ChartConfig): ((value: string) => string) 
   // Apply enhanced color distribution (same logic as pie charts)
   const paletteVersion = getColorPaletteVersion(config)
 
-  // Skip enhanced distribution if not v2, too many keys, or wrong palette length
-  if (paletteVersion !== 2 || numberOfKeys > 9 || palette.length !== 9) {
+  // Skip enhanced distribution if using custom colors, not v2, too many keys, or wrong palette length
+  if (isUsingCustomColors || paletteVersion !== 2 || numberOfKeys > 9 || palette.length !== 9) {
     // Use existing logic for v1 palettes and other cases
     while (numberOfKeys > palette.length) {
       palette = palette.concat(palette)
@@ -90,9 +95,11 @@ export const getColorScale = (config: ChartConfig): ((value: string) => string) 
     }
   }
 
+  const range = applySeriesColorAssignmentsToRange(config, domain, palette)
+
   return scaleOrdinal({
-    domain: config.runtime.seriesLabelsAll,
-    range: palette,
+    domain,
+    range,
     unknown: null
   })
 }

--- a/packages/chart/src/helpers/getColorScale.ts
+++ b/packages/chart/src/helpers/getColorScale.ts
@@ -35,9 +35,10 @@ export const getColorScale = (config: ChartConfig): ((value: string) => string) 
 
   const domain = config.runtime.seriesLabelsAll
 
+  const customColorsOrdered = config.general?.palette?.customColorsOrdered
+
   // Check for customColorsOrdered first (direct 1-to-1 mapping, no distribution needed)
-  if (config.general?.palette?.customColorsOrdered && Array.isArray(config.general.palette.customColorsOrdered)) {
-    const customColorsOrdered = config.general.palette.customColorsOrdered
+  if (Array.isArray(customColorsOrdered) && customColorsOrdered.length > 0) {
     const range = applySeriesColorAssignmentsToRange(config, domain, customColorsOrdered)
     return scaleOrdinal({
       domain,
@@ -46,9 +47,10 @@ export const getColorScale = (config: ChartConfig): ((value: string) => string) 
     })
   }
 
-  const isUsingCustomColors = Boolean(config.general?.palette?.customColors)
+  const customColors = config.general?.palette?.customColors
+  const isUsingCustomColors = Array.isArray(customColors) && customColors.length > 0
   let palette =
-    config.general?.palette?.customColors ||
+    (isUsingCustomColors ? customColors : undefined) ||
     palettesSource[migratePaletteWithMap(migratedPaletteName, paletteMigrationMap, false)] ||
     palettesSource[configPalette]
 

--- a/packages/chart/src/helpers/smallMultiplesHelpers.ts
+++ b/packages/chart/src/helpers/smallMultiplesHelpers.ts
@@ -1,6 +1,7 @@
 import { scaleOrdinal } from '@visx/scale'
 import { getColorScale } from './getColorScale'
 import { ColorScale } from '../types/ChartContext'
+import { hasSeriesColorAssignmentOverrides } from './colorAssignmentHelpers'
 
 /**
  * Get filtered data for a specific tile based on its mode
@@ -205,6 +206,10 @@ export const getFullColorPalette = (config, numberOfTiles) => {
  */
 export const createTileColorScale = (tileItem, config, originalColorScale, tileIndex, numberOfTiles) => {
   const colorMode = config.smallMultiples?.colorMode || 'same'
+
+  if (tileItem.mode === 'by-series' && hasSeriesColorAssignmentOverrides(config)) {
+    return originalColorScale
+  }
 
   if (colorMode === 'same') {
     if (tileItem.mode === 'by-series') {

--- a/packages/chart/src/helpers/tests/getColorScale.test.ts
+++ b/packages/chart/src/helpers/tests/getColorScale.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { getColorScale } from '../getColorScale'
+import { ChartConfig } from '../../types/ChartConfig'
+
+const buildConfig = (overrides: Partial<ChartConfig> = {}): ChartConfig =>
+  ({
+    visualizationType: 'Line',
+    visualizationSubType: 'regular',
+    general: {
+      palette: {
+        customColors: ['#111111', '#222222', '#333333'],
+        colorAssignmentMode: 'by-value',
+        colorAssignments: [
+          { key: 'series_a', color: '#aa0000' },
+          { key: 'series_c', color: '#00cc00' }
+        ]
+      }
+    },
+    legend: {},
+    series: [
+      { dataKey: 'series_a', name: 'Series A', type: 'Line' },
+      { dataKey: 'series_b', name: 'Series B', type: 'Line' },
+      { dataKey: 'series_c', name: 'Series C', type: 'Line' }
+    ],
+    runtime: {
+      seriesKeys: ['series_a', 'series_b', 'series_c'],
+      seriesLabels: {
+        series_a: 'Series A',
+        series_b: 'Series B',
+        series_c: 'Series C'
+      },
+      seriesLabelsAll: ['Series A', 'Series B', 'Series C']
+    },
+    ...overrides
+  } as ChartConfig)
+
+describe('getColorScale series color assignments', () => {
+  it('keeps assigned series colors stable when runtime series order changes', () => {
+    const colorScale = getColorScale(
+      buildConfig({
+        runtime: {
+          seriesKeys: ['series_c', 'series_a'],
+          seriesLabels: {
+            series_a: 'Series A',
+            series_c: 'Series C'
+          },
+          seriesLabelsAll: ['Series C', 'Series A']
+        } as any
+      })
+    )
+
+    expect(colorScale('Series A')).toBe('#aa0000')
+    expect(colorScale('Series C')).toBe('#00cc00')
+  })
+
+  it('keeps assigned colors when missing series later reappear', () => {
+    const filteredScale = getColorScale(
+      buildConfig({
+        runtime: {
+          seriesKeys: ['series_a'],
+          seriesLabels: { series_a: 'Series A' },
+          seriesLabelsAll: ['Series A']
+        } as any
+      })
+    )
+    const restoredScale = getColorScale(buildConfig())
+
+    expect(filteredScale('Series A')).toBe('#aa0000')
+    expect(restoredScale('Series C')).toBe('#00cc00')
+  })
+
+  it('uses ordered palette/custom fallback for unassigned series', () => {
+    const colorScale = getColorScale(buildConfig())
+
+    expect(colorScale('Series A')).toBe('#aa0000')
+    expect(colorScale('Series B')).toBe('#222222')
+    expect(colorScale('Series C')).toBe('#00cc00')
+  })
+
+  it('resolves assignments by dataKey when display labels differ', () => {
+    const colorScale = getColorScale(
+      buildConfig({
+        series: [{ dataKey: 'raw_value', name: 'Display Value', type: 'Line' }] as any,
+        runtime: {
+          seriesKeys: ['raw_value'],
+          seriesLabels: { raw_value: 'Display Value' },
+          seriesLabelsAll: ['Display Value']
+        } as any,
+        general: {
+          palette: {
+            customColors: ['#111111'],
+            colorAssignmentMode: 'by-value',
+            colorAssignments: [{ key: 'raw_value', color: '#123456' }]
+          }
+        } as any
+      })
+    )
+
+    expect(colorScale('Display Value')).toBe('#123456')
+  })
+
+  it('preserves ordered mode behavior when assignments are present', () => {
+    const colorScale = getColorScale(
+      buildConfig({
+        general: {
+          palette: {
+            customColors: ['#111111', '#222222', '#333333'],
+            colorAssignmentMode: 'ordered',
+            colorAssignments: [{ key: 'series_a', color: '#aa0000' }]
+          }
+        } as any
+      })
+    )
+
+    expect(colorScale('Series A')).toBe('#111111')
+    expect(colorScale('Series B')).toBe('#222222')
+  })
+
+  it('preserves scatter plot customColors through the shared scale', () => {
+    const colorScale = getColorScale(
+      buildConfig({
+        visualizationType: 'Scatter Plot',
+        general: {
+          palette: {
+            customColors: ['#101010', '#202020', '#303030']
+          }
+        } as any
+      })
+    )
+
+    expect(colorScale('Series A')).toBe('#101010')
+    expect(colorScale('Series B')).toBe('#202020')
+  })
+})

--- a/packages/chart/src/helpers/tests/getColorScale.test.ts
+++ b/packages/chart/src/helpers/tests/getColorScale.test.ts
@@ -159,4 +159,39 @@ describe('getColorScale series color assignments', () => {
     expect(colorScale('Series B')).toBe('#222222')
     expect(colorScale('Series C')).toBe('#333333')
   })
+
+  it('falls back to customColors when customColorsOrdered is empty', () => {
+    const colorScale = getColorScale(
+      buildConfig({
+        general: {
+          palette: {
+            customColorsOrdered: [],
+            customColors: ['#101010', '#202020', '#303030']
+          }
+        } as any
+      })
+    )
+
+    expect(colorScale('Series A')).toBe('#101010')
+    expect(colorScale('Series B')).toBe('#202020')
+    expect(colorScale('Series C')).toBe('#303030')
+  })
+
+  it('falls back to the named palette when customColors is empty', () => {
+    const colorScale = getColorScale(
+      buildConfig({
+        general: {
+          palette: {
+            name: 'qualitative_standard',
+            version: '2.0',
+            customColors: []
+          }
+        } as any
+      })
+    )
+
+    expect(colorScale('Series A')).toBe('#0057B7')
+    expect(colorScale('Series B')).toBe('#00B1CE')
+    expect(colorScale('Series C')).toBe('#5A8E3F')
+  })
 })

--- a/packages/chart/src/helpers/tests/getColorScale.test.ts
+++ b/packages/chart/src/helpers/tests/getColorScale.test.ts
@@ -131,4 +131,32 @@ describe('getColorScale series color assignments', () => {
     expect(colorScale('Series A')).toBe('#101010')
     expect(colorScale('Series B')).toBe('#202020')
   })
+
+  it('uses v2 customColors in authored order when customColorsOrdered is absent', () => {
+    const colorScale = getColorScale(
+      buildConfig({
+        general: {
+          palette: {
+            name: 'qualitative_standard',
+            version: '2.0',
+            customColors: [
+              '#111111',
+              '#222222',
+              '#333333',
+              '#444444',
+              '#555555',
+              '#666666',
+              '#777777',
+              '#888888',
+              '#999999'
+            ]
+          }
+        } as any
+      })
+    )
+
+    expect(colorScale('Series A')).toBe('#111111')
+    expect(colorScale('Series B')).toBe('#222222')
+    expect(colorScale('Series C')).toBe('#333333')
+  })
 })

--- a/packages/chart/src/helpers/tests/smallMultiplesHelpers.test.ts
+++ b/packages/chart/src/helpers/tests/smallMultiplesHelpers.test.ts
@@ -74,4 +74,26 @@ describe('smallMultiplesHelpers createTileColorScale', () => {
     expect(tileScale('Series A')).toBe('#aa0000')
     expect(tileScale('Series B')).toBe('#00bb00')
   })
+
+  it('ignores stale by-value assignments when deciding whether to override same color mode', () => {
+    const colorScale = scaleOrdinal({
+      domain: ['Series A', 'Series B'],
+      range: ['#aa0000', '#00bb00'],
+      unknown: null
+    })
+    const config = buildConfig({
+      general: {
+        palette: {
+          customColors: ['#111111', '#222222'],
+          colorAssignmentMode: 'by-value',
+          colorAssignments: [{ key: 'removed_series', color: '#00bb00' }]
+        }
+      } as any
+    })
+
+    const tileScale = createTileColorScale({ mode: 'by-series', seriesKey: 'series_b' }, config, colorScale, 1, 2)
+
+    expect(tileScale('Series A')).toBe('#aa0000')
+    expect(tileScale('Series B')).toBe('#aa0000')
+  })
 })

--- a/packages/chart/src/helpers/tests/smallMultiplesHelpers.test.ts
+++ b/packages/chart/src/helpers/tests/smallMultiplesHelpers.test.ts
@@ -1,0 +1,77 @@
+import { scaleOrdinal } from '@visx/scale'
+import { describe, expect, it } from 'vitest'
+import { createTileColorScale } from '../smallMultiplesHelpers'
+import { ChartConfig } from '../../types/ChartConfig'
+
+const buildConfig = (overrides: Partial<ChartConfig> = {}): ChartConfig =>
+  ({
+    visualizationType: 'Line',
+    visualizationSubType: 'regular',
+    general: {
+      palette: {
+        customColors: ['#111111', '#222222'],
+        colorAssignmentMode: 'ordered'
+      }
+    },
+    legend: {},
+    smallMultiples: {
+      mode: 'by-series',
+      colorMode: 'same'
+    },
+    series: [
+      { dataKey: 'series_a', name: 'Series A', type: 'Line' },
+      { dataKey: 'series_b', name: 'Series B', type: 'Line' }
+    ],
+    runtime: {
+      seriesKeys: ['series_a', 'series_b'],
+      seriesLabels: {
+        series_a: 'Series A',
+        series_b: 'Series B'
+      },
+      seriesLabelsAll: ['Series A', 'Series B']
+    },
+    ...overrides
+  } as ChartConfig)
+
+describe('smallMultiplesHelpers createTileColorScale', () => {
+  it('uses the same first color for by-series tiles in same color mode by default', () => {
+    const colorScale = scaleOrdinal({
+      domain: ['Series A', 'Series B'],
+      range: ['#111111', '#222222'],
+      unknown: null
+    })
+
+    const tileScale = createTileColorScale(
+      { mode: 'by-series', seriesKey: 'series_b' },
+      buildConfig(),
+      colorScale,
+      1,
+      2
+    )
+
+    expect(tileScale('Series A')).toBe('#111111')
+    expect(tileScale('Series B')).toBe('#111111')
+  })
+
+  it('lets by-value assignments override same color mode for by-series tiles', () => {
+    const colorScale = scaleOrdinal({
+      domain: ['Series A', 'Series B'],
+      range: ['#aa0000', '#00bb00'],
+      unknown: null
+    })
+    const config = buildConfig({
+      general: {
+        palette: {
+          customColors: ['#111111', '#222222'],
+          colorAssignmentMode: 'by-value',
+          colorAssignments: [{ key: 'series_b', color: '#00bb00' }]
+        }
+      } as any
+    })
+
+    const tileScale = createTileColorScale({ mode: 'by-series', seriesKey: 'series_b' }, config, colorScale, 1, 2)
+
+    expect(tileScale('Series A')).toBe('#aa0000')
+    expect(tileScale('Series B')).toBe('#00bb00')
+  })
+})

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -18,6 +18,8 @@ type General = CoreGeneral & {
     isReversed?: boolean
     customColors?: string[]
     customColorsOrdered?: string[]
+    colorAssignmentMode?: 'ordered' | 'by-value'
+    colorAssignments?: { key: string; color: string }[]
   }
   useIntelligentLineChartLabels?: boolean
 }

--- a/packages/core/CONFIG.md
+++ b/packages/core/CONFIG.md
@@ -167,6 +167,8 @@ Use `Palette` when a package stores its v2 palette selection in `general.palette
 | `isReversed` | `boolean` | No | Reverses the active palette order. | Common in sequential color scales. |
 | `customColors` | `string[]` | No | Custom color list used in some editor flows. | Usually CSS color strings or hex values. |
 | `customColorsOrdered` | `string[]` | No | Ordered custom color list preserved by the editor. | Used when explicit order matters. |
+| `colorAssignmentMode` | `'ordered' \| 'by-value'` | No | Selects whether data-driven color assignments are active. | Omitted or `ordered` preserves palette order. Packages must explicitly opt into `by-value` behavior. |
+| `colorAssignments` | `{ key: string; color: string }[]` | No | Assigns colors to stable data keys. | `key` is package-defined, usually a series or category key; `color` is a CSS color string. Stale keys can remain harmlessly in saved configs. |
 
 ### `Footnotes`
 

--- a/packages/core/components/DataColorSelector/DataColorSelector.test.tsx
+++ b/packages/core/components/DataColorSelector/DataColorSelector.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import DataColorSelector from './DataColorSelector'
+import { DATA_COLOR_PRESETS } from '../../helpers/dataColors'
+
+describe('DataColorSelector', () => {
+  it('preserves default data-color mapping behavior', () => {
+    const onChange = vi.fn()
+
+    render(<DataColorSelector value='#123456' onChange={onChange} />)
+
+    fireEvent.click(screen.getByTitle('#123456'))
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByTitle('None')).toBeInTheDocument()
+    DATA_COLOR_PRESETS.forEach(color => {
+      expect(screen.getByTitle(color)).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Custom')).toBeInTheDocument()
+    expect(screen.getByText('#123456')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle(DATA_COLOR_PRESETS[1]))
+
+    expect(onChange).toHaveBeenCalledWith(DATA_COLOR_PRESETS[1])
+  })
+
+  it('keeps the default none and custom color controls active', () => {
+    const onChange = vi.fn()
+
+    render(<DataColorSelector value={DATA_COLOR_PRESETS[0]} onChange={onChange} />)
+
+    fireEvent.click(screen.getByTitle(DATA_COLOR_PRESETS[0]))
+    fireEvent.click(screen.getByTitle('None'))
+
+    expect(onChange).toHaveBeenCalledWith('')
+
+    fireEvent.click(screen.getByTitle(DATA_COLOR_PRESETS[0]))
+    fireEvent.change(screen.getByLabelText('Custom'), { target: { value: '#445566' } })
+
+    expect(onChange).toHaveBeenCalledWith('#445566')
+  })
+
+  it('supports a restricted color list without none or custom controls', () => {
+    const onChange = vi.fn()
+
+    render(
+      <DataColorSelector
+        value='#111111'
+        onChange={onChange}
+        colors={['#111111', '', '#222222', '#111111']}
+        allowNone={false}
+        allowCustom={false}
+        showCustomValue={false}
+        aria-label='Color for Alpha'
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Color for Alpha' }))
+
+    const options = within(screen.getByRole('listbox')).getAllByRole('option')
+    expect(options.map(option => option.getAttribute('title'))).toEqual(['#111111', '#222222'])
+    expect(screen.queryByTitle('None')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Custom')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle('#222222'))
+
+    expect(onChange).toHaveBeenCalledWith('#222222')
+  })
+})

--- a/packages/core/components/DataColorSelector/DataColorSelector.test.tsx
+++ b/packages/core/components/DataColorSelector/DataColorSelector.test.tsx
@@ -41,6 +41,12 @@ describe('DataColorSelector', () => {
     expect(onChange).toHaveBeenCalledWith('#445566')
   })
 
+  it('provides a fallback accessible name for the trigger button', () => {
+    render(<DataColorSelector value='' onChange={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Select color' })).toBeInTheDocument()
+  })
+
   it('supports a restricted color list without none or custom controls', () => {
     const onChange = vi.fn()
 

--- a/packages/core/components/DataColorSelector/DataColorSelector.tsx
+++ b/packages/core/components/DataColorSelector/DataColorSelector.tsx
@@ -83,7 +83,7 @@ const DataColorSelector: React.FC<DataColorSelectorProps> = ({
         className='data-color-selector__trigger'
         onClick={handleToggle}
         title={value || 'Select color'}
-        aria-label={ariaLabel}
+        aria-label={ariaLabel || value || 'Select color'}
         aria-expanded={isOpen}
         aria-haspopup='true'
       >

--- a/packages/core/components/DataColorSelector/DataColorSelector.tsx
+++ b/packages/core/components/DataColorSelector/DataColorSelector.tsx
@@ -5,14 +5,28 @@ import './DataColorSelector.css'
 interface DataColorSelectorProps {
   value: string
   onChange: (color: string) => void
+  colors?: string[]
+  allowNone?: boolean
+  allowCustom?: boolean
+  showCustomValue?: boolean
+  'aria-label'?: string
 }
 
-const DataColorSelector: React.FC<DataColorSelectorProps> = ({ value, onChange }) => {
+const DataColorSelector: React.FC<DataColorSelectorProps> = ({
+  value,
+  onChange,
+  colors = DATA_COLOR_PRESETS,
+  allowNone = true,
+  allowCustom = true,
+  showCustomValue = true,
+  'aria-label': ariaLabel
+}) => {
   const [isOpen, setIsOpen] = useState(false)
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 })
   const triggerRef = useRef<HTMLButtonElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
-  const isPreset = DATA_COLOR_PRESETS.includes(value as any)
+  const colorOptions = Array.from(new Set(colors.filter(Boolean)))
+  const isPreset = colorOptions.includes(value)
   const isCustom = !!value && !isPreset
 
   const handleSelect = (color: string) => {
@@ -69,6 +83,7 @@ const DataColorSelector: React.FC<DataColorSelectorProps> = ({ value, onChange }
         className='data-color-selector__trigger'
         onClick={handleToggle}
         title={value || 'Select color'}
+        aria-label={ariaLabel}
         aria-expanded={isOpen}
         aria-haspopup='true'
       >
@@ -88,15 +103,17 @@ const DataColorSelector: React.FC<DataColorSelectorProps> = ({ value, onChange }
           style={{ top: dropdownPos.top, left: dropdownPos.left }}
         >
           <div className='data-color-selector__presets'>
-            <button
-              type='button'
-              className={`data-color-selector__swatch data-color-selector__swatch--none ${!value ? 'data-color-selector__swatch--active' : ''}`}
-              onClick={() => handleSelect('')}
-              title='None'
-              role='option'
-              aria-selected={!value}
-            />
-            {DATA_COLOR_PRESETS.map(preset => (
+            {allowNone && (
+              <button
+                type='button'
+                className={`data-color-selector__swatch data-color-selector__swatch--none ${!value ? 'data-color-selector__swatch--active' : ''}`}
+                onClick={() => handleSelect('')}
+                title='None'
+                role='option'
+                aria-selected={!value}
+              />
+            )}
+            {colorOptions.map(preset => (
               <button
                 key={preset}
                 type='button'
@@ -109,20 +126,22 @@ const DataColorSelector: React.FC<DataColorSelectorProps> = ({ value, onChange }
               />
             ))}
           </div>
-          <div className='data-color-selector__custom'>
-            <label className='data-color-selector__custom-label'>
-              <span>Custom</span>
-              <input
-                type='color'
-                className='data-color-selector__custom-input'
-                value={value || '#000000'}
-                onChange={e => onChange(e.target.value)}
-              />
-            </label>
-            {isCustom && (
-              <span className='data-color-selector__custom-value'>{value}</span>
-            )}
-          </div>
+          {allowCustom && (
+            <div className='data-color-selector__custom'>
+              <label className='data-color-selector__custom-label'>
+                <span>Custom</span>
+                <input
+                  type='color'
+                  className='data-color-selector__custom-input'
+                  value={value || '#000000'}
+                  onChange={e => onChange(e.target.value)}
+                />
+              </label>
+              {showCustomValue && isCustom && (
+                <span className='data-color-selector__custom-value'>{value}</span>
+              )}
+            </div>
+          )}
         </div>
       )}
     </>

--- a/packages/core/helpers/ver/4.25.4.ts
+++ b/packages/core/helpers/ver/4.25.4.ts
@@ -4,7 +4,9 @@ import cloneConfig from '../cloneConfig'
 export const makeChartLegendsUnified = config => {
   if (config.type === 'chart') {
     config.legend = config.legend || {}
-    config.legend.unified = true
+    if (config.legend.unified === undefined) {
+      config.legend.unified = true
+    }
   } else if (config.type === 'dashboard') {
     Object.values(config.visualizations).forEach(visualization => {
       makeChartLegendsUnified(visualization)

--- a/packages/core/helpers/ver/tests/4.25.4.test.ts
+++ b/packages/core/helpers/ver/tests/4.25.4.test.ts
@@ -4,21 +4,47 @@ import { ChartConfig } from '@cdc/chart/src/types/ChartConfig'
 import { DashboardConfig } from '@cdc/dashboard/src/types/DashboardConfig'
 
 describe('makeChartLegendsUnified(config) ', () => {
-  it('sets chart legends unified to true', () => {
-    const mockConfig = { type: 'chart', legend: { unified: false } } as Partial<ChartConfig>
+  it('sets missing chart legend unified values to true', () => {
+    const mockConfig = { type: 'chart', legend: {} } as Partial<ChartConfig>
     makeChartLegendsUnified(mockConfig)
     expect(mockConfig.legend?.unified).toBe(true)
   })
-  it('sets dashboard nested chart legends unified to true', () => {
+
+  it('preserves explicit chart legend unified false values', () => {
+    const mockConfig = { type: 'chart', legend: { unified: false } } as Partial<ChartConfig>
+    makeChartLegendsUnified(mockConfig)
+    expect(mockConfig.legend?.unified).toBe(false)
+  })
+
+  it('preserves explicit chart legend unified true values', () => {
+    const mockConfig = { type: 'chart', legend: { unified: true } } as Partial<ChartConfig>
+    makeChartLegendsUnified(mockConfig)
+    expect(mockConfig.legend?.unified).toBe(true)
+  })
+
+  it('sets missing dashboard nested chart legend unified values to true', () => {
     const mockConfig = {
       type: 'dashboard',
       visualizations: {
-        '1': { type: 'chart', legend: { unified: false } } as ChartConfig,
-        '2': { type: 'chart', legend: { unified: false } } as ChartConfig
+        '1': { type: 'chart', legend: {} } as ChartConfig,
+        '2': { type: 'chart', legend: {} } as ChartConfig
       }
     } as Partial<DashboardConfig>
     makeChartLegendsUnified(mockConfig)
     expect(mockConfig.visualizations['1'].legend?.unified).toBe(true)
+    expect(mockConfig.visualizations['2'].legend?.unified).toBe(true)
+  })
+
+  it('preserves explicit dashboard nested chart legend unified values', () => {
+    const mockConfig = {
+      type: 'dashboard',
+      visualizations: {
+        '1': { type: 'chart', legend: { unified: false } } as ChartConfig,
+        '2': { type: 'chart', legend: { unified: true } } as ChartConfig
+      }
+    } as Partial<DashboardConfig>
+    makeChartLegendsUnified(mockConfig)
+    expect(mockConfig.visualizations['1'].legend?.unified).toBe(false)
     expect(mockConfig.visualizations['2'].legend?.unified).toBe(true)
   })
 })

--- a/packages/core/helpers/ver/tests/coveUpdateWorker.test.ts
+++ b/packages/core/helpers/ver/tests/coveUpdateWorker.test.ts
@@ -183,6 +183,27 @@ describe('coveUpdateWorker', () => {
       expectVersionAtLeast(result.version, '4.26.4-1')
     })
 
+    it('preserves explicit false legend.unified values when always-run migrations execute', () => {
+      const config: any = {
+        type: 'dashboard',
+        version: '4.26.5',
+        rows: [],
+        visualizations: {
+          chart1: {
+            type: 'chart',
+            legend: {
+              unified: false
+            }
+          }
+        }
+      }
+
+      const result = coveUpdateWorker(config)
+
+      expect(result.visualizations.chart1.legend.unified).toBe(false)
+      expectVersionAtLeast(result.version, '4.26.5')
+    })
+
     it('treats malformed config versions as 0.0.0 and runs through to the latest migration', () => {
       const config: any = {
         type: 'dashboard',

--- a/packages/core/types/Palette.ts
+++ b/packages/core/types/Palette.ts
@@ -11,6 +11,8 @@ export type Palette = {
   name?: string
   customColors?: string[]
   customColorsOrdered?: string[]
+  colorAssignmentMode?: 'ordered' | 'by-value'
+  colorAssignments?: { key: string; color: string }[]
   version?: PaletteVersion
   isReversed?: boolean
   backups?: PaletteBackup[]


### PR DESCRIPTION
## Summary

This PR adds the ability to associate each chart series with a color in the selected palette. The main use case is a chart where series are hidden or shown based on a filter, and you want the colors to stay consistent for each view of the chart. This also allows you to assign colors without reordering the series and legend.

## Testing Steps

Open or create a chart and experiment with the new [Visual -> Color Assignment Mode] setting, or look at [this story](http://localhost:6006/?path=/story/components-templates-chart-series-color-assignments--filtered-series-keep-assigned-colors).