### PR TITLE
Fix HeatMap preserving Sample Config

### DIFF
--- a/packages/editor/src/components/ChooseTab.test.tsx
+++ b/packages/editor/src/components/ChooseTab.test.tsx
@@ -68,32 +68,27 @@ describe('ChooseTab', () => {
         payload: expect.objectContaining({
           visualizationType: 'HeatMap',
           type: 'chart',
-          title: 'Synthetic Varicella Cases by HHS Region',
           xAxis: expect.objectContaining({
-            dataKey: 'Month',
-            label: 'Month'
+            type: 'categorical'
           }),
           yAxis: expect.objectContaining({
-            label: 'HHS Region',
             titlePlacement: 'side'
           }),
-          series: expect.arrayContaining([
-            expect.objectContaining({
-              dataKey: 'HHS Region 1',
-              name: 'Region 1',
-              type: 'HeatMap'
-            })
-          ]),
           heatmap: expect.objectContaining({
             cellPadding: 2
           }),
           legend: expect.objectContaining({
             position: 'top',
-            style: 'gradient',
-            label: 'Reported cases'
+            style: 'gradient'
           })
         })
       })
     )
+
+    const payload = dispatch.mock.calls.find(([action]) => action.type === 'EDITOR_SET_CONFIG')?.[0].payload
+    expect(payload.title).toBeUndefined()
+    expect(payload.xAxis.dataKey).toBeUndefined()
+    expect(payload.yAxis.label).toBeUndefined()
+    expect(payload.series).toBeUndefined()
   })
 })

--- a/packages/editor/src/components/ChooseTab.test.tsx
+++ b/packages/editor/src/components/ChooseTab.test.tsx
@@ -85,7 +85,7 @@ describe('ChooseTab', () => {
       })
     )
 
-    const payload = dispatch.mock.calls.find(([action]) => action.type === 'EDITOR_SET_CONFIG')?.[0].payload
+    const payload = dispatch.mock.calls.find(([action]) => action.type === 'EDITOR_SET_CONFIG')![0].payload
     expect(payload.title).toBeUndefined()
     expect(payload.xAxis.dataKey).toBeUndefined()
     expect(payload.yAxis.label).toBeUndefined()

--- a/packages/editor/src/components/ChooseTab.tsx
+++ b/packages/editor/src/components/ChooseTab.tsx
@@ -72,9 +72,6 @@ const VizButton: React.FC<VizButtonProps> = ({ activeVizButtonID, onConfigure, .
 
 const HeatMapIcon = () => <img className='choose-vis__heatmap-icon' src={HeatMapIconSrc} alt='' aria-hidden='true' />
 
-const heatMapRegionColumns = Array.from({ length: 10 }, (_, index) => `HHS Region ${index + 1}`)
-const heatMapSampleColumns = ['Month', ...heatMapRegionColumns]
-
 const ChooseTab: React.FC = (): JSX.Element => {
   const { config, tempConfig } = useContext(ConfigContext)
 
@@ -453,14 +450,9 @@ const buttons = [
     label: 'HeatMap',
     type: 'chart',
     subType: 'HeatMap',
-    title: 'Synthetic Varicella Cases by HHS Region',
-    showTitle: true,
-    description: 'Example data are synthetic and for demonstration only.',
     orientation: 'vertical',
     xAxis: {
       type: 'categorical',
-      dataKey: 'Month',
-      label: 'Month',
       size: 75,
       maxTickRotation: 0,
       tickRotation: 0,
@@ -468,7 +460,6 @@ const buttons = [
     },
     yAxis: {
       type: 'categorical',
-      label: 'HHS Region',
       size: 120,
       titlePlacement: 'side'
     },
@@ -478,28 +469,6 @@ const buttons = [
       columnLabelGap: 48,
       xAxisPosition: 'top',
       showCellValues: false
-    },
-    series: heatMapRegionColumns.map((region, index) => ({
-      dataKey: region,
-      name: `Region ${index + 1}`,
-      type: 'HeatMap',
-      axis: 'Left',
-      tooltip: true
-    })),
-    columns: heatMapSampleColumns.reduce(
-      (columns, columnName) => ({
-        ...columns,
-        [columnName]: {
-          name: columnName,
-          label: columnName.replace('HHS ', ''),
-          dataTable: true
-        }
-      }),
-      {}
-    ),
-    dataFormat: {
-      commas: true,
-      roundTo: 0
     },
     general: {
       palette: {
@@ -511,8 +480,7 @@ const buttons = [
     legend: {
       position: 'top',
       style: 'gradient',
-      subStyle: 'smooth',
-      label: 'Reported cases'
+      subStyle: 'smooth'
     },
     icon: <HeatMapIcon />,
     content: 'Display a heatmap to compare intensity across two dimensions.'

--- a/packages/editor/src/components/DataImport/components/DataImport.tsx
+++ b/packages/editor/src/components/DataImport/components/DataImport.tsx
@@ -222,11 +222,19 @@ const DataImport = () => {
       // Validate parsed data and set if no issues.
       try {
         let result = parseTextByMimeType(this.result.toString(), mimeType, externalURL, setErrors)
+        if (undefined === result) return
+
         if (config.vegaConfig) {
           return updateDataFromVegaData(result, fileSource, fileSourceType)
         }
         const { data: extractedData, dataMetadata } = extractDataAndMetadata(result)
         const text = transform.autoStandardize(extractedData)
+        if (!text) {
+          const isEmptyData = null == extractedData || (Array.isArray(extractedData) && extractedData.length === 0)
+          setErrors([isEmptyData ? errorMessages.emptyData : errorMessages.dataType])
+          return
+        }
+
         if (config.data && config.series) {
           if (dataExists(text, config.series, config?.xAxis?.dataKey)) {
             handleSetConfig(text, true, dataMetadata)

--- a/packages/editor/src/components/DataImport/components/DataImport.tsx
+++ b/packages/editor/src/components/DataImport/components/DataImport.tsx
@@ -34,6 +34,7 @@ import { getFileExtension } from '../helpers/getFileExtension'
 import { parseTextByMimeType } from '../helpers/parseTextByMimeType'
 import { getMimeType } from '../helpers/getMimeType'
 import { applyAutoDetectedDateParseFormat } from '../helpers/applyAutoDetectedDateParseFormat'
+import { dataExists } from '../helpers/dataExists'
 import {
   extractCoveData,
   getSampleVegaJson,
@@ -67,23 +68,6 @@ const DataImport = () => {
   const setEditingDataset = (datasetKey: string) => {
     _setEditingDataset(datasetKey)
     setNewDatasetName(datasetKey)
-  }
-
-  /**
-   * Check to see all series for the viz exists in the new dataset
-   */
-  const dataExists = (newData, oldSeries, oldAxisX) => {
-    // Loop through old series to make sure each exists in the new data
-
-    oldSeries.map(function (currentValue, index, newData) {
-      if (!newData.find(element => element.dataKey === currentValue.dataKey)) return false
-    })
-
-    // Is the X Axis still in the dataset?
-    const columns = newData.columns || Object.keys(newData[0])
-    if (columns.indexOf(oldAxisX) < 0) return false
-
-    return true
   }
 
   const loadExternal = async () => {
@@ -244,11 +228,13 @@ const DataImport = () => {
         const { data: extractedData, dataMetadata } = extractDataAndMetadata(result)
         const text = transform.autoStandardize(extractedData)
         if (config.data && config.series) {
-          if (dataExists(text, config.series, config?.xAxis.dataKey)) {
+          if (dataExists(text, config.series, config?.xAxis?.dataKey)) {
             handleSetConfig(text, true, dataMetadata)
           } else {
             resetEditor(
               {
+                type: config.type,
+                visualizationType: config.visualizationType,
                 data: text,
                 dataMetadata,
                 dataFileName: fileSource,

--- a/packages/editor/src/components/DataImport/helpers/dataExists.ts
+++ b/packages/editor/src/components/DataImport/helpers/dataExists.ts
@@ -1,0 +1,18 @@
+type SeriesConfig = {
+  dataKey?: string
+}
+
+const getColumns = (newData: any): string[] => {
+  if (!newData) return []
+  if (Array.isArray(newData.columns)) return newData.columns
+  return Object.keys(newData[0] || {})
+}
+
+export const dataExists = (newData: any, oldSeries: SeriesConfig[] = [], oldAxisX?: string) => {
+  const columns = getColumns(newData)
+  const requiredColumns = [oldAxisX, ...oldSeries.map(series => series?.dataKey)].filter((column): column is string =>
+    Boolean(column)
+  )
+
+  return requiredColumns.every(column => columns.includes(column))
+}

--- a/packages/editor/src/components/DataImport/tests/dataExists.test.ts
+++ b/packages/editor/src/components/DataImport/tests/dataExists.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { dataExists } from '../helpers/dataExists'
+
+describe('dataExists', () => {
+  it('requires the configured x-axis and every configured series column', () => {
+    const newData = [
+      {
+        Month: 'Jan',
+        Cases: '10'
+      }
+    ]
+
+    expect(dataExists(newData, [{ dataKey: 'HHS Region 1' }], 'Month')).toBe(false)
+  })
+
+  it('returns true when all configured columns exist in the new data', () => {
+    const newData = [
+      {
+        Month: 'Jan',
+        'HHS Region 1': '10'
+      }
+    ]
+
+    expect(dataExists(newData, [{ dataKey: 'HHS Region 1' }], 'Month')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- ChooseTab.tsx no longer bakes Varicella config into every new HeatMap
- DataImport now uses a dataExists helper instead of a inline map check, which was broken
- dataExists.ts verifies the x-axis and all configures series columns acrually exists before keeping an old config.