### PR TITLE
feat: enhance Filters component to support excludedData for multi-sel…

### DIFF
--- a/packages/core/components/Filters/Filters.test.tsx
+++ b/packages/core/components/Filters/Filters.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import Filters from './Filters'
 
 vi.mock('../../helpers/metrics/helpers', () => ({
   publishAnalyticsEvent: vi.fn()
+}))
+
+vi.mock('../ui/Icon', () => ({
+  default: () => null
 }))
 
 const baseConfig = {
@@ -104,5 +108,39 @@ describe('Filters filter notes', () => {
 
     expect(wrapper).toHaveClass('filters-section__wrapper--multiple')
     expect(wrapper).not.toHaveClass('filters-section__wrapper--single')
+  })
+})
+
+describe('Filters option data source', () => {
+  it('uses excludedData to generate multi-select options when provided', () => {
+    const sexFilter = {
+      columnName: 'Sex',
+      values: [],
+      showDropdown: true,
+      id: 4,
+      parents: [],
+      active: ['Female', 'Male'],
+      filterStyle: 'multi-select',
+      label: 'Sex',
+      order: 'asc',
+      type: 'url'
+    } as any
+
+    render(
+      <Filters
+        config={{
+          ...baseConfig,
+          data: [{ Sex: 'Male' }, { Sex: 'Female' }, { Sex: 'All' }],
+          filters: [sexFilter]
+        }}
+        excludedData={[{ Sex: 'Male' }, { Sex: 'Female' }]}
+        setFilters={vi.fn()}
+        dimensions={[1200, 800]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }))
+
+    expect(screen.queryByText('All')).not.toBeInTheDocument()
   })
 })

--- a/packages/core/components/Filters/Filters.tsx
+++ b/packages/core/components/Filters/Filters.tsx
@@ -46,16 +46,21 @@ type FilterProps = {
   dimensions?: DimensionsType
   config: Visualization
   setFilters: Function
+  setConfig?: Function
   interactionLabel?: string
+  filteredData?: any[] | Record<string, any[]>
+  excludedData?: any[] | Record<string, any[]>
 }
 
 const Filters: React.FC<FilterProps> = ({
   config: visualizationConfig,
   dimensions,
   setFilters,
-  interactionLabel = ''
+  interactionLabel = '',
+  excludedData
 }) => {
   const { filters, general, theme, filterBehavior } = visualizationConfig
+  const filterValueData = excludedData ?? visualizationConfig.data
   const getApplyButtonVariant = (currentTheme?: string): ButtonVariant | undefined =>
     currentTheme === 'theme-blue' ? 'primary' : (currentTheme as ButtonVariant | undefined)
   const [showApplyButton, setShowApplyButton] = useState(false)
@@ -144,7 +149,10 @@ const Filters: React.FC<FilterProps> = ({
     const queryParams = getQueryParams()
     newFilters.forEach((filter, i) => {
       if (!filter.values || filter.values.length === 0) {
-        filter.values = getUniqueValues(visualizationConfig.data, filter.columnName)
+        filter.values = getUniqueValues(
+          Array.isArray(filterValueData) ? filterValueData : visualizationConfig.data,
+          filter.columnName
+        )
       }
 
       // Determine reset value based on filter configuration
@@ -203,8 +211,8 @@ const Filters: React.FC<FilterProps> = ({
     // Here charts is using config.filters where maps is using a runtime value
     if (!filters) return []
     if (filters.fromHash) delete filters.fromHash // support for Maps config
-    return addValuesToFilters(filters as VizFilter[], visualizationConfig.data)
-  }, [filters])
+    return addValuesToFilters(filters as VizFilter[], filterValueData)
+  }, [filters, filterValueData])
 
   if (visualizationConfig?.filters?.length === 0) return <></>
 


### PR DESCRIPTION
This pull request enhances the `Filters` component by allowing it to use an optional `excludedData` prop as the data source for generating filter options, instead of always relying on the main `data` array from the visualization config. This makes the filter options more flexible and enables exclusion of certain data points from filter options. The test suite is updated to cover this new behavior.

**Enhancements to filter data source handling:**
- [`Filters.tsx`](diffhunk://#diff-971dda220b7e320d55244a1db4eeffb507690230fa920d1325c2e141fcb97ddbR49-R63): Added `excludedData` and `filteredData` as optional props to `FilterProps`, and updated the component to use `excludedData` (if provided) as the source for filter option values instead of the default `data` in the visualization config. All relevant logic now references this new data source. [[1]](diffhunk://#diff-971dda220b7e320d55244a1db4eeffb507690230fa920d1325c2e141fcb97ddbR49-R63) [[2]](diffhunk://#diff-971dda220b7e320d55244a1db4eeffb507690230fa920d1325c2e141fcb97ddbL147-R155) [[3]](diffhunk://#diff-971dda220b7e320d55244a1db4eeffb507690230fa920d1325c2e141fcb97ddbL206-R215)

**Testing improvements:**
- [`Filters.test.tsx`](diffhunk://#diff-2e59522afcfd5fe32dfca2d06fc8d3e6a38a17a07d54f9062c262b3b8092221eL1-R12): Added a new test case to verify that the filter options are generated from `excludedData` when it is provided, ensuring excluded values (like 'All') do not appear in the filter dropdown. Also added a mock for the `Icon` component to prevent rendering issues in tests. [[1]](diffhunk://#diff-2e59522afcfd5fe32dfca2d06fc8d3e6a38a17a07d54f9062c262b3b8092221eL1-R12) [[2]](diffhunk://#diff-2e59522afcfd5fe32dfca2d06fc8d3e6a38a17a07d54f9062c262b3b8092221eR113-R146)