### PR TITLE
Enhancement [DEV-13412] Copy and paste across dashboard tabs

### DIFF
--- a/packages/dashboard/src/DashboardCopyPasteContext.test.tsx
+++ b/packages/dashboard/src/DashboardCopyPasteContext.test.tsx
@@ -8,7 +8,18 @@ const CopyPasteHarness = () => {
 
   return (
     <>
-      <button onClick={() => copyWidget({ sourceWidgetKey: 'source-widget', label: 'Source Component' })}>
+      <button
+        onClick={() =>
+          copyWidget({
+            sourceWidgetKey: 'source-widget',
+            label: 'Source Component',
+            visualization: { uid: 'source-widget', type: 'markup-include' } as any,
+            dashboard: { sharedFilters: [] },
+            sourceDashboardIndex: 0,
+            sourceFilterTarget: 'source-widget'
+          })
+        }
+      >
         Copy Test Component
       </button>
       {copiedWidget && <span>{copiedWidget.label}</span>}

--- a/packages/dashboard/src/DashboardCopyPasteContext.tsx
+++ b/packages/dashboard/src/DashboardCopyPasteContext.tsx
@@ -1,9 +1,5 @@
 import React, { createContext, useCallback, useEffect, useMemo, useState } from 'react'
-
-export type CopiedDashboardWidget = {
-  sourceWidgetKey: string
-  label: string
-}
+import type { CopiedDashboardWidget } from './helpers/cloneDashboardWidget'
 
 type DashboardCopyPasteContextValue = {
   copiedWidget?: CopiedDashboardWidget

--- a/packages/dashboard/src/components/Column.test.tsx
+++ b/packages/dashboard/src/components/Column.test.tsx
@@ -17,6 +17,20 @@ vi.mock('./Widget/Widget', () => ({
   )
 }))
 
+const makeCopiedWidget = () => ({
+  sourceWidgetKey: 'source-widget',
+  label: 'Source',
+  visualization: {
+    uid: 'source-widget',
+    type: 'markup-include',
+    visualizationType: 'markup-include',
+    contentEditor: { title: 'Source' }
+  },
+  dashboard: { sharedFilters: [] },
+  sourceDashboardIndex: 0,
+  sourceFilterTarget: 'source-widget'
+})
+
 const renderColumn = ({
   data,
   copiedWidget = undefined,
@@ -77,7 +91,7 @@ const renderColumn = ({
 
 describe('Column copy paste slots', () => {
   it('shows paste-ready text in an empty simple column and dispatches clone on click', () => {
-    const copiedWidget = { sourceWidgetKey: 'source-widget', label: 'Source' }
+    const copiedWidget = makeCopiedWidget()
     const { dispatch, clearCopiedWidget } = renderColumn({ data: { width: 12 }, copiedWidget })
 
     fireEvent.click(
@@ -86,13 +100,13 @@ describe('Column copy paste slots', () => {
 
     expect(dispatch).toHaveBeenCalledWith({
       type: 'CLONE_VISUALIZATION',
-      payload: { sourceWidgetKey: 'source-widget', rowIdx: 0, colIdx: 0 }
+      payload: { copiedWidget, rowIdx: 0, colIdx: 0, isCrossDashboardPaste: false }
     })
     expect(clearCopiedWidget).toHaveBeenCalled()
   })
 
   it('shows paste-ready text in the empty conditional slot and dispatches with entry index', () => {
-    const copiedWidget = { sourceWidgetKey: 'source-widget', label: 'Source' }
+    const copiedWidget = makeCopiedWidget()
     const { dispatch } = renderColumn({
       data: { width: 12, conditionalWidgets: [{ widget: 'existing-widget' }] },
       copiedWidget
@@ -106,7 +120,7 @@ describe('Column copy paste slots', () => {
 
     expect(dispatch).toHaveBeenCalledWith({
       type: 'CLONE_VISUALIZATION',
-      payload: { sourceWidgetKey: 'source-widget', rowIdx: 0, colIdx: 0, entryIdx: 1 }
+      payload: { copiedWidget, rowIdx: 0, colIdx: 0, entryIdx: 1, isCrossDashboardPaste: false }
     })
   })
 

--- a/packages/dashboard/src/components/Column.tsx
+++ b/packages/dashboard/src/components/Column.tsx
@@ -3,6 +3,7 @@ import { useDrop } from 'react-dnd'
 
 import { DashboardContext, DashboardDispatchContext } from '../DashboardContext'
 import { DashboardCopyPasteContext } from '../DashboardCopyPasteContext'
+import type { CopiedDashboardWidget } from '../helpers/cloneDashboardWidget'
 import Widget from './Widget/Widget'
 import { getColumnWidgetEntries, hasConditionalWidgets } from '../helpers/dashboardColumnWidgets'
 
@@ -46,6 +47,11 @@ const handleTitle = (config, sharedFilters = []) => {
   if (config.type === 'table') return config.table?.label
   return config.title
 }
+
+const isCrossDashboardPaste = (copiedWidget: CopiedDashboardWidget, activeDashboard?: number) =>
+  copiedWidget.sourceDashboardIndex !== undefined &&
+  activeDashboard !== undefined &&
+  copiedWidget.sourceDashboardIndex !== activeDashboard
 
 type ConditionalColumnProps = {
   data: any
@@ -103,7 +109,12 @@ const SimpleColumn: React.FC<SimpleColumnProps> = ({ data, rowIdx, colIdx, toggl
 
     dispatch({
       type: 'CLONE_VISUALIZATION',
-      payload: { sourceWidgetKey: copiedWidget.sourceWidgetKey, rowIdx, colIdx }
+      payload: {
+        copiedWidget,
+        rowIdx,
+        colIdx,
+        isCrossDashboardPaste: isCrossDashboardPaste(copiedWidget, config.activeDashboard)
+      }
     })
     clearCopiedWidget()
   }
@@ -202,7 +213,13 @@ const ConditionalColumnSlot: React.FC<ConditionalColumnSlotProps> = ({
 
     dispatch({
       type: 'CLONE_VISUALIZATION',
-      payload: { sourceWidgetKey: copiedWidget.sourceWidgetKey, rowIdx, colIdx, entryIdx: entryIndex }
+      payload: {
+        copiedWidget,
+        rowIdx,
+        colIdx,
+        entryIdx: entryIndex,
+        isCrossDashboardPaste: isCrossDashboardPaste(copiedWidget, config.activeDashboard)
+      }
     })
     clearCopiedWidget()
   }

--- a/packages/dashboard/src/components/Widget/Widget.test.tsx
+++ b/packages/dashboard/src/components/Widget/Widget.test.tsx
@@ -146,7 +146,24 @@ describe('Widget', () => {
 
     fireEvent.click(screen.getByTitle('Copy Component'))
 
-    expect(copyWidget).toHaveBeenCalledWith({ sourceWidgetKey: 'markup-1', label: 'Example' })
+    expect(copyWidget).toHaveBeenCalledWith({
+      sourceWidgetKey: 'markup-1',
+      label: 'Example',
+      visualization: {
+        uid: 'markup-1',
+        type: 'markup-include',
+        visualizationType: 'markup-include',
+        contentEditor: { title: 'Example' }
+      },
+      dashboard: { sharedFilters: [] },
+      sourceDashboardIndex: 0,
+      sourceDashboardCondition: {
+        id: 'column-condition-1',
+        datasetKey: 'condition-data',
+        operator: 'hasData'
+      },
+      sourceFilterTarget: 'markup-1'
+    })
   })
 
   it('uses a delete button for removing widgets', () => {
@@ -179,7 +196,14 @@ describe('Widget', () => {
   it('marks the copied widget and lets the active copy button cancel copy mode', () => {
     const clearCopiedWidget = vi.fn()
     const { container, copyWidget } = renderWidget({
-      copiedWidget: { sourceWidgetKey: 'markup-1', label: 'Example' },
+      copiedWidget: {
+        sourceWidgetKey: 'markup-1',
+        label: 'Example',
+        visualization: { uid: 'markup-1', type: 'markup-include' },
+        dashboard: { sharedFilters: [] },
+        sourceDashboardIndex: 0,
+        sourceFilterTarget: 'markup-1'
+      },
       clearCopiedWidget
     })
 

--- a/packages/dashboard/src/components/Widget/Widget.tsx
+++ b/packages/dashboard/src/components/Widget/Widget.tsx
@@ -16,6 +16,7 @@ import { DashboardConditionSummary } from '../DashboardConditionSummary'
 import { labelHash } from '@cdc/core/helpers/labelHash'
 import { dashboardConditionsSupportedForRow } from '../../helpers/dashboardFilterTargets'
 import { getConditionalWidgets, hasConditionalWidgets } from '../../helpers/dashboardColumnWidgets'
+import { createCopiedDashboardWidget } from '../../helpers/cloneDashboardWidget'
 import './widget.styles.css'
 
 type WidgetConfig = AnyVisualization & { rowIdx: number; colIdx: number; entryIdx?: number }
@@ -144,10 +145,14 @@ const Widget = ({
       return
     }
 
-    copyWidget({
-      sourceWidgetKey: widgetConfig.uid as string,
-      label: title || labelHash[type] || type
-    })
+    copyWidget(
+      createCopiedDashboardWidget(
+        config,
+        widgetConfig.uid as string,
+        title || labelHash[type] || type,
+        config.visualizations[widgetConfig.uid as string] || widgetConfig
+      )
+    )
   }
 
   let isConfigurationReady = false

--- a/packages/dashboard/src/helpers/cloneDashboardWidget.ts
+++ b/packages/dashboard/src/helpers/cloneDashboardWidget.ts
@@ -1,8 +1,10 @@
 import _ from 'lodash'
 import type { AnyVisualization } from '@cdc/core/types/Visualization'
 import { createCoveId } from '@cdc/core/helpers/createCoveId'
-import type { DashboardConfig } from '../types/DashboardConfig'
-import { ConfigRow, DashboardCondition } from '../types/ConfigRow'
+import type { MultiDashboardConfig } from '../types/MultiDashboard'
+import type { ConfigRow, DashboardCondition } from '../types/ConfigRow'
+import type { Dashboard } from '../types/Dashboard'
+import type { SharedFilter } from '../types/SharedFilter'
 import { getDashboardConditionIds } from './dashboardConditions'
 import { getConditionalWidgets, hasConditionalWidgets, normalizeConditionalColumn } from './dashboardColumnWidgets'
 
@@ -12,6 +14,20 @@ export type CloneDashboardWidgetTarget = {
   entryIdx?: number
 }
 
+export type CopiedDashboardWidget = {
+  sourceWidgetKey: string
+  label: string
+  visualization: AnyVisualization
+  dashboard: Pick<Dashboard, 'sharedFilters'>
+  sourceDashboardIndex?: number
+  sourceDashboardCondition?: DashboardCondition
+  sourceFilterTarget: string | number
+}
+
+export type CloneDashboardWidgetOptions = {
+  isCrossDashboardPaste?: boolean
+}
+
 const normalizeTarget = (target: string | number) => `${target}`
 
 const appendTarget = (targets: (string | number)[], target: string | number) => {
@@ -19,8 +35,10 @@ const appendTarget = (targets: (string | number)[], target: string | number) => 
   return [...targets, target]
 }
 
-const createClonedWidgetKey = (sourceWidgetKey: string, visualizations: Record<string, AnyVisualization>) => {
-  const sourceVisualization = visualizations[sourceWidgetKey]
+const createClonedWidgetKey = (
+  sourceVisualization: AnyVisualization,
+  visualizations: Record<string, AnyVisualization>
+) => {
   return createCoveId(sourceVisualization.type, { existingIds: Object.keys(visualizations) })
 }
 
@@ -52,12 +70,30 @@ const getWidgetFilterTarget = (rows: ConfigRow[], widgetKey: string): string | n
   return widgetKey
 }
 
-export const cloneDashboardWidget = (
-  config: DashboardConfig,
+export const createCopiedDashboardWidget = (
+  config: MultiDashboardConfig,
   sourceWidgetKey: string,
-  target: CloneDashboardWidgetTarget
-): DashboardConfig => {
-  const sourceVisualization = config.visualizations?.[sourceWidgetKey]
+  label: string,
+  sourceVisualization: AnyVisualization = config.visualizations[sourceWidgetKey]
+): CopiedDashboardWidget => ({
+  sourceWidgetKey,
+  label,
+  visualization: _.cloneDeep(sourceVisualization),
+  dashboard: {
+    sharedFilters: _.cloneDeep(config.dashboard?.sharedFilters || [])
+  },
+  sourceDashboardIndex: config.activeDashboard,
+  sourceDashboardCondition: _.cloneDeep(getSourceDashboardCondition(config.rows || [], sourceWidgetKey)),
+  sourceFilterTarget: getWidgetFilterTarget(config.rows || [], sourceWidgetKey)
+})
+
+export const cloneDashboardWidget = (
+  config: MultiDashboardConfig,
+  copiedWidget: CopiedDashboardWidget,
+  target: CloneDashboardWidgetTarget,
+  options: CloneDashboardWidgetOptions = {}
+): MultiDashboardConfig => {
+  const sourceVisualization = copiedWidget.visualization
   const targetColumn = config.rows?.[target.rowIdx]?.columns?.[target.colIdx]
 
   if (!sourceVisualization || !targetColumn) return config
@@ -69,12 +105,11 @@ export const cloneDashboardWidget = (
     return config
   }
 
-  const clonedWidgetKey = createClonedWidgetKey(sourceWidgetKey, config.visualizations)
+  const clonedWidgetKey = createClonedWidgetKey(sourceVisualization, config.visualizations)
   const clonedVisualization = { ..._.cloneDeep(sourceVisualization), uid: clonedWidgetKey }
-  const sourceDashboardCondition = getSourceDashboardCondition(config.rows, sourceWidgetKey)
-  const clonedDashboardCondition = sourceDashboardCondition
+  const clonedDashboardCondition = copiedWidget.sourceDashboardCondition
     ? {
-        ..._.cloneDeep(sourceDashboardCondition),
+        ..._.cloneDeep(copiedWidget.sourceDashboardCondition),
         id: createCoveId('condition', { existingIds: getDashboardConditionIds(config.rows) })
       }
     : undefined
@@ -98,19 +133,47 @@ export const cloneDashboardWidget = (
     nextRows[target.rowIdx].columns[target.colIdx].widget = clonedWidgetKey
   }
 
-  const sourceFilterTarget = getWidgetFilterTarget(config.rows, sourceWidgetKey)
-  const clonedFilterTarget = nextRows[target.rowIdx]?.dataKey ? target.rowIdx : clonedWidgetKey
-  const sharedFilters = config.dashboard.sharedFilters?.map(sharedFilter => {
-    if (!sharedFilter.usedBy?.length) return sharedFilter
+  let sharedFilters = config.dashboard.sharedFilters
+  const isSameDashboard = !options.isCrossDashboardPaste
 
-    let nextUsedBy = sharedFilter.usedBy
+  if (sourceVisualization.type === 'dashboardFilters') {
+    const sourceFilterIndexes = (sourceVisualization.sharedFilterIndexes || []).map(Number)
+    const filterIndexMap = sourceFilterIndexes.reduce<Record<number, number>>((acc, sourceFilterIndex) => {
+      if (Number.isNaN(sourceFilterIndex)) return acc
 
-    if (sharedFilter.usedBy.some(target => normalizeTarget(target) === normalizeTarget(sourceFilterTarget))) {
-      nextUsedBy = appendTarget(nextUsedBy, clonedFilterTarget)
-    }
+      if (isSameDashboard) {
+        if (config.dashboard.sharedFilters?.[sourceFilterIndex]) acc[sourceFilterIndex] = sourceFilterIndex
+        return acc
+      }
 
-    return nextUsedBy === sharedFilter.usedBy ? sharedFilter : { ...sharedFilter, usedBy: nextUsedBy }
-  })
+      const sourceFilter = copiedWidget.dashboard.sharedFilters?.[sourceFilterIndex]
+      if (!sourceFilter) return acc
+
+      const nextFilterIndex = sharedFilters?.length ?? 0
+      sharedFilters = [...(sharedFilters || []), _.cloneDeep(sourceFilter) as SharedFilter]
+      acc[sourceFilterIndex] = nextFilterIndex
+      return acc
+    }, {})
+
+    clonedVisualization.sharedFilterIndexes = sourceFilterIndexes
+      .filter(sourceFilterIndex => filterIndexMap[sourceFilterIndex] !== undefined)
+      .map(sourceFilterIndex => filterIndexMap[sourceFilterIndex])
+  } else if (isSameDashboard) {
+    const clonedFilterTarget = nextRows[target.rowIdx]?.dataKey ? target.rowIdx : clonedWidgetKey
+    sharedFilters = config.dashboard.sharedFilters?.map(sharedFilter => {
+      if (!sharedFilter.usedBy?.length) return sharedFilter
+
+      let nextUsedBy = sharedFilter.usedBy
+
+      if (
+        sharedFilter.usedBy.some(target => normalizeTarget(target) === normalizeTarget(copiedWidget.sourceFilterTarget))
+      ) {
+        nextUsedBy = appendTarget(nextUsedBy, clonedFilterTarget)
+      }
+
+      return nextUsedBy === sharedFilter.usedBy ? sharedFilter : { ...sharedFilter, usedBy: nextUsedBy }
+    })
+  }
 
   return {
     ...config,

--- a/packages/dashboard/src/helpers/cloneDashboardWidget.ts
+++ b/packages/dashboard/src/helpers/cloneDashboardWidget.ts
@@ -42,6 +42,20 @@ const createClonedWidgetKey = (
   return createCoveId(sourceVisualization.type, { existingIds: Object.keys(visualizations) })
 }
 
+const sanitizeCrossDashboardSharedFilter = (sharedFilter: SharedFilter): SharedFilter => {
+  const clonedFilter = _.cloneDeep(sharedFilter) as SharedFilter
+  delete clonedFilter.setBy
+  delete clonedFilter.active
+  delete clonedFilter.queuedActive
+  clonedFilter.usedBy = []
+
+  if (clonedFilter.subGrouping) {
+    delete clonedFilter.subGrouping.active
+  }
+
+  return clonedFilter
+}
+
 const getSourceDashboardCondition = (rows: ConfigRow[], sourceWidgetKey: string): DashboardCondition | undefined => {
   for (const row of rows) {
     for (const column of row.columns || []) {
@@ -150,7 +164,7 @@ export const cloneDashboardWidget = (
       if (!sourceFilter) return acc
 
       const nextFilterIndex = sharedFilters?.length ?? 0
-      sharedFilters = [...(sharedFilters || []), _.cloneDeep(sourceFilter) as SharedFilter]
+      sharedFilters = [...(sharedFilters || []), sanitizeCrossDashboardSharedFilter(sourceFilter)]
       acc[sourceFilterIndex] = nextFilterIndex
       return acc
     }, {})

--- a/packages/dashboard/src/helpers/tests/cloneDashboardWidget.test.ts
+++ b/packages/dashboard/src/helpers/tests/cloneDashboardWidget.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cloneDashboardWidget } from '../cloneDashboardWidget'
+import { cloneDashboardWidget, CopiedDashboardWidget } from '../cloneDashboardWidget'
 
 const makeConfig = () =>
   ({
@@ -61,6 +61,18 @@ const makeConfig = () =>
     }
   } as any)
 
+const copyWidget = (config: any, sourceWidgetKey = 'source-widget', activeDashboard = 0): CopiedDashboardWidget => ({
+  sourceWidgetKey,
+  label: 'Source',
+  visualization: structuredClone(config.visualizations[sourceWidgetKey]),
+  dashboard: structuredClone(config.dashboard),
+  sourceDashboardIndex: activeDashboard,
+  sourceDashboardCondition: structuredClone(
+    config.rows[0]?.columns[0]?.conditionalWidgets?.find(entry => entry.widget === sourceWidgetKey)?.dashboardCondition
+  ),
+  sourceFilterTarget: sourceWidgetKey
+})
+
 describe('cloneDashboardWidget', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -71,7 +83,7 @@ describe('cloneDashboardWidget', () => {
     const config = makeConfig()
     delete config.rows[0].columns[0].conditionalWidgets[0].dashboardCondition
 
-    const result = cloneDashboardWidget(config, 'source-widget', { rowIdx: 0, colIdx: 1 })
+    const result = cloneDashboardWidget(config, copyWidget(config), { rowIdx: 0, colIdx: 1 })
     const clonedWidgetKey = result.rows[0].columns[1].widget
 
     expect(clonedWidgetKey).toBeTruthy()
@@ -87,7 +99,7 @@ describe('cloneDashboardWidget', () => {
     vi.spyOn(Math, 'random').mockReturnValueOnce(0.123456789).mockReturnValueOnce(0.23456789)
     const config = makeConfig()
 
-    const result = cloneDashboardWidget(config, 'source-widget', { rowIdx: 0, colIdx: 2, entryIdx: 1 })
+    const result = cloneDashboardWidget(config, copyWidget(config), { rowIdx: 0, colIdx: 2, entryIdx: 1 })
     const clonedEntry = result.rows[0].columns[2].conditionalWidgets[1]
 
     expect(clonedEntry.widget).toBeTruthy()
@@ -114,7 +126,7 @@ describe('cloneDashboardWidget', () => {
       visualizationType: 'markup-include'
     }
 
-    const result = cloneDashboardWidget(config, 'source-widget', { rowIdx: 0, colIdx: 1 })
+    const result = cloneDashboardWidget(config, copyWidget(config), { rowIdx: 0, colIdx: 1 })
 
     expect(result.rows[0].columns[1].widget).toBe('markup-include-8fzzzbjm')
   })
@@ -123,7 +135,7 @@ describe('cloneDashboardWidget', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.123456789)
     const config = makeConfig()
 
-    const result = cloneDashboardWidget(config, 'source-widget', { rowIdx: 0, colIdx: 2, entryIdx: 1 })
+    const result = cloneDashboardWidget(config, copyWidget(config), { rowIdx: 0, colIdx: 2, entryIdx: 1 })
     const clonedEntry = result.rows[0].columns[2].conditionalWidgets[1]
 
     expect(result.dashboard.sharedFilters[0].usedBy).toEqual(['source-widget', clonedEntry.widget])
@@ -132,5 +144,113 @@ describe('cloneDashboardWidget', () => {
     expect(result.dashboard.sharedFilters[2].usedBy).toBeUndefined()
     expect(result.dashboard.sharedFilters[3].usedBy).toEqual([])
     expect(result.dashboard.sharedFilters[4].usedBy).toEqual([0])
+  })
+
+  it('uses the copied snapshot instead of the source config at paste time', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.123456789)
+    const config = makeConfig()
+    delete config.rows[0].columns[0].conditionalWidgets[0].dashboardCondition
+    const copiedWidget = copyWidget(config)
+    config.visualizations['source-widget'].contentEditor.title = 'Edited after copy'
+
+    const result = cloneDashboardWidget(config, copiedWidget, { rowIdx: 0, colIdx: 1 })
+    const clonedWidgetKey = result.rows[0].columns[1].widget
+
+    expect(result.visualizations[clonedWidgetKey].contentEditor.title).toBe('Source')
+  })
+
+  it('clones a normal component across dashboards without copying shared filters or retargeting usedBy', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.123456789)
+    const sourceConfig = makeConfig()
+    const targetConfig = {
+      ...makeConfig(),
+      activeDashboard: 1,
+      dashboard: { sharedFilters: [{ key: 'target-only', usedBy: ['target-widget'] }] },
+      rows: [{ columns: [{ width: 12 }], expandCollapseAllButtons: false }],
+      visualizations: {}
+    } as any
+
+    const result = cloneDashboardWidget(
+      targetConfig,
+      copyWidget(sourceConfig, 'source-widget', 0),
+      {
+        rowIdx: 0,
+        colIdx: 0
+      },
+      { isCrossDashboardPaste: true }
+    )
+    const clonedWidgetKey = result.rows[0].columns[0].conditionalWidgets?.[0].widget
+
+    expect(clonedWidgetKey).toBeTruthy()
+    expect(result.visualizations[clonedWidgetKey].contentEditor.title).toBe('Source')
+    expect(result.dashboard.sharedFilters).toEqual([{ key: 'target-only', usedBy: ['target-widget'] }])
+  })
+
+  it('preserves valid same-dashboard dashboard filter indexes and drops missing indexes', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.123456789)
+    const config = makeConfig()
+    config.visualizations['source-filter-widget'] = {
+      uid: 'source-filter-widget',
+      type: 'dashboardFilters',
+      visualizationType: 'dashboardFilters',
+      sharedFilterIndexes: [0, 9, 2]
+    }
+
+    const result = cloneDashboardWidget(config, copyWidget(config, 'source-filter-widget'), { rowIdx: 0, colIdx: 1 })
+    const clonedWidgetKey = result.rows[0].columns[1].widget
+
+    expect(result.visualizations[clonedWidgetKey].sharedFilterIndexes).toEqual([0, 2])
+    expect(result.dashboard.sharedFilters).toHaveLength(5)
+  })
+
+  it('clones dashboard filter shared filters across dashboards and rewrites indexes in display order', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.123456789)
+    const sourceConfig = makeConfig()
+    sourceConfig.dashboard.sharedFilters[1] = {
+      key: 'parent',
+      type: 'datafilter',
+      columnName: 'state',
+      parents: ['root'],
+      apiFilter: { textSelector: 'name', valueSelector: 'id' },
+      subGrouping: { columnName: 'group' },
+      active: 'CA',
+      queuedActive: 'NY'
+    }
+    sourceConfig.visualizations['source-filter-widget'] = {
+      uid: 'source-filter-widget',
+      type: 'dashboardFilters',
+      visualizationType: 'dashboardFilters',
+      sharedFilterIndexes: [1, 0, 99]
+    }
+    const targetConfig = {
+      ...makeConfig(),
+      activeDashboard: 1,
+      dashboard: { sharedFilters: [{ key: 'target-existing' }] },
+      rows: [{ columns: [{ width: 12 }], expandCollapseAllButtons: false }],
+      visualizations: {}
+    } as any
+
+    const result = cloneDashboardWidget(
+      targetConfig,
+      copyWidget(sourceConfig, 'source-filter-widget', 0),
+      {
+        rowIdx: 0,
+        colIdx: 0
+      },
+      { isCrossDashboardPaste: true }
+    )
+    const clonedWidgetKey = result.rows[0].columns[0].widget
+
+    expect(result.visualizations[clonedWidgetKey].sharedFilterIndexes).toEqual([1, 2])
+    expect(result.dashboard.sharedFilters).toHaveLength(3)
+    expect(result.dashboard.sharedFilters[1]).toMatchObject({
+      key: 'parent',
+      parents: ['root'],
+      apiFilter: { textSelector: 'name', valueSelector: 'id' },
+      subGrouping: { columnName: 'group' },
+      active: 'CA',
+      queuedActive: 'NY'
+    })
+    expect(result.dashboard.sharedFilters[2].key).toBe('scoped-to-source')
   })
 })

--- a/packages/dashboard/src/helpers/tests/cloneDashboardWidget.test.ts
+++ b/packages/dashboard/src/helpers/tests/cloneDashboardWidget.test.ts
@@ -211,8 +211,10 @@ describe('cloneDashboardWidget', () => {
       type: 'datafilter',
       columnName: 'state',
       parents: ['root'],
+      setBy: 'source-widget',
+      usedBy: ['source-widget'],
       apiFilter: { textSelector: 'name', valueSelector: 'id' },
-      subGrouping: { columnName: 'group' },
+      subGrouping: { columnName: 'group', active: 'Metro' },
       active: 'CA',
       queuedActive: 'NY'
     }
@@ -246,11 +248,16 @@ describe('cloneDashboardWidget', () => {
     expect(result.dashboard.sharedFilters[1]).toMatchObject({
       key: 'parent',
       parents: ['root'],
+      usedBy: [],
       apiFilter: { textSelector: 'name', valueSelector: 'id' },
-      subGrouping: { columnName: 'group' },
-      active: 'CA',
-      queuedActive: 'NY'
+      subGrouping: { columnName: 'group' }
     })
+    expect(result.dashboard.sharedFilters[1].setBy).toBeUndefined()
+    expect(result.dashboard.sharedFilters[1].active).toBeUndefined()
+    expect(result.dashboard.sharedFilters[1].queuedActive).toBeUndefined()
+    expect(result.dashboard.sharedFilters[1].subGrouping.active).toBeUndefined()
     expect(result.dashboard.sharedFilters[2].key).toBe('scoped-to-source')
+    expect(result.dashboard.sharedFilters[2].usedBy).toEqual([])
+    expect(result.dashboard.sharedFilters[2].setBy).toBeUndefined()
   })
 })

--- a/packages/dashboard/src/store/dashboard.actions.ts
+++ b/packages/dashboard/src/store/dashboard.actions.ts
@@ -4,6 +4,7 @@ import { Tab } from '../types/Tab'
 import { ConfigRow } from '../types/ConfigRow'
 import { AnyVisualization } from '@cdc/core/types/Visualization'
 import { SharedFilter } from '../types/SharedFilter'
+import type { CopiedDashboardWidget } from '../helpers/cloneDashboardWidget'
 
 type ADD_VISUALIZATION = Action<
   'ADD_VISUALIZATION',
@@ -13,7 +14,13 @@ type APPLY_CONFIG = Action<'APPLY_CONFIG', [Config, Object?]>
 type DELETE_WIDGET = Action<'DELETE_WIDGET', { uid: string }>
 type CLONE_VISUALIZATION = Action<
   'CLONE_VISUALIZATION',
-  { sourceWidgetKey: string; rowIdx: number; colIdx: number; entryIdx?: number }
+  {
+    copiedWidget: CopiedDashboardWidget
+    rowIdx: number
+    colIdx: number
+    entryIdx?: number
+    isCrossDashboardPaste?: boolean
+  }
 >
 type MOVE_VISUALIZATION = Action<
   'MOVE_VISUALIZATION',

--- a/packages/dashboard/src/store/dashboard.reducer.test.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.test.ts
@@ -129,6 +129,19 @@ const baseState = (): DashboardState =>
     filtersApplied: false
   } as DashboardState)
 
+const copyWidgetFromState = (state: DashboardState, sourceWidgetKey: string, activeDashboard = 0) => ({
+  sourceWidgetKey,
+  label: sourceWidgetKey,
+  visualization: structuredClone(state.config.visualizations[sourceWidgetKey]),
+  dashboard: structuredClone(state.config.dashboard),
+  sourceDashboardIndex: activeDashboard,
+  sourceDashboardCondition: structuredClone(
+    state.config.rows[0]?.columns[0]?.conditionalWidgets?.find(entry => entry.widget === sourceWidgetKey)
+      ?.dashboardCondition
+  ),
+  sourceFilterTarget: sourceWidgetKey
+})
+
 describe('dashboard reducer conditional columns', () => {
   it('collapses back to simple mode when deleting alternates leaves one unconditioned entry', () => {
     const state = baseState()
@@ -392,7 +405,7 @@ describe('dashboard reducer conditional columns', () => {
 
     const nextState = reducer(state, {
       type: 'CLONE_VISUALIZATION',
-      payload: { sourceWidgetKey: 'viz-1', rowIdx: 0, colIdx: 1 }
+      payload: { copiedWidget: copyWidgetFromState(state, 'viz-1'), rowIdx: 0, colIdx: 1 }
     })
     const clonedWidgetKey = nextState.config.rows[0].columns[1].widget
 
@@ -439,7 +452,7 @@ describe('dashboard reducer conditional columns', () => {
 
     const nextState = reducer(state, {
       type: 'CLONE_VISUALIZATION',
-      payload: { sourceWidgetKey: 'viz-1', rowIdx: 0, colIdx: 1 }
+      payload: { copiedWidget: copyWidgetFromState(state, 'viz-1'), rowIdx: 0, colIdx: 1 }
     })
     const clonedWidgetKey = nextState.config.rows[0].columns[1].widget
 
@@ -487,7 +500,7 @@ describe('dashboard reducer conditional columns', () => {
 
     const nextState = reducer(state, {
       type: 'CLONE_VISUALIZATION',
-      payload: { sourceWidgetKey: 'viz-1', rowIdx: 1, colIdx: 0 }
+      payload: { copiedWidget: copyWidgetFromState(state, 'viz-1'), rowIdx: 1, colIdx: 0 }
     })
     const clonedEntry = nextState.config.rows[1].columns[0].conditionalWidgets?.[0]
     const clonedConditionId = clonedEntry?.dashboardCondition?.id

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -212,8 +212,13 @@ const reducer = (state: DashboardState, action: DashboardActions): DashboardStat
       }
     }
     case 'CLONE_VISUALIZATION': {
-      const { sourceWidgetKey, rowIdx, colIdx, entryIdx } = action.payload
-      const nextConfig = cloneDashboardWidget(state.config, sourceWidgetKey, { rowIdx, colIdx, entryIdx })
+      const { copiedWidget, rowIdx, colIdx, entryIdx, isCrossDashboardPaste } = action.payload
+      const nextConfig = cloneDashboardWidget(
+        state.config,
+        copiedWidget,
+        { rowIdx, colIdx, entryIdx },
+        { isCrossDashboardPaste }
+      )
 
       if (nextConfig === state.config) return state
 


### PR DESCRIPTION
## Summary

Extends dashboard editor copy/paste functionality to work across multidashboard tabs.

## Testing Steps

Open a multidashboard in the dashboard editor, try to copy/paste a component between tabs.