### PR TITLE
Fix for date-axis in scatter plots

### DIFF
--- a/packages/chart/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/packages/chart/src/components/ScatterPlot/ScatterPlot.jsx
@@ -6,7 +6,7 @@ import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
 import { buildSeriesTooltipListHtml } from '../../helpers/tooltipHelpers'
 
-const ScatterPlot = ({ xScale, yScale, yAxisWidth }) => {
+const ScatterPlot = ({ xScale, yScale, yAxisWidth, getXAxisData }) => {
   const {
     transformedData: data,
     config,
@@ -78,7 +78,7 @@ const ScatterPlot = ({ xScale, yScale, yAxisWidth }) => {
             <circle
               key={`${dataIndex}-${index}`}
               r={circleRadii}
-              cx={xScale(item[config.xAxis.dataKey])}
+              cx={xScale(getXAxisData(item))}
               cy={yScale(item[s])}
               fill={displayArea ? seriesColor : 'transparent'}
               fillOpacity={transparentArea ? 0.25 : 1}


### PR DESCRIPTION
## Summary
Choosing date scaling type "Date" (any) for scatter plots is resulting in the plots being drawn improperly. "Categorical" works fine though. This should fix it to allow both types. Determined this should go in the next release and not squeeze into the one about to go out.

## Testing Steps
Scatter plot > Editor > Date/Category Axis > "Date" or "Categorical"
