### PR TITLE
Fix [DEV-13233] Don't draw effect circles for nonnumeric data

### DIFF
--- a/docs/PUBLIC_DOCUMENTATION_WORKFLOW.md
+++ b/docs/PUBLIC_DOCUMENTATION_WORKFLOW.md
@@ -1,24 +1,43 @@
 # Public Documentation Workflow
 
-Use this workflow when drafting public COVE documentation for feature branches that add or change user-facing COVE editor behavior. This usually means new editor controls, option values, labels, settings, or workflows that COVE users can interact with.
+Use this workflow when drafting public COVE documentation for feature branches that add or change user-facing COVE editor authoring behavior. This means new or changed editor controls, option values, labels, settings, panels, or workflows that COVE users can interact with while creating or editing a visualization or dashboard.
 
-Public documentation is written for COVE editor users: somewhat technical, but not expected to understand package internals, config schemas, migrations, or rendering code. This workflow is not for internal implementation notes, developer-facing config docs, or architecture documentation.
+Public documentation is written for COVE editor users: somewhat technical, but not expected to understand package internals, config schemas, migrations, or rendering code. This workflow is not for internal implementation notes, developer-facing config docs, architecture documentation, or runtime-only bug fixes.
 
 ## Goal
 
-Produce a short copy-paste-ready markdown draft for the public documentation maintainer. Save the same draft locally as a backup in `.public-docs/<branch-name>.md`, and also print the full draft in the final response.
+When the branch includes editor-facing authoring changes, produce a short copy-paste-ready markdown draft for the public documentation maintainer. Save the same draft locally as a backup in `.public-docs/<branch-name>.md`, and also print the full draft in the final response.
+
+When the branch does not include editor-facing authoring changes, do not create a draft file. End with a brief note that no public documentation changes are needed.
 
 Do not mirror, cache, or check in public documentation pages. Fetch only the live public pages needed for the current branch.
 
 ## Workflow
 
 1. Compare the current branch against `dev` by default.
-2. Identify user-facing editor changes from the branch diff, especially editor controls, labels, options, stories, tests, config documentation, migrations, and context docs. Use migrations and legacy-handling changes only to understand the current user-facing behavior.
-3. Use the URL index below to choose the likely public documentation page or pages.
-4. Fetch the live public page before drafting so the new copy fits the existing page and avoids duplicating current content.
-5. Draft only the new documentation text needed for the feature.
-6. Save the draft to `.public-docs/<branch-name>.md`.
-7. Print the full draft in the final response.
+2. Identify whether the branch changes editor-facing authoring behavior. Look for new or changed editor controls, labels, option values, settings, panel copy, authoring workflows, stories, tests, config documentation, migrations, and context docs. Use migrations and legacy-handling changes only to understand the current editor behavior.
+3. If the branch has no editor-facing authoring changes, stop the workflow. Do not fetch public documentation pages and do not create a `.public-docs` file. Report: `No public documentation changes needed.`
+4. If the branch does have editor-facing authoring changes, use the URL index below to choose the likely public documentation page or pages.
+5. Fetch the live public page before drafting so the new copy fits the existing page and avoids duplicating current content.
+6. Draft only the new documentation text needed for the feature.
+7. Save the draft to `.public-docs/<branch-name>.md`.
+8. Print the full draft in the final response.
+
+## Eligibility Examples
+
+Create a public documentation draft for:
+
+- New editor controls, panels, or authoring workflows.
+- Changed editor labels, option names, option meanings, defaults, or visible help text.
+- New supported values that users select or enter in the editor.
+- Runtime behavior changes that alter the meaning of an editor-authored setting.
+
+Do not create a public documentation draft for:
+
+- Runtime-only rendering fixes that do not change editor authoring behavior.
+- Internal refactors, helper changes, tests, or package implementation details.
+- Bug fixes that preserve the existing editor controls, labels, options, and workflows.
+- Developer-facing config documentation or context-document updates with no public editor impact.
 
 ## Draft Format
 

--- a/packages/chart/src/components/LineChart/helpers.test.ts
+++ b/packages/chart/src/components/LineChart/helpers.test.ts
@@ -244,6 +244,21 @@ describe('LineChart helpers', () => {
         expect(circles[1].isFilled).toBe(false)
       })
 
+      it('should skip open circles for nonnumeric values while preserving zero values', () => {
+        const data = [
+          { Date: '10/5/2025', Category: 'COVID-19', Value: 'N/A', Attribute: 'Marked' },
+          { Date: '10/12/2025', Category: 'COVID-19', Value: null, Attribute: 'Marked' },
+          { Date: '10/19/2025', Category: 'COVID-19', Value: 0, Attribute: 'Marked' },
+          { Date: '10/26/2025', Category: 'COVID-19', Value: '12.3', Attribute: 'Marked' }
+        ]
+
+        const circles = filterCircles(circlesPreliminaryData, data, 'COVID-19', 'Category', 'Value')
+
+        expect(circles).toHaveLength(2)
+        expect(circles.map(circle => circle.data.Value)).toEqual([0, '12.3'])
+        expect(circles.every(circle => circle.isFilled === false)).toBe(true)
+      })
+
       it('should return empty array when no matches', () => {
         const circles = filterCircles(
           circlesPreliminaryData,

--- a/packages/chart/src/components/LineChart/helpers.test.ts
+++ b/packages/chart/src/components/LineChart/helpers.test.ts
@@ -340,6 +340,20 @@ describe('LineChart helpers', () => {
         expect(circles[0].isFilled).toBe(true)
         expect(circles[0].size).toBe(6)
       })
+
+      it('should skip filled circles for nonnumeric values while preserving zero values', () => {
+        const data = [
+          { Date: '10/5/2025', Category: 'Influenza', Value: 'N/A', Attribute: 'Marked' },
+          { Date: '10/12/2025', Category: 'Influenza', Value: null, Attribute: 'Marked' },
+          { Date: '10/19/2025', Category: 'Influenza', Value: 0, Attribute: 'Marked' },
+          { Date: '10/26/2025', Category: 'Influenza', Value: '12.3', Attribute: 'Marked' }
+        ]
+
+        const circles = filterCircles(filledCirclesConfig, data, 'Influenza', 'Category', 'Value')
+
+        expect(circles).toHaveLength(2)
+        expect(circles.map(circle => circle.data.Value)).toEqual([0, '12.3'])
+      })
     })
   })
 })

--- a/packages/chart/src/components/LineChart/helpers.ts
+++ b/packages/chart/src/components/LineChart/helpers.ts
@@ -2,6 +2,9 @@ import { DataItem, StyleProps, Style } from './LineChartProps'
 import { PreliminaryDataItem } from '../../types/ChartConfig'
 
 import _ from 'lodash'
+
+const isCalculable = value => !isNaN(parseFloat(value)) && isFinite(value)
+
 export const createStyles = (props: StyleProps): Style[] => {
   const {
     preliminaryData,
@@ -96,7 +99,7 @@ export const filterCircles = (
       if (
         item[fc.column] === fc.value &&
         fc.seriesKeys.includes(seriesKey) &&
-        item[valueKey] &&
+        isCalculable(item[valueKey]) &&
         fc.style === 'Open Circles'
       ) {
         const result = {
@@ -109,7 +112,7 @@ export const filterCircles = (
       if (
         (!fc.value || item[fc.column] === fc.value) &&
         fc.seriesKeys.includes(seriesKey) &&
-        item[valueKey] &&
+        isCalculable(item[valueKey]) &&
         fc.style === 'Filled Circles'
       ) {
         const result = {
@@ -125,7 +128,6 @@ export const filterCircles = (
   return filteredData
 }
 
-const isCalculable = value => !isNaN(parseFloat(value)) && isFinite(value)
 const handleFirstIndex = ({
   data,
   seriesKey,


### PR DESCRIPTION
## Summary

* Updates line-chart circle effect filtering so open and filled circle markers only render for plottable numeric values.
* Preserves circle rendering for 0 and numeric strings.
* Adds helper coverage for N/A, null, 0, and numeric string values.