### PR TITLE
Preserve legacy table footnotes on collapse

### DIFF
--- a/packages/core/CONFIG.md
+++ b/packages/core/CONFIG.md
@@ -298,7 +298,7 @@ Shared annotation structures are used by charts and maps that support text or ca
 
 ### `Table`
 
-`Table` controls built-in data tables and related download controls across charts, dashboards, maps, and standalone table packages. When a package renders footnotes alongside the built-in table, collapsing that table also hides the rendered footnotes until the table is expanded again.
+`Table` controls built-in data tables and related download controls across charts, dashboards, maps, and standalone table packages. Standalone table widgets that render footnotes with the table hide those footnotes while collapsed unless `preserveFootnotesOnCollapse` is enabled.
 
 | Field | Type | Required | Description | Allowed values / Notes |
 | --- | --- | --- | --- | --- |
@@ -308,6 +308,7 @@ Shared annotation structures are used by charts and maps that support text or ca
 | `caption` | `string` | No | Table caption. | Optional. |
 | `expanded` | `boolean` | No | Starts the table expanded. | `true`, `false` |
 | `collapsible` | `boolean` | No | Allows the table to collapse. | `true`, `false` |
+| `preserveFootnotesOnCollapse` | `boolean` | No | Keeps standalone table footnotes visible when the table is collapsed. | Defaults to `false`. Migration `4.26.6-1` sets this to `true` for legacy table visualizations that already have footnotes. |
 | `limitHeight` | `boolean` | No | Limits the rendered table height. | `true`, `false` |
 | `height` | `number \| string` | No | Height used when the table is height-limited. | Pixels in current implementations. Numeric strings are supported in saved/editor configs; standalone data-table defaults may use `''` when height limiting is off. |
 | `cellMinWidth` | `number \| string` | No | Minimum width for rendered cells. | Numeric strings are supported in saved/editor configs. |

--- a/packages/core/components/DataTable/DataTableStandAlone.test.tsx
+++ b/packages/core/components/DataTable/DataTableStandAlone.test.tsx
@@ -17,7 +17,7 @@ vi.mock('./DataTable', () => ({
   )
 }))
 
-vi.mock('../Filters', () => ({
+vi.mock('../Filters/Filters', () => ({
   default: () => null
 }))
 
@@ -25,7 +25,7 @@ vi.mock('../Footnotes/FootnotesStandAlone', () => ({
   default: ({ config }) => <div data-testid='footnotes'>{config?.staticFootnotes?.[0]?.text}</div>
 }))
 
-vi.mock('../EditorWrapper', () => ({
+vi.mock('../EditorWrapper/EditorWrapper', () => ({
   default: ({ component: Component, visualizationKey, visualizationConfig, updateConfig, viewport, datasets }) => (
     <Component
       visualizationKey={visualizationKey}
@@ -171,5 +171,24 @@ describe('DataTableStandAlone', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Collapse table' }))
 
     expect(screen.queryByTestId('footnotes')).not.toBeInTheDocument()
+  })
+
+  it('keeps footnotes visible when preserveFootnotesOnCollapse is enabled', () => {
+    const config = {
+      type: 'table',
+      visualizationType: 'table',
+      filters: [],
+      data: [{ name: 'Alice' }],
+      table: { expanded: true, label: 'People', preserveFootnotesOnCollapse: true },
+      footnotes: {
+        staticFootnotes: [{ text: 'Persistent table footnote' }]
+      }
+    } as any
+
+    render(<DataTableStandAlone visualizationKey='tableA' config={config} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse table' }))
+
+    expect(screen.getByTestId('footnotes')).toHaveTextContent('Persistent table footnote')
   })
 })

--- a/packages/core/components/DataTable/DataTableStandAlone.tsx
+++ b/packages/core/components/DataTable/DataTableStandAlone.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { ViewPort } from '../../types/ViewPort'
-import EditorWrapper from '../EditorWrapper'
+import EditorWrapper from '../EditorWrapper/EditorWrapper'
 import DataTable from './DataTable'
 import DataTableEditorPanel from './components/DataTableEditorPanel'
-import Filters from '../Filters'
+import Filters from '../Filters/Filters'
 import { TableConfig } from './types/TableConfig'
 import { filterVizData } from '../../helpers/filterVizData'
 import { addValuesToFilters } from '../../helpers/addValuesToFilters'
@@ -93,7 +93,7 @@ const DataTableStandAlone: React.FC<StandAloneProps> = ({
         interactionLabel={interactionLabel}
         onExpandedChange={setTableExpanded}
       />
-      {tableExpanded && (
+      {(tableExpanded || config.table?.preserveFootnotesOnCollapse) && (
         <FootnotesStandAlone
           config={config.footnotes}
           filters={config.filters?.filter(f => f.filterFootnotes)}

--- a/packages/core/components/EditorPanel/DataTableEditor.test.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.test.tsx
@@ -11,7 +11,7 @@ vi.mock('../ui/Icon', () => ({
   default: () => <span data-testid='icon' />
 }))
 
-vi.mock('../MultiSelect', () => ({
+vi.mock('../MultiSelect/MultiSelect', () => ({
   default: () => <div data-testid='multi-select' />
 }))
 
@@ -190,6 +190,31 @@ describe('DataTableEditor', () => {
     fireEvent.click(screen.getByLabelText('Show Dataset Link'))
 
     expect(updateField).toHaveBeenCalledWith('table', null, 'showDatasetLink', true)
+  })
+
+  it('wires the standalone table footnote collapse checkbox to table.preserveFootnotesOnCollapse', () => {
+    const updateField = renderEditor(
+      {
+        ...baseConfig,
+        type: 'table',
+        visualizationType: 'table',
+        table: {
+          ...baseConfig.table,
+          preserveFootnotesOnCollapse: false
+        }
+      },
+      vi.fn()
+    )
+
+    fireEvent.click(screen.getByLabelText('Keep footnotes visible when collapsed'))
+
+    expect(updateField).toHaveBeenCalledWith('table', null, 'preserveFootnotesOnCollapse', true)
+  })
+
+  it('does not show the footnote collapse checkbox for chart data tables', () => {
+    renderEditor(baseConfig)
+
+    expect(screen.queryByLabelText('Keep footnotes visible when collapsed')).not.toBeInTheDocument()
   })
 
   it('shows the dataset link text field for dashboard tables when the dataset link is enabled', () => {

--- a/packages/core/components/EditorPanel/DataTableEditor.tsx
+++ b/packages/core/components/EditorPanel/DataTableEditor.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 import Tooltip from '@cdc/core/components/ui/Tooltip'
 import Icon from '../ui/Icon'
 import { CheckBox, TextField, Select } from './Inputs'
-import MultiSelect from '../MultiSelect'
+import MultiSelect from '../MultiSelect/MultiSelect'
 import { UpdateFieldFunc } from '../../types/UpdateFieldFunc'
 import { Visualization } from '../../types/Visualization'
 import _ from 'lodash'
@@ -32,6 +32,7 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
       : config.dataFileSourceType === 'url' && Boolean(config.runtimeDataUrl || config.dataUrl || config.dataFileName)
   const usesDashboardDatasetLinkToggle = isDashboard && config.type === 'table'
   const supportsSearch = config.visualizationType !== 'Box Plot'
+  const supportsFootnoteCollapseToggle = config.type === 'table' && config.table?.collapsible
   const excludedColumns = useMemo(() => {
     return Object.keys(config.columns)
       .map<[string, boolean]>(key => [config.columns[key].name, config.columns[key].dataTable])
@@ -293,6 +294,15 @@ const DataTableEditor: React.FC<DataTableProps> = ({ config, updateField, isDash
           value={config.table.showBottomCollapse}
           fieldName='showBottomCollapse'
           label='Show collapse below table'
+          section='table'
+          updateField={updateField}
+        />
+      )}
+      {supportsFootnoteCollapseToggle && (
+        <CheckBox
+          value={config.table.preserveFootnotesOnCollapse ?? false}
+          fieldName='preserveFootnotesOnCollapse'
+          label='Keep footnotes visible when collapsed'
           section='table'
           updateField={updateField}
         />

--- a/packages/core/helpers/coveUpdateWorker.ts
+++ b/packages/core/helpers/coveUpdateWorker.ts
@@ -27,6 +27,7 @@ import update_4_26_4 from './ver/4.26.4'
 import update_4_26_4_1 from './ver/4.26.4-1'
 import update_4_26_5 from './ver/4.26.5'
 import update_4_26_6 from './ver/4.26.6'
+import update_4_26_6_1 from './ver/4.26.6-1'
 
 import { stripDataFromConfig, restoreDataToConfig } from './configDataHelpers'
 
@@ -60,7 +61,8 @@ export const coveUpdateWorker = (config, multiDashboardVersion?) => {
     ['4.26.4', update_4_26_4],
     ['4.26.4-1', update_4_26_4_1],
     ['4.26.5', update_4_26_5],
-    ['4.26.6', update_4_26_6]
+    ['4.26.6', update_4_26_6],
+    ['4.26.6-1', update_4_26_6_1]
   ]
 
   const initialVersion = genConfig.version

--- a/packages/core/helpers/ver/4.26.6-1.ts
+++ b/packages/core/helpers/ver/4.26.6-1.ts
@@ -1,0 +1,39 @@
+import cloneConfig from '../cloneConfig'
+
+const ver = '4.26.6-1'
+
+const hasStaticFootnotes = footnotes =>
+  Array.isArray(footnotes?.staticFootnotes) &&
+  footnotes.staticFootnotes.some(footnote =>
+    String(footnote?.text || '')
+      .replace(/<[^>]*>/g, '')
+      .trim()
+  )
+
+const hasDynamicFootnotes = footnotes => Boolean(footnotes?.dataKey && footnotes?.dynamicFootnotes?.textColumn)
+
+const hasRenderableFootnotes = config => hasStaticFootnotes(config?.footnotes) || hasDynamicFootnotes(config?.footnotes)
+
+const preserveLegacyTableFootnotes = config => {
+  if (config?.type === 'table' && hasRenderableFootnotes(config)) {
+    config.table = config.table || {}
+
+    if (config.table.preserveFootnotesOnCollapse === undefined) {
+      config.table.preserveFootnotesOnCollapse = true
+    }
+  }
+
+  if (config?.type === 'dashboard' && config.visualizations) {
+    Object.values(config.visualizations).forEach(preserveLegacyTableFootnotes)
+  }
+}
+
+const update_4_26_6_1 = config => {
+  const newConfig = cloneConfig(config)
+  preserveLegacyTableFootnotes(newConfig)
+  newConfig.version = ver
+  return newConfig
+}
+
+export { preserveLegacyTableFootnotes }
+export default update_4_26_6_1

--- a/packages/core/helpers/ver/tests/4.26.6-1.test.ts
+++ b/packages/core/helpers/ver/tests/4.26.6-1.test.ts
@@ -1,0 +1,145 @@
+import update_4_26_6_1 from '../4.26.6-1'
+import { coveUpdateWorker } from '../../coveUpdateWorker'
+import { describe, expect, it } from 'vitest'
+
+describe('update_4_26_6_1', () => {
+  it('preserves static table footnotes for legacy table visualizations', () => {
+    const config: any = {
+      type: 'table',
+      version: '4.26.6',
+      table: { expanded: false, collapsible: true },
+      footnotes: {
+        staticFootnotes: [{ text: 'Legacy table footnote' }]
+      }
+    }
+
+    const result = update_4_26_6_1(config)
+
+    expect(result.table.preserveFootnotesOnCollapse).toBe(true)
+    expect(result.version).toBe('4.26.6-1')
+    expect(config.table.preserveFootnotesOnCollapse).toBeUndefined()
+  })
+
+  it('preserves dynamic table footnotes for legacy table visualizations', () => {
+    const result = update_4_26_6_1({
+      type: 'table',
+      version: '4.26.6',
+      table: { expanded: false, collapsible: true },
+      footnotes: {
+        dataKey: 'footnote-data',
+        dynamicFootnotes: {
+          textColumn: 'Note'
+        }
+      }
+    } as any)
+
+    expect(result.table.preserveFootnotesOnCollapse).toBe(true)
+  })
+
+  it('does not add the compatibility flag to tables without footnotes', () => {
+    const result = update_4_26_6_1({
+      type: 'table',
+      version: '4.26.6',
+      table: { expanded: false, collapsible: true }
+    } as any)
+
+    expect(result.table.preserveFootnotesOnCollapse).toBeUndefined()
+  })
+
+  it('does not add the compatibility flag for empty static footnote markup', () => {
+    const result = update_4_26_6_1({
+      type: 'table',
+      version: '4.26.6',
+      table: { expanded: false, collapsible: true },
+      footnotes: {
+        staticFootnotes: [{ text: '<br><span> </span>' }]
+      }
+    } as any)
+
+    expect(result.table.preserveFootnotesOnCollapse).toBeUndefined()
+  })
+
+  it('preserves explicit table footnote collapse settings', () => {
+    const result = update_4_26_6_1({
+      type: 'table',
+      version: '4.26.6',
+      table: {
+        expanded: false,
+        collapsible: true,
+        preserveFootnotesOnCollapse: false
+      },
+      footnotes: {
+        staticFootnotes: [{ text: 'Use the new collapse behavior' }]
+      }
+    } as any)
+
+    expect(result.table.preserveFootnotesOnCollapse).toBe(false)
+  })
+
+  it('updates dashboard table visualizations recursively', () => {
+    const result = update_4_26_6_1({
+      type: 'dashboard',
+      version: '4.26.6',
+      visualizations: {
+        chartA: {
+          type: 'chart',
+          table: { expanded: false },
+          footnotes: {
+            staticFootnotes: [{ text: 'Chart footnote stays outside table collapse' }]
+          }
+        },
+        tableA: {
+          type: 'table',
+          table: { expanded: false, collapsible: true },
+          footnotes: {
+            staticFootnotes: [{ text: 'Dashboard table footnote' }]
+          }
+        },
+        nestedDashboard: {
+          type: 'dashboard',
+          visualizations: {
+            tableB: {
+              type: 'table',
+              table: { expanded: false, collapsible: true },
+              footnotes: {
+                staticFootnotes: [{ text: 'Nested dashboard table footnote' }]
+              }
+            }
+          }
+        }
+      }
+    } as any)
+
+    expect(result.visualizations.chartA.table.preserveFootnotesOnCollapse).toBeUndefined()
+    expect(result.visualizations.tableA.table.preserveFootnotesOnCollapse).toBe(true)
+    expect(result.visualizations.nestedDashboard.visualizations.tableB.table.preserveFootnotesOnCollapse).toBe(true)
+  })
+
+  it('runs after 4.26.6 in coveUpdateWorker', () => {
+    const result = coveUpdateWorker({
+      type: 'table',
+      version: '4.26.6',
+      table: { expanded: false, collapsible: true },
+      footnotes: {
+        staticFootnotes: [{ text: 'Already 4.26.6 table footnote' }]
+      }
+    } as any)
+
+    expect(result.table.preserveFootnotesOnCollapse).toBe(true)
+    expect(result.version).toBe('4.26.6-1')
+  })
+
+  it('does not rerun for configs already migrated to 4.26.6-1', () => {
+    const result = coveUpdateWorker({
+      type: 'table',
+      version: '4.26.6-1',
+      table: { expanded: false, collapsible: true },
+      footnotes: {
+        staticFootnotes: [{ text: 'Already migrated table footnote' }]
+      }
+    } as any)
+
+    expect(result.table.preserveFootnotesOnCollapse).toBeUndefined()
+    expect(result.version).toBe('4.26.6-1')
+  })
+})

--- a/packages/core/helpers/ver/tests/4.26.6.test.ts
+++ b/packages/core/helpers/ver/tests/4.26.6.test.ts
@@ -332,7 +332,7 @@ describe('update_4_26_6', () => {
       }
     } as any)
 
-    expect(result.version).toBe('4.26.6')
+    expect(result.version).toBe('4.26.6-1')
     expect(result.dashboard.sharedFilters[0].fileNameTargets).toEqual([
       { datasetKey: 'state-line-data', fileName: 'state_${value}' }
     ])
@@ -350,7 +350,7 @@ describe('update_4_26_6', () => {
     const result = coveUpdateWorker(config)
 
     expect(result.yAxis.autoMaxStrategy).toBeUndefined()
-    expect(result.version).toBe('4.26.6')
+    expect(result.version).toBe('4.26.6-1')
   })
 })
 
@@ -769,9 +769,9 @@ describe('update_4_26_6', () => {
         row.columns?.some(column => column.widget === secondChildGeneratedTables[0][0])
       )
     ).toHaveLength(1)
-    expect(result.version).toBe('4.26.6')
-    expect(result.multiDashboards[0].version).toBe('4.26.6')
-    expect(result.multiDashboards[1].version).toBe('4.26.6')
+    expect(result.version).toBe('4.26.6-1')
+    expect(result.multiDashboards[0].version).toBe('4.26.6-1')
+    expect(result.multiDashboards[1].version).toBe('4.26.6-1')
   })
 
   it('migrates runtime active multi-dashboard fields without overwriting the active tab', () => {

--- a/packages/core/types/Table.ts
+++ b/packages/core/types/Table.ts
@@ -26,6 +26,7 @@ export type Table = {
   downloadPdfButton?: boolean
   excludeColumns?: string[]
   expanded?: boolean
+  preserveFootnotesOnCollapse?: boolean
   groupBy?: string
   height?: number
   includeContextInDownload?: boolean


### PR DESCRIPTION
## Summary
Added a migration update so that old visualizations maintain their current functionality around collapsed footnotes.
