### PR TITLE
enhancement: add world map zoom focus

### DIFF
--- a/packages/map/src/_stories/CdcMap.Editor.ZoomControlsTests.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Editor.ZoomControlsTests.stories.tsx
@@ -60,7 +60,13 @@ export const ZoomControlsTest: Story = {
       (before, after) => !before.mapClasses.includes('world') && after.mapClasses.includes('world')
     )
 
-    const mapTypeSelect = canvas.getByLabelText(/Map Type/i) as HTMLSelectElement
+    const mapTypeSelect = canvas
+      .getAllByLabelText(/Map Type/i, { selector: 'select' })
+      .find(select =>
+        Array.from((select as HTMLSelectElement).options).some(option => option.value === 'world-geocode')
+      ) as HTMLSelectElement
+    expect(mapTypeSelect).toBeTruthy()
+
     await performAndAssert(
       'World Data Map → Switch type to data',
       getZoomControlsState,
@@ -70,19 +76,38 @@ export const ZoomControlsTest: Story = {
       (_before, after) => after.mapClasses.includes('world')
     )
 
-    const allowMapZoomingCheckbox = canvas.getByLabelText(/Allow Map Zooming/i) as HTMLInputElement
-    expect(allowMapZoomingCheckbox.checked)
+    const getAllowMapZoomingCheckbox = () => canvas.getByLabelText(/Allow Map Zooming/i) as HTMLInputElement
+    expect(getAllowMapZoomingCheckbox().checked).toBe(true)
 
-    await userEvent.click(allowMapZoomingCheckbox)
-    expect(!allowMapZoomingCheckbox.checked)
+    await performAndAssert(
+      'World Data Map → Disable map zooming',
+      getZoomControlsState,
+      async () => {
+        await userEvent.click(getAllowMapZoomingCheckbox())
+      },
+      (before, after) =>
+        before.hasZoomControls &&
+        before.hasZoomInButton &&
+        before.hasZoomOutButton &&
+        !after.hasZoomControls &&
+        !after.hasZoomInButton &&
+        !after.hasZoomOutButton
+    )
+    expect(getAllowMapZoomingCheckbox().checked).toBe(false)
 
     await performAndAssert(
       'World Data Map → Enable map zooming',
       getZoomControlsState,
       async () => {
-        await userEvent.click(allowMapZoomingCheckbox)
+        await userEvent.click(getAllowMapZoomingCheckbox())
       },
-      (before, after) => after.hasZoomControls && after.hasZoomInButton && after.hasZoomOutButton
+      (before, after) =>
+        !before.hasZoomControls &&
+        !before.hasZoomInButton &&
+        !before.hasZoomOutButton &&
+        after.hasZoomControls &&
+        after.hasZoomInButton &&
+        after.hasZoomOutButton
     )
   }
 }

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -48,6 +48,7 @@ import useMapLayers from '../../../hooks/useMapLayers.tsx'
 
 import HexSetting from './HexShapeSettings.jsx'
 import ConfigContext, { MapDispatchContext } from '../../../context.ts'
+import { CONTINENT_OPTIONS, computeAreaPosition } from '../../../data/continent-bounding-boxes'
 import { MapContext } from '../../../types/MapContext.js'
 import Alert from '@cdc/core/components/Alert'
 import { updateFieldFactory } from '@cdc/core/helpers/updateFieldFactory'
@@ -1509,6 +1510,20 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                           />
                         )}
                       </>
+                    )}
+                    {config.general.geoType === 'world' && (
+                      <Select
+                        label='Zoom Focus'
+                        value={config.general.zoomFocusArea || 'world'}
+                        options={CONTINENT_OPTIONS}
+                        onChange={e => {
+                          const areaKey = e.target.value
+                          const _newConfig = cloneConfig(config)
+                          _newConfig.general.zoomFocusArea = areaKey
+                          setConfig(_newConfig)
+                          dispatch({ type: 'SET_POSITION', payload: computeAreaPosition(areaKey) })
+                        }}
+                      />
                     )}
                     {/* Type */}
                     <Select

--- a/packages/map/src/components/WorldMap/WorldMap.tsx
+++ b/packages/map/src/components/WorldMap/WorldMap.tsx
@@ -23,6 +23,7 @@ import {
   SVG_HEIGHT,
   MAX_ZOOM_LEVEL
 } from '../../helpers'
+import { computeAreaPosition } from '../../data/continent-bounding-boxes'
 import useGeoClickHandler from '../../hooks/useGeoClickHandler'
 import useApplyTooltipsToGeo from '../../hooks/useApplyTooltipsToGeo'
 import useCountryZoom from '../../hooks/useCountryZoom'
@@ -172,13 +173,13 @@ const WorldMap = () => {
       dispatch({ type: 'SET_RUNTIME_DATA', payload: newRuntimeData })
     }
 
-    // If countries are selected, center on them; otherwise, use default world position
+    // If countries are selected, center on them; otherwise zoom to configured area (or world default)
     const countriesPicked = getCountriesPicked(config)
 
     if (countriesPicked && countriesPicked.length > 0) {
       centerOnCountries('reset')
     } else {
-      dispatch({ type: 'SET_POSITION', payload: { coordinates: [0, 30], zoom: 1 } })
+      dispatch({ type: 'SET_POSITION', payload: computeAreaPosition(config.general.zoomFocusArea || 'world') })
     }
   }
 

--- a/packages/map/src/data/continent-bounding-boxes.ts
+++ b/packages/map/src/data/continent-bounding-boxes.ts
@@ -1,0 +1,86 @@
+import { geoMercator } from 'd3-geo'
+
+export type ContinentKey = 'world' | 'africa' | 'europe' | 'asia' | 'north_america' | 'south_america' | 'oceania'
+
+// [minLon, minLat], [maxLon, maxLat]
+export const CONTINENT_BOUNDS: Record<ContinentKey, [[number, number], [number, number]]> = {
+  world: [
+    [-180, -60],
+    [180, 80]
+  ],
+  africa: [
+    [-18, -35],
+    [52, 38]
+  ],
+  europe: [
+    [-25, 35],
+    [45, 72]
+  ],
+  asia: [
+    [26, -10],
+    [180, 77]
+  ],
+  north_america: [
+    [-170, 5],
+    [-50, 72]
+  ],
+  south_america: [
+    [-82, -56],
+    [-34, 13]
+  ],
+  oceania: [
+    [110, -50],
+    [180, -5]
+  ]
+}
+
+export const CONTINENT_OPTIONS = [
+  { value: 'world', label: 'World (Default)' },
+  { value: 'africa', label: 'Africa' },
+  { value: 'asia', label: 'Asia' },
+  { value: 'europe', label: 'Europe' },
+  { value: 'north_america', label: 'North America' },
+  { value: 'south_america', label: 'South America' },
+  { value: 'oceania', label: 'Oceania' }
+]
+
+const SVG_WIDTH = 880
+const SVG_HEIGHT = 500
+const SVG_PADDING = 25
+const BASE_MERCATOR_SCALE = 153
+
+export function computeAreaPosition(areaKey: string): { coordinates: [number, number]; zoom: number } {
+  if (!areaKey || areaKey === 'world') return { coordinates: [0, 30], zoom: 1 }
+  const bounds = CONTINENT_BOUNDS[areaKey as ContinentKey]
+  if (!bounds) return { coordinates: [0, 30], zoom: 1 }
+  const [[minLon, minLat], [maxLon, maxLat]] = bounds
+  const bboxFeature = {
+    type: 'Feature' as const,
+    geometry: {
+      type: 'Polygon' as const,
+      coordinates: [
+        [
+          [minLon, minLat],
+          [minLon, maxLat],
+          [maxLon, maxLat],
+          [maxLon, minLat],
+          [minLon, minLat]
+        ]
+      ]
+    },
+    properties: {}
+  }
+  const fitted = geoMercator().fitExtent(
+    [
+      [SVG_PADDING, SVG_PADDING],
+      [SVG_WIDTH - SVG_PADDING, SVG_HEIGHT - SVG_PADDING]
+    ],
+    bboxFeature
+  )
+  const zoom = fitted.scale() / BASE_MERCATOR_SCALE
+  const center = fitted.invert?.([SVG_WIDTH / 2, SVG_HEIGHT / 2])
+  if (center && isFinite(center[0]) && isFinite(center[1])) {
+    return { coordinates: center as [number, number], zoom }
+  }
+  return { coordinates: [0, 30], zoom: 1 }
+}

--- a/packages/map/src/store/map.reducer.ts
+++ b/packages/map/src/store/map.reducer.ts
@@ -7,6 +7,7 @@ import { Modal } from '../types/Modal'
 import { GeneratedLegend } from '../helpers/generateRuntimeLegend'
 import { RuntimeData } from '../types/RuntimeData'
 import { getQueryParam } from '@cdc/core/helpers/queryStringUtils'
+import { computeAreaPosition } from '../data/continent-bounding-boxes'
 
 export const getInitialState = (configObj = {}): MapState => {
   const filteredStateCode = typeof window !== 'undefined' ? getQueryParam('state-code') || '' : ''
@@ -18,6 +19,9 @@ export const getInitialState = (configObj = {}): MapState => {
   // if (!configObj?.general?.palette?.name) {
   //   delete defaultsWithoutPaletteaName.general?.palette.name
   // }
+
+  const zoomFocusArea = (configObj as Partial<MapConfig>)?.general?.zoomFocusArea
+  const initialPosition = zoomFocusArea ? computeAreaPosition(zoomFocusArea) : { coordinates: [0, 0], zoom: 1 }
 
   return {
     dataUrl: configObj.dataUrl || '',
@@ -32,7 +36,7 @@ export const getInitialState = (configObj = {}): MapState => {
     isDraggingAnnotation: false,
     topoData: null,
     translate: [0, 0],
-    position: { coordinates: [0, 0], zoom: 1 },
+    position: initialPosition,
     projection: null,
     requiredColumns: [],
     scale: 1,

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -184,6 +184,7 @@ export type MapConfig = Visualization & {
       name: string
     }[]
     hideUnselectedCountries?: boolean // When true, hide unselected countries; when false (default), gray them out
+    zoomFocusArea?: string
     territoriesAlwaysShow: boolean
     territoriesLabel: string
     title: string


### PR DESCRIPTION
This pull request introduces a new feature allowing users to set a "Zoom Focus" area on the world map, enabling the map to automatically center and zoom to a specific continent or the entire world. The implementation includes UI changes, configuration updates, and logic to compute and apply the appropriate map position and zoom based on user selection.

**Feature: Zoom Focus Area Selection**

* Added a "Zoom Focus" dropdown to the world map editor panel, allowing users to select a continent or "World" as the default zoom area. The selection updates the map configuration and triggers recentering and zooming. [[1]](diffhunk://#diff-36bc1c81c42e002cca80a6c6d32eec97bf23af6b1f2a3ece9fc4fcf04490d222R1514-R1527) [[2]](diffhunk://#diff-36bc1c81c42e002cca80a6c6d32eec97bf23af6b1f2a3ece9fc4fcf04490d222R51)
* Introduced a new `zoomFocusArea` property in the `MapConfig` type and ensured it is used during map state initialization and updates. [[1]](diffhunk://#diff-aa11ca6da563b5c3567eb2fdbaad42f57a5fbe59a0e74e9650786dad172da221R187) [[2]](diffhunk://#diff-ca2787206927d3d8c8c5883b95b3883f78b12b0cf69cbdeed07405a163bd2455R23-R25) [[3]](diffhunk://#diff-ca2787206927d3d8c8c5883b95b3883f78b12b0cf69cbdeed07405a163bd2455L35-R39)

**Logic and Data Enhancements**

* Created a new utility module `continent-bounding-boxes.ts` that defines bounding boxes for each continent, provides options for the dropdown, and implements the `computeAreaPosition` function to calculate the center coordinates and zoom level for the selected area.
* Updated the map rendering logic so that when no countries are selected, the map centers and zooms to the area specified by `zoomFocusArea` rather than always defaulting to the world view. [[1]](diffhunk://#diff-6e4dd1f196ec1546714413a9e4dadfc6e471120ea918234f5b5300dce6dd9ce3L175-R182) [[2]](diffhunk://#diff-6e4dd1f196ec1546714413a9e4dadfc6e471120ea918234f5b5300dce6dd9ce3R26)

**Integration**

* Ensured that the new zoom focus logic is applied during both initial state setup and when the user changes the selection in the editor panel. [[1]](diffhunk://#diff-ca2787206927d3d8c8c5883b95b3883f78b12b0cf69cbdeed07405a163bd2455R10) [[2]](diffhunk://#diff-ca2787206927d3d8c8c5883b95b3883f78b12b0cf69cbdeed07405a163bd2455R23-R25) [[3]](diffhunk://#diff-ca2787206927d3d8c8c5883b95b3883f78b12b0cf69cbdeed07405a163bd2455L35-R39) [[4]](diffhunk://#diff-36bc1c81c42e002cca80a6c6d32eec97bf23af6b1f2a3ece9fc4fcf04490d222R1514-R1527)

These changes collectively improve the usability of the world map by allowing users to focus on specific regions out of the box or via configuration.