### PR TITLE
DEV-13165 Dynamic Charts Line Weights

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -480,7 +480,9 @@ const CdcChart: React.FC<CdcChartProps> = ({
               lineType: series.lineType,
               originalDataKey: series.dataKey,
               dynamicCategory: series.dynamicCategory,
-              tooltip: true
+              tooltip: true,
+              weight: series.weight,
+              axis: series.axis
             })
           })
           // return the series keys

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -142,7 +142,8 @@ const PreliminaryData: React.FC<PreliminaryProps> = ({ config, updateConfig, dat
       hideBarSymbol: false,
       hideLineStyle: false,
       circleSize: 6,
-      displayGray: true
+      displayGray: true,
+      weight: undefined
     }
     preliminaryData.push(defaultValues)
     updateConfig({ ...config, preliminaryData })
@@ -197,7 +198,8 @@ const PreliminaryData: React.FC<PreliminaryProps> = ({ config, updateConfig, dat
             type,
             value,
             hideBarSymbol,
-            hideLineStyle
+            hideLineStyle,
+            weight
           },
           i
         ) => (
@@ -295,6 +297,14 @@ const PreliminaryData: React.FC<PreliminaryProps> = ({ config, updateConfig, dat
                                 label={'suppression line style'}
                                 updateField={(_, __, fieldName, value) => update(fieldName, value, i)}
                                 options={getStyleOptions(type)}
+                              />
+                              <TextField
+                                type='number'
+                                value={weight}
+                                fieldName='weight'
+                                label='Line Weight'
+                                placeholder='Default'
+                                updateField={(_, __, fieldName, value) => update(fieldName, value, i)}
                               />
                               <CheckBox
                                 value={hideLineStyle}
@@ -493,6 +503,16 @@ const PreliminaryData: React.FC<PreliminaryProps> = ({ config, updateConfig, dat
                               value={circleSize}
                               fieldName='circleSize'
                               label='circle size'
+                              updateField={(_, __, fieldName, value) => update(fieldName, value, i)}
+                            />
+                          )}
+                          {style && !style.includes('Circles') && (
+                            <TextField
+                              type='number'
+                              value={weight}
+                              fieldName='weight'
+                              label='Line Weight'
+                              placeholder='Default'
                               updateField={(_, __, fieldName, value) => update(fieldName, value, i)}
                             />
                           )}

--- a/packages/chart/src/components/EditorPanel/EditorPanel.tsx
+++ b/packages/chart/src/components/EditorPanel/EditorPanel.tsx
@@ -300,6 +300,8 @@ const PreliminaryData: React.FC<PreliminaryProps> = ({ config, updateConfig, dat
                               />
                               <TextField
                                 type='number'
+                                min={1}
+                                max={9}
                                 value={weight}
                                 fieldName='weight'
                                 label='Line Weight'
@@ -509,6 +511,8 @@ const PreliminaryData: React.FC<PreliminaryProps> = ({ config, updateConfig, dat
                           {style && !style.includes('Circles') && (
                             <TextField
                               type='number'
+                              min={1}
+                              max={9}
                               value={weight}
                               fieldName='weight'
                               label='Line Weight'

--- a/packages/chart/src/components/LineChart/helpers.test.ts
+++ b/packages/chart/src/components/LineChart/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { createStyles, filterCircles } from './helpers'
+import { createStyles, filterCircles, createDataSegments } from './helpers'
 import { PreliminaryDataItem } from '../../types/ChartConfig'
 
 describe('LineChart helpers', () => {
@@ -273,6 +273,56 @@ describe('LineChart helpers', () => {
         // Should use default strokeWidth when no custom weight
         expect(styles[0].strokeWidth).toBe(2)
       })
+
+      it.each([
+        { weight: 5, expected: 5, label: 'applies a valid custom weight' },
+        { weight: 1, expected: 1, label: 'applies the minimum custom weight of 1' },
+        { weight: 9, expected: 9, label: 'applies the maximum custom weight of 9' },
+        { weight: 0.5, expected: 2, label: 'falls back to default for a weight below 1' },
+        { weight: 0, expected: 2, label: 'falls back to default for a weight of 0' },
+        { weight: -1, expected: 2, label: 'falls back to default for negative weight' },
+        { weight: '', expected: 2, label: 'falls back to default for empty string' },
+        { weight: 'abc', expected: 2, label: 'falls back to default for non-numeric weight' }
+      ])('$label', ({ weight, expected }) => {
+        const preliminaryData: PreliminaryDataItem[] = [
+          {
+            type: 'effect',
+            seriesKeys: ['COVID-19'],
+            column: 'Attribute',
+            value: 'Dotted',
+            style: 'Dashed Small',
+            label: 'COVID Dotted',
+            displayTooltip: true,
+            displayLegend: true,
+            displayTable: true,
+            symbol: '',
+            iconCode: '',
+            lineCode: '',
+            hideBarSymbol: false,
+            hideLineStyle: false,
+            circleSize: 6,
+            displayGray: false,
+            weight: weight as PreliminaryDataItem['weight']
+          }
+        ]
+
+        const data = [{ Date: '10/5/2025', Category: 'COVID-19', Value: '43.6', Attribute: 'Dotted' }]
+
+        const styles = createStyles({
+          preliminaryData,
+          data,
+          stroke: '#000',
+          strokeWidth: 2,
+          handleLineType: mockHandleLineType,
+          lineType: 'solid-line',
+          seriesKey: 'COVID-19',
+          dynamicCategory: 'Category',
+          originalSeriesKey: 'Value'
+        })
+
+        expect(styles).toHaveLength(1)
+        expect(styles[0].strokeWidth).toBe(expected)
+      })
     })
   })
 
@@ -463,6 +513,62 @@ describe('LineChart helpers', () => {
         expect(circles).toHaveLength(2)
         expect(circles.map(circle => circle.data.Value)).toEqual([0, '12.3'])
       })
+    })
+  })
+
+  describe('createDataSegments', () => {
+    const mockColorScale = vi.fn(() => '#000')
+
+    const makeSuppression = (overrides: Partial<PreliminaryDataItem> = {}): PreliminaryDataItem => ({
+      type: 'suppression',
+      seriesKeys: ['COVID-19'],
+      column: '',
+      value: 'Suppressed',
+      style: 'Dashed Small',
+      label: 'Suppressed',
+      displayTooltip: true,
+      displayLegend: true,
+      displayTable: true,
+      symbol: '',
+      iconCode: '',
+      lineCode: '',
+      hideBarSymbol: false,
+      hideLineStyle: false,
+      circleSize: 6,
+      displayGray: false,
+      ...overrides
+    })
+
+    const suppressionData = [
+      { Date: '10/5/2025', 'COVID-19': '43.6' },
+      { Date: '10/12/2025', 'COVID-19': 'Suppressed' },
+      { Date: '10/19/2025', 'COVID-19': '42.6' }
+    ]
+
+    it('propagates the suppression weight onto the generated segment', () => {
+      const segments = createDataSegments({
+        data: suppressionData,
+        seriesKey: 'COVID-19',
+        preliminaryData: [makeSuppression({ weight: 5 })],
+        colorScale: mockColorScale
+      })
+
+      const suppressedSegments = segments.filter(segment => segment.style)
+      expect(suppressedSegments.length).toBeGreaterThan(0)
+      expect(suppressedSegments.every(segment => segment.weight === 5)).toBe(true)
+    })
+
+    it('leaves the segment weight undefined when no custom weight is set', () => {
+      const segments = createDataSegments({
+        data: suppressionData,
+        seriesKey: 'COVID-19',
+        preliminaryData: [makeSuppression()],
+        colorScale: mockColorScale
+      })
+
+      const suppressedSegments = segments.filter(segment => segment.style)
+      expect(suppressedSegments.length).toBeGreaterThan(0)
+      expect(suppressedSegments.every(segment => segment.weight === undefined)).toBe(true)
     })
   })
 })

--- a/packages/chart/src/components/LineChart/helpers.test.ts
+++ b/packages/chart/src/components/LineChart/helpers.test.ts
@@ -180,6 +180,100 @@ describe('LineChart helpers', () => {
         expect(styles[2].strokeDasharray).toBe('5 5')
       })
     })
+
+    describe('with custom weight', () => {
+      it('should apply custom weight from preliminaryData item', () => {
+        const preliminaryDataWithWeight: PreliminaryDataItem[] = [
+          {
+            type: 'effect',
+            seriesKeys: ['COVID-19'],
+            column: 'Attribute',
+            value: 'Dotted',
+            style: 'Dashed Small',
+            label: 'COVID Dotted',
+            displayTooltip: true,
+            displayLegend: true,
+            displayTable: true,
+            symbol: '',
+            iconCode: '',
+            lineCode: '',
+            hideBarSymbol: false,
+            hideLineStyle: false,
+            circleSize: 6,
+            displayGray: false,
+            weight: 5 // Custom weight
+          }
+        ]
+
+        const data = [
+          { Date: '10/5/2025', Category: 'COVID-19', Value: '43.6', Attribute: 'Dotted' },
+          { Date: '10/12/2025', Category: 'COVID-19', Value: '40.7', Attribute: '' },
+          { Date: '10/19/2025', Category: 'COVID-19', Value: '42.6', Attribute: 'Dotted' }
+        ]
+
+        const styles = createStyles({
+          preliminaryData: preliminaryDataWithWeight,
+          data,
+          stroke: '#000',
+          strokeWidth: 2, // Default weight
+          handleLineType: mockHandleLineType,
+          lineType: 'solid-line',
+          seriesKey: 'COVID-19',
+          dynamicCategory: 'Category',
+          originalSeriesKey: 'Value'
+        })
+
+        expect(styles).toHaveLength(3)
+        // First point has effect with custom weight
+        expect(styles[0].strokeWidth).toBe(5)
+        // Second point inherits custom weight from next point's effect
+        expect(styles[1].strokeWidth).toBe(5)
+        // Third point has effect with custom weight
+        expect(styles[2].strokeWidth).toBe(5)
+      })
+
+      it('should use default strokeWidth when preliminaryData has no weight', () => {
+        const preliminaryDataNoWeight: PreliminaryDataItem[] = [
+          {
+            type: 'effect',
+            seriesKeys: ['COVID-19'],
+            column: 'Attribute',
+            value: 'Dotted',
+            style: 'Dashed Small',
+            label: 'COVID Dotted',
+            displayTooltip: true,
+            displayLegend: true,
+            displayTable: true,
+            symbol: '',
+            iconCode: '',
+            lineCode: '',
+            hideBarSymbol: false,
+            hideLineStyle: false,
+            circleSize: 6,
+            displayGray: false
+            // No weight property
+          }
+        ]
+
+        const data = [{ Date: '10/5/2025', Category: 'COVID-19', Value: '43.6', Attribute: 'Dotted' }]
+
+        const styles = createStyles({
+          preliminaryData: preliminaryDataNoWeight,
+          data,
+          stroke: '#000',
+          strokeWidth: 2,
+          handleLineType: mockHandleLineType,
+          lineType: 'solid-line',
+          seriesKey: 'COVID-19',
+          dynamicCategory: 'Category',
+          originalSeriesKey: 'Value'
+        })
+
+        expect(styles).toHaveLength(1)
+        // Should use default strokeWidth when no custom weight
+        expect(styles[0].strokeWidth).toBe(2)
+      })
+    })
   })
 
   describe('filterCircles', () => {

--- a/packages/chart/src/components/LineChart/helpers.ts
+++ b/packages/chart/src/components/LineChart/helpers.ts
@@ -45,9 +45,9 @@ export const createStyles = (props: StyleProps): Style[] => {
     validPreliminaryData.find(pd => isEffectLine(pd, point))
 
   const styles: Style[] = []
-  const createStyle = (lineStyle): Style => ({
+  const createStyle = (lineStyle, customWeight?: number | string): Style => ({
     stroke: stroke,
-    strokeWidth: strokeWidth,
+    strokeWidth: Number(customWeight) || strokeWidth,
     strokeDasharray: lineStyle
   })
 
@@ -55,14 +55,14 @@ export const createStyles = (props: StyleProps): Style[] => {
     const matchingPd: PreliminaryDataItem = getMatchingPd(d)
 
     let style: Style = matchingPd
-      ? createStyle(handleLineType(matchingPd.style))
+      ? createStyle(handleLineType(matchingPd.style), matchingPd.weight)
       : createStyle(handleLineType(lineType))
 
     styles.push(style)
 
     // If matchingPd exists, update the previous style if there is a previous element
     if (matchingPd && index > 0) {
-      styles[index - 1] = createStyle(handleLineType(matchingPd.style))
+      styles[index - 1] = createStyle(handleLineType(matchingPd.style), matchingPd.weight)
     }
   })
   return styles as Style[]

--- a/packages/chart/src/components/LineChart/helpers.ts
+++ b/packages/chart/src/components/LineChart/helpers.ts
@@ -45,11 +45,16 @@ export const createStyles = (props: StyleProps): Style[] => {
     validPreliminaryData.find(pd => isEffectLine(pd, point))
 
   const styles: Style[] = []
-  const createStyle = (lineStyle, customWeight?: number | string): Style => ({
-    stroke: stroke,
-    strokeWidth: Number(customWeight) || strokeWidth,
-    strokeDasharray: lineStyle
-  })
+  const createStyle = (lineStyle, customWeight?: number | string): Style => {
+    const parsedWeight = Number(customWeight)
+    const hasValidWeight =
+      customWeight !== '' && customWeight != null && Number.isFinite(parsedWeight) && parsedWeight >= 1
+    return {
+      stroke: stroke,
+      strokeWidth: hasValidWeight ? parsedWeight : strokeWidth,
+      strokeDasharray: lineStyle
+    }
+  }
 
   data.forEach((d, index) => {
     const matchingPd: PreliminaryDataItem = getMatchingPd(d)
@@ -141,7 +146,8 @@ const handleFirstIndex = ({
   const result = {
     data: { '0': [] },
     style: '',
-    color: ''
+    color: '',
+    weight: undefined
   }
 
   // If data is empty, return the empty result
@@ -162,6 +168,7 @@ const handleFirstIndex = ({
 
     result.data[pairCount].push(modifiedItem)
     result.style = suppressionData.style
+    result.weight = suppressionData.weight
     result.color = dynamicCategory && modifiedItem ? colorScale(modifiedItem[dynamicCategory]) : ''
 
     // Find the next calculable item index
@@ -192,7 +199,8 @@ const handleLastIndex = ({
   const result = {
     data: { '0': [] },
     style: '',
-    color: ''
+    color: '',
+    weight: undefined
   }
   const lastIndexDataItem = data[data.length - 1]
 
@@ -215,6 +223,7 @@ const handleLastIndex = ({
         lastAddedIndex = prevIndex
       }
       result.style = pd.style
+      result.weight = pd.weight
       result.color = colorScale(modifiedItem[dynamicCategory])
     }
   })
@@ -234,7 +243,8 @@ const handleMiddleIndices = ({
   let result = {
     data: {},
     style: '',
-    color: 'red'
+    color: 'red',
+    weight: undefined
   }
 
   //skip processing if data or preliminaryData is not an array
@@ -272,6 +282,7 @@ const handleMiddleIndices = ({
         // Only add siblings to results if both siblings are found
         if (siblingBefore && siblingAfter) {
           result.style = pd.style
+          result.weight = pd.weight
           result.color = colorScale(item[dynamicCategory])
           result.data[pairCount++] = [siblingBefore, siblingAfter]
         }

--- a/packages/chart/src/components/LineChart/index.tsx
+++ b/packages/chart/src/components/LineChart/index.tsx
@@ -319,7 +319,7 @@ const LineChart = (props: LineChartProps) => {
                               ? segment.color
                               : colorScale(config.runtime.seriesLabels[seriesKey])
                           }
-                          strokeWidth={seriesData[0]?.weight || 2}
+                          strokeWidth={Number(segment.weight) || seriesData.weight || 2}
                           strokeOpacity={1}
                           shapeRendering='geometricPrecision'
                           strokeDasharray={handleLineType(segment.style)}

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -85,6 +85,7 @@ export interface PreliminaryDataItem {
   hideLineStyle: boolean
   circleSize: number
   displayGray: boolean
+  weight?: number
 }
 
 type DataFormat = {


### PR DESCRIPTION
Adds line weight support to dynamic line charts and supports individual line weight changes on effect lines

## Summary
- Fix for line weights with dynamic categories, can be changed universally across the chart in the "Data Series" "Displaying" section
- Adds support for changing line weights for individual effects in the "suppressed/effect" section. Defaults to undefined and uses the overall charts lineweights

## Testing Steps
Line chart with dynamic categories such as in the associated ticket. Change line weight in various parts under "data series"
