### PR TITLE
Enhancement [DEV-13409]  Map legend sorting and non-geo data

### DIFF
--- a/dev-portal/compare.html
+++ b/dev-portal/compare.html
@@ -92,9 +92,8 @@
 
     .toolbar__slider-row {
       display: grid;
-      <<<<<<< HEAD grid-template-columns: minmax(220px, 280px);
-      =======grid-template-columns: repeat(3, minmax(220px, 280px));
-      >>>>>>>dev gap: 12px;
+      grid-template-columns: repeat(3, minmax(220px, 280px));
+      gap: 12px;
       align-items: start;
     }
 

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -113,6 +113,8 @@ Legend configuration is shared with core. The map package honors the shared lege
 | `legend.singleColumn`, `legend.singleRow`, `legend.verticalSorted` | `boolean` | No | `false` | Layout and sorting controls for legend items. | Runtime may still adapt for available space. |
 | `legend.showSpecialClassesLast` | `boolean` | No | `false` | Moves special classes to the end of the legend. | `true`, `false` |
 | `legend.dynamicDescription` | `boolean` | No | `false` | Enables dynamic legend description behavior. | `true`, `false` |
+| `legend.categoryValuesOrder` | `(string \| number)[]` | No | `[]` | Custom order for category legend items. | Only used when non-empty and `legend.type` is `category`; omit or clear it to use automatic category ordering. |
+| `legend.additionalCategories` | `string[]` | No | `[]` | Adds extra category labels to the legend domain. | Extra categories participate in the same automatic or custom category ordering path as categories found in data. |
 
 When `legend` is omitted entirely, the package initial state supplies the defaults above. When a config provides a partial `legend` object, missing `numberOfItems`, `position`, `style`, and `hideBorder` can be backfilled from legacy defaults: `3`, `side`, `circles`, and `false`.
 
@@ -120,8 +122,8 @@ When `legend` is omitted entirely, the package initial state supplies the defaul
 | --- | --- |
 | `legend.separateZero` | When `true`, numeric legends split zero into its own class unless `general.equalNumberOptIn` changes the scaling path. |
 | `legend.breakpoints` | Manual numeric legend boundaries. Values outside the authored interior breakpoints still render because the runtime extends the first and last classes to the data minimum and maximum. |
-| `legend.categoryValuesOrder` | Controls the order of categorical legend items and small-multiple tile sorting. |
-| `legend.additionalCategories` | Adds extra category labels to the legend. |
+| Category legend ordering | Category legends use automatic ordering when `legend.categoryValuesOrder` is missing or empty. Automatic ordering places numeric values and simple numeric ranges first, ordered by their numeric bounds, including decimals, comma-formatted numbers, ranges such as `1 - 14` or `1,000 - 1,999`, `to` ranges such as `1 to 4`, and open-ended bins such as `<10`, `>10`, or `30+`. Non-numeric categories appear after numeric categories in first-seen data order. A non-empty `legend.categoryValuesOrder` is treated as an explicit custom order. |
+| `legend.additionalCategories` | Adds extra category labels to the legend before category ordering runs. |
 | `legend.groupBy` | Groups categorical legend items when the editor uses grouped category views. |
 | `legend.tickRotation` | Rotates legend tick labels in supported layouts. |
 | `legend.hideBorder` | Hides the legend border when `true`. The default is `true` for the package’s current initial state. |

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -115,6 +115,7 @@ Legend configuration is shared with core. The map package honors the shared lege
 | `legend.dynamicDescription` | `boolean` | No | `false` | Enables dynamic legend description behavior. | `true`, `false` |
 | `legend.categoryValuesOrder` | `(string \| number)[]` | No | `[]` | Custom order for category legend items. | Only used when non-empty and `legend.type` is `category`; omit or clear it to use automatic category ordering. |
 | `legend.additionalCategories` | `string[]` | No | `[]` | Adds extra category labels to the legend domain. | Extra categories participate in the same automatic or custom category ordering path as categories found in data. |
+| `legend.includeNonGeoDataInDomain` | `boolean` | No | `false` | Allows rows that do not resolve to map geography to contribute category values to the legend domain. | Only used when `legend.type` is `category`. These rows are domain-only and are not added to runtime map data. |
 
 When `legend` is omitted entirely, the package initial state supplies the defaults above. When a config provides a partial `legend` object, missing `numberOfItems`, `position`, `style`, and `hideBorder` can be backfilled from legacy defaults: `3`, `side`, `circles`, and `false`.
 
@@ -124,6 +125,7 @@ When `legend` is omitted entirely, the package initial state supplies the defaul
 | `legend.breakpoints` | Manual numeric legend boundaries. Values outside the authored interior breakpoints still render because the runtime extends the first and last classes to the data minimum and maximum. |
 | Category legend ordering | Category legends use automatic ordering when `legend.categoryValuesOrder` is missing or empty. Automatic ordering places numeric values and simple numeric ranges first, ordered by their numeric bounds, including decimals, comma-formatted numbers, ranges such as `1 - 14` or `1,000 - 1,999`, `to` ranges such as `1 to 4`, and open-ended bins such as `<10`, `>10`, or `30+`. Non-numeric categories appear after numeric categories in first-seen data order. A non-empty `legend.categoryValuesOrder` is treated as an explicit custom order. |
 | `legend.additionalCategories` | Adds extra category labels to the legend before category ordering runs. |
+| `legend.includeNonGeoDataInDomain` | For category legends, rows that cannot be matched to a map geography can still add category values to the legend when this is `true`. This differs from `table.showNonGeoData`: the rows remain out of runtime map data, tooltips, data tables, and visible-data downloads. |
 | `legend.groupBy` | Groups categorical legend items when the editor uses grouped category views. |
 | `legend.tickRotation` | Rotates legend tick labels in supported layouts. |
 | `legend.hideBorder` | Hides the legend border when `true`. The default is `true` for the package’s current initial state. |

--- a/packages/map/src/_stories/CdcMap.Editor.LegendSectionTests.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Editor.LegendSectionTests.stories.tsx
@@ -575,11 +575,31 @@ export const CategorySortTests: Story = {
 
     await openAccordion(canvas, 'Legend')
 
+    const includeNonGeoCategoriesCheckbox = Array.from(
+      canvasElement.querySelectorAll('input[type="checkbox"]') || []
+    ).find(input => {
+      const label = input.closest('label')
+      return label?.textContent?.includes('Include Non-Geographic Categories')
+    }) as HTMLInputElement
+
     const categorySortSelect = Array.from(canvasElement.querySelectorAll('select') || []).find(select => {
       const label = select.closest('label')
       const labelSpan = label?.querySelector('.edit-label')
       return labelSpan?.textContent?.includes('Category Sort')
     }) as HTMLSelectElement
+
+    expect(includeNonGeoCategoriesCheckbox).toBeTruthy()
+
+    await performAndAssert(
+      'Include Non-Geographic Categories → Toggle on',
+      () => ({
+        checked: includeNonGeoCategoriesCheckbox.checked
+      }),
+      async () => {
+        await userEvent.click(includeNonGeoCategoriesCheckbox)
+      },
+      (_before, after) => after.checked === true
+    )
 
     const getCategorySortControls = () => ({
       mode: categorySortSelect?.value,

--- a/packages/map/src/_stories/CdcMap.Editor.LegendSectionTests.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Editor.LegendSectionTests.stories.tsx
@@ -2,8 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { within, userEvent, expect } from 'storybook/test'
 import CdcMap from '../CdcMap'
 import usaStateGradientConfig from './_mock/usa-state-gradient.json'
-import multiCountryConfig from './_mock/multi-country.json'
-import wastewaterMapSmallMultiplesConfig from './_mock/small_multiples/wastewater-map-small-multiples.json'
+import wastewaterMapConfig from './_mock/wastewater-map.json'
 import { performAndAssert, waitForEditor, waitForPresence, openAccordion } from '@cdc/core/helpers/testing'
 
 type Story = StoryObj<typeof CdcMap>
@@ -21,6 +20,17 @@ export default mapMeta
 const DEFAULT_ARGS = {
   isEditor: true,
   config: usaStateGradientConfig
+}
+
+const CATEGORY_SORT_ARGS = {
+  isEditor: true,
+  config: {
+    ...wastewaterMapConfig,
+    legend: {
+      ...wastewaterMapConfig.legend,
+      categoryValuesOrder: []
+    }
+  }
 }
 
 export const LegendSectionTests: Story = {
@@ -548,6 +558,57 @@ export const LegendSectionTests: Story = {
           after.descriptionText.includes('This is a custom legend description') &&
           after.legendHTML !== before.legendHTML
         )
+      }
+    )
+  }
+}
+
+export const CategorySortTests: Story = {
+  args: {
+    ...CATEGORY_SORT_ARGS
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await waitForEditor(canvas)
+    await waitForPresence('.map-container', canvasElement)
+
+    await openAccordion(canvas, 'Legend')
+
+    const categorySortSelect = Array.from(canvasElement.querySelectorAll('select') || []).find(select => {
+      const label = select.closest('label')
+      const labelSpan = label?.querySelector('.edit-label')
+      return labelSpan?.textContent?.includes('Category Sort')
+    }) as HTMLSelectElement
+
+    const getCategorySortControls = () => ({
+      mode: categorySortSelect?.value,
+      hasDragList: Boolean(canvasElement.querySelector('.sort-list')),
+      dragItems: Array.from(canvasElement.querySelectorAll('.sort-list li') || []).map(item => item.textContent?.trim())
+    })
+
+    expect(getCategorySortControls().mode).toBe('automatic')
+    expect(getCategorySortControls().hasDragList).toBe(false)
+
+    await performAndAssert(
+      'Category Sort → Custom sort',
+      getCategorySortControls,
+      async () => {
+        await userEvent.selectOptions(categorySortSelect, 'custom')
+      },
+      (_before, after) => {
+        return after.mode === 'custom' && after.hasDragList && after.dragItems.length > 0
+      }
+    )
+
+    await performAndAssert(
+      'Category Sort → Automatic sort',
+      getCategorySortControls,
+      async () => {
+        await userEvent.selectOptions(categorySortSelect, 'automatic')
+      },
+      (_before, after) => {
+        return after.mode === 'automatic' && !after.hasDragList
       }
     )
   }

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -106,6 +106,8 @@ type CategoryListProps = {
   categoryValuesOrder: any[]
 }
 
+type CategorySortMode = 'automatic' | 'custom'
+
 const ColumnSection = ({ fieldKey, fieldName, show, setShow, children }: ColumnSectionProps) => {
   if (!show) {
     return (
@@ -1253,16 +1255,16 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
 
   let numberOfItemsLimit = 8
 
-  const getCategoryValuesOrder = (): string[] | [] => {
+  const getCategoryValuesOrder = (): any[] => {
     let values =
       runtimeLegend?.items?.length > 0
         ? runtimeLegend.items.filter(item => !item.special).map(runtimeLegendItem => runtimeLegendItem.value)
         : []
 
-    if (config.legend.cateogryValuesOrder) {
+    if (config.legend.categoryValuesOrder?.length) {
       return values.sort((a, b) => {
-        let aVal = config.legend.cateogryValuesOrder.indexOf(a)
-        let bVal = config.legend.cateogryValuesOrder.indexOf(b)
+        let aVal = config.legend.categoryValuesOrder.indexOf(a)
+        let bVal = config.legend.categoryValuesOrder.indexOf(b)
         if (aVal === bVal) return 0
         if (aVal === -1) return 1
         if (bVal === -1) return -1
@@ -1271,6 +1273,18 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
     } else {
       return values
     }
+  }
+
+  const categorySortMode: CategorySortMode = config.legend.categoryValuesOrder?.length ? 'custom' : 'automatic'
+
+  const setCategorySortMode = (mode: CategorySortMode) => {
+    setConfig({
+      ...config,
+      legend: {
+        ...config.legend,
+        categoryValuesOrder: mode === 'custom' ? getCategoryValuesOrder() : []
+      }
+    })
   }
 
   const isLoadedFromUrl =
@@ -2994,32 +3008,65 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                       )}
                       {'category' === legend.type && (
                         <React.Fragment>
-                          <label>
-                            <span className='edit-label'>
-                              Category Order
-                              <Tooltip style={{ textTransform: 'none' }}>
-                                <Tooltip.Target>
-                                  <Icon display='question' style={{ marginLeft: '0.5rem' }} />
-                                </Tooltip.Target>
-                                <Tooltip.Content>
-                                  <p>Drag map categories into preferred legend order. </p>
-                                </Tooltip.Content>
-                              </Tooltip>
-                            </span>
-                          </label>
-                          {/* TODO: Swap out this drag and drop library back to something simpler. I had to remove the old one because it hadn't been updated and wouldn't work with Webpack 5. This is overkill for our needs. */}
-                          <DragDropContext
-                            onDragEnd={({ source, destination }) => categoryMove(source.index, destination.index)}
-                          >
-                            <Droppable droppableId='category_order'>
-                              {provided => (
-                                <ul {...provided.droppableProps} className='sort-list' ref={provided.innerRef}>
-                                  <CategoryList categoryValuesOrder={getCategoryValuesOrder()} />
-                                  {provided.placeholder}
-                                </ul>
-                              )}
-                            </Droppable>
-                          </DragDropContext>
+                          <Select
+                            label={
+                              <>
+                                Category Sort
+                                <Tooltip style={{ textTransform: 'none' }}>
+                                  <Tooltip.Target>
+                                    <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                                  </Tooltip.Target>
+                                  <Tooltip.Content>
+                                    <p>
+                                      Automatic sort places numeric values and ranges first, ordered by their numeric
+                                      bounds. Non-numeric categories appear after those in data order. If the legend
+                                      does not contain numbers, categories stay in data order.
+                                    </p>
+                                  </Tooltip.Content>
+                                </Tooltip>
+                              </>
+                            }
+                            fieldName='categorySortMode'
+                            value={categorySortMode}
+                            options={[
+                              { label: 'Automatic sort', value: 'automatic' },
+                              { label: 'Custom sort', value: 'custom' }
+                            ]}
+                            onChange={event => setCategorySortMode(event.target.value as CategorySortMode)}
+                          />
+                          {categorySortMode === 'custom' && (
+                            <React.Fragment>
+                              <label>
+                                <span className='edit-label'>
+                                  Category Order
+                                  <Tooltip style={{ textTransform: 'none' }}>
+                                    <Tooltip.Target>
+                                      <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                                    </Tooltip.Target>
+                                    <Tooltip.Content>
+                                      <p>Drag map categories into preferred legend order. </p>
+                                    </Tooltip.Content>
+                                  </Tooltip>
+                                </span>
+                              </label>
+                              {/* TODO: Swap out this drag and drop library back to something simpler. I had to remove the old one because it hadn't been updated and wouldn't work with Webpack 5. This is overkill for our needs. */}
+                              <DragDropContext
+                                onDragEnd={({ source, destination }) => {
+                                  if (!destination) return
+                                  categoryMove(source.index, destination.index)
+                                }}
+                              >
+                                <Droppable droppableId='category_order'>
+                                  {provided => (
+                                    <ul {...provided.droppableProps} className='sort-list' ref={provided.innerRef}>
+                                      <CategoryList categoryValuesOrder={getCategoryValuesOrder()} />
+                                      {provided.placeholder}
+                                    </ul>
+                                  )}
+                                </Droppable>
+                              </DragDropContext>
+                            </React.Fragment>
+                          )}
                           {runtimeLegend && runtimeLegend.length >= 10 && (
                             <section className='error-box my-2'>
                               <div>

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -3008,6 +3008,27 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                       )}
                       {'category' === legend.type && (
                         <React.Fragment>
+                          <CheckBox
+                            value={Boolean(legend.includeNonGeoDataInDomain)}
+                            section='legend'
+                            subsection={null}
+                            fieldName='includeNonGeoDataInDomain'
+                            label='Include Non-Geographic Categories'
+                            updateField={updateField}
+                            tooltip={
+                              <Tooltip style={{ textTransform: 'none' }}>
+                                <Tooltip.Target>
+                                  <Icon display='question' style={{ marginLeft: '0.5rem' }} />
+                                </Tooltip.Target>
+                                <Tooltip.Content>
+                                  <p>
+                                    Adds category values from rows that are not associated with a map geography to the
+                                    legend. These rows do not appear on the map or in the map data table.
+                                  </p>
+                                </Tooltip.Content>
+                              </Tooltip>
+                            }
+                          />
                           <Select
                             label={
                               <>

--- a/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.test.ts
+++ b/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.test.ts
@@ -24,4 +24,26 @@ describe('sortGroupedLegendItems', () => {
       '0'
     ])
   })
+
+  it('places values missing from custom order after explicitly ordered values', () => {
+    const items = ['Unknown', '0', '1 - 14'].map(buildItem)
+
+    expect(sortGroupedLegendItems(items, ['1 - 14', '0']).map(item => item.label)).toEqual([
+      '1 - 14',
+      '0',
+      'Unknown'
+    ])
+  })
+
+  it('uses rawLabel for custom ordering when display labels differ', () => {
+    const items = [
+      { ...buildItem('0'), rawLabel: 'Zero' },
+      { ...buildItem('1 - 14'), rawLabel: 'One to Fourteen' }
+    ]
+
+    expect(sortGroupedLegendItems(items, ['One to Fourteen', 'Zero']).map(item => item.label)).toEqual([
+      '1 - 14',
+      '0'
+    ])
+  })
 })

--- a/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.test.ts
+++ b/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { sortGroupedLegendItems } from './Legend.Group'
+
+const buildItem = (label: string) => ({
+  color: '#000',
+  label,
+  rawLabel: label,
+  special: false
+})
+
+describe('sortGroupedLegendItems', () => {
+  it('uses automatic numeric category ordering when no custom order is configured', () => {
+    const items = ['15 - 29', 'Unknown', '0', '1 - 14'].map(buildItem)
+
+    expect(sortGroupedLegendItems(items).map(item => item.label)).toEqual(['0', '1 - 14', '15 - 29', 'Unknown'])
+  })
+
+  it('preserves custom category order when configured', () => {
+    const items = ['0', '1 - 14', '15 - 29'].map(buildItem)
+
+    expect(sortGroupedLegendItems(items, ['15 - 29', '1 - 14', '0']).map(item => item.label)).toEqual([
+      '15 - 29',
+      '1 - 14',
+      '0'
+    ])
+  })
+})

--- a/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.tsx
+++ b/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.tsx
@@ -28,7 +28,7 @@ export const sortGroupedLegendItems = (items: LegendItem[], categoryValuesOrder:
     })
   }
 
-  return sortAutomaticCategoryValues(items, { getValue: item => item.rawLabel ?? item.label })
+  return sortAutomaticCategoryValues(items, item => item.rawLabel ?? item.label)
 }
 
 const LegendGroup = ({ legendItems }) => {

--- a/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.tsx
+++ b/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.tsx
@@ -4,16 +4,28 @@ import LegendShape from '@cdc/core/components/LegendShape'
 import { toggleLegendActive } from '../../../../helpers/toggleLegendActive'
 import ErrorBoundary from '@cdc/core/components/ErrorBoundary'
 import ConfigContext, { MapDispatchContext } from '../../../../context'
+import { sortAutomaticCategoryValues } from '../../../../helpers/categorySortHelpers'
 
 interface LegendItem {
   color: string
   label: string
+  rawLabel?: string
   disabled?: boolean
   special: boolean
 }
 
 interface GroupedData {
   [key: string]: LegendItem[]
+}
+
+export const sortGroupedLegendItems = (items: LegendItem[], categoryValuesOrder: unknown[] = []) => {
+  if (categoryValuesOrder.length) {
+    return [...items].sort(
+      (a, b) => categoryValuesOrder.indexOf(a.label) - categoryValuesOrder.indexOf(b.label)
+    )
+  }
+
+  return sortAutomaticCategoryValues(items, { getValue: item => item.rawLabel ?? item.label })
 }
 
 const LegendGroup = ({ legendItems }) => {
@@ -41,11 +53,7 @@ const LegendGroup = ({ legendItems }) => {
 
     // Sort items in each group
     Object.entries(result).forEach(([group, items]) => {
-      result[group] = [...items].sort(
-        (a, b) =>
-          (config.legend.categoryValuesOrder ?? []).indexOf(a.label) -
-          (config.legend.categoryValuesOrder ?? []).indexOf(b.label)
-      )
+      result[group] = sortGroupedLegendItems(items, config.legend.categoryValuesOrder ?? [])
     })
 
     return result
@@ -89,7 +97,7 @@ const LegendGroup = ({ legendItems }) => {
 
   const groupedData = useMemo(
     () => groupLegendItems(legendItems, config.data, config.legend.groupBy),
-    [legendItems, config.data, config.legend.groupBy]
+    [legendItems, config.data, config.legend.groupBy, config.legend.categoryValuesOrder, config.columns.primary.name]
   )
 
   const hasDisabledItems = runtimeLegend.items.some(item => item.disabled)

--- a/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.tsx
+++ b/packages/map/src/components/Legend/components/LegendGroup/Legend.Group.tsx
@@ -4,7 +4,10 @@ import LegendShape from '@cdc/core/components/LegendShape'
 import { toggleLegendActive } from '../../../../helpers/toggleLegendActive'
 import ErrorBoundary from '@cdc/core/components/ErrorBoundary'
 import ConfigContext, { MapDispatchContext } from '../../../../context'
-import { sortAutomaticCategoryValues } from '../../../../helpers/categorySortHelpers'
+import {
+  sortAutomaticCategoryValues,
+  sortByConfiguredCategoryOrder
+} from '../../../../helpers/categorySortHelpers'
 
 interface LegendItem {
   color: string
@@ -20,9 +23,9 @@ interface GroupedData {
 
 export const sortGroupedLegendItems = (items: LegendItem[], categoryValuesOrder: unknown[] = []) => {
   if (categoryValuesOrder.length) {
-    return [...items].sort(
-      (a, b) => categoryValuesOrder.indexOf(a.label) - categoryValuesOrder.indexOf(b.label)
-    )
+    return sortByConfiguredCategoryOrder(items, categoryValuesOrder, {
+      getValue: item => item.rawLabel ?? item.label
+    })
   }
 
   return sortAutomaticCategoryValues(items, { getValue: item => item.rawLabel ?? item.label })

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -87,7 +87,8 @@ const createInitialState = () => {
       tickRotation: '',
       singleColumnLegend: false,
       hideBorder: true,
-      groupBy: ''
+      groupBy: '',
+      includeNonGeoDataInDomain: false
     },
     filters: [],
     data: [],

--- a/packages/map/src/helpers/categorySortHelpers.ts
+++ b/packages/map/src/helpers/categorySortHelpers.ts
@@ -1,0 +1,120 @@
+type CategoryNumericSortKey = {
+  lower: number
+  upper: number
+}
+
+type SortAutomaticCategoryValuesOptions<T> = {
+  getValue?: (item: T) => unknown
+  isSpecial?: (item: T) => boolean
+}
+
+const numericPattern = String.raw`[+-]?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?`
+const exactNumberPattern = new RegExp(`^\\s*(${numericPattern})\\s*$`)
+const boundedRangePattern = new RegExp(`^\\s*(${numericPattern})\\s*(?:-|to)\\s*(${numericPattern})\\s*$`, 'i')
+const greaterThanPattern = new RegExp(`^\\s*>\\s*(${numericPattern})\\s*$`)
+const lessThanPattern = new RegExp(`^\\s*<\\s*(${numericPattern})\\s*$`)
+const plusRangePattern = new RegExp(`^\\s*(${numericPattern})\\s*\\+\\s*$`)
+
+const parseCategoryNumber = (value: string): number => Number(value.replace(/,/g, ''))
+
+const isValidSortKey = ({ lower, upper }: CategoryNumericSortKey): boolean =>
+  Number.isFinite(lower) && (Number.isFinite(upper) || upper === Number.POSITIVE_INFINITY) && lower <= upper
+
+export const getCategoryNumericSortKey = (value: unknown): CategoryNumericSortKey | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? { lower: value, upper: value } : null
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const boundedRangeMatch = value.match(boundedRangePattern)
+  if (boundedRangeMatch) {
+    const sortKey = {
+      lower: parseCategoryNumber(boundedRangeMatch[1]),
+      upper: parseCategoryNumber(boundedRangeMatch[2])
+    }
+
+    return isValidSortKey(sortKey) ? sortKey : null
+  }
+
+  const greaterThanMatch = value.match(greaterThanPattern)
+  if (greaterThanMatch) {
+    const sortKey = {
+      lower: parseCategoryNumber(greaterThanMatch[1]),
+      upper: Number.POSITIVE_INFINITY
+    }
+
+    return isValidSortKey(sortKey) ? sortKey : null
+  }
+
+  const lessThanMatch = value.match(lessThanPattern)
+  if (lessThanMatch) {
+    const upper = parseCategoryNumber(lessThanMatch[1])
+    const sortKey = {
+      lower: 0,
+      upper
+    }
+
+    return isValidSortKey(sortKey) ? sortKey : null
+  }
+
+  const plusRangeMatch = value.match(plusRangePattern)
+  if (plusRangeMatch) {
+    const sortKey = {
+      lower: parseCategoryNumber(plusRangeMatch[1]),
+      upper: Number.POSITIVE_INFINITY
+    }
+
+    return isValidSortKey(sortKey) ? sortKey : null
+  }
+
+  const exactNumberMatch = value.match(exactNumberPattern)
+  if (exactNumberMatch) {
+    const number = parseCategoryNumber(exactNumberMatch[1])
+    const sortKey = { lower: number, upper: number }
+
+    return isValidSortKey(sortKey) ? sortKey : null
+  }
+
+  return null
+}
+
+export const sortAutomaticCategoryValues = <T>(
+  values: T[],
+  { getValue = value => value, isSpecial = () => false }: SortAutomaticCategoryValuesOptions<T> = {}
+): T[] => {
+  const parsedValues = values.map((value, index) => {
+    const special = isSpecial(value)
+
+    return {
+      value,
+      index,
+      parsed: special ? null : getCategoryNumericSortKey(getValue(value)),
+      special
+    }
+  })
+
+  const sortableValues = parsedValues.filter(item => !item.special && item.parsed)
+  const nonSortableValues = parsedValues.filter(item => !item.special && !item.parsed)
+  const specialCategoryValues = parsedValues.filter(item => item.special)
+
+  if (!sortableValues.length) {
+    return values
+  }
+
+  const sortedNumericValues = sortableValues.sort((a, b) => {
+    if (a.parsed!.lower !== b.parsed!.lower) {
+      return a.parsed!.lower - b.parsed!.lower
+    }
+
+    if (a.parsed!.upper !== b.parsed!.upper) {
+      return a.parsed!.upper - b.parsed!.upper
+    }
+
+    return a.index - b.index
+  })
+
+  return [...sortedNumericValues, ...nonSortableValues, ...specialCategoryValues].map(item => item.value)
+}

--- a/packages/map/src/helpers/categorySortHelpers.ts
+++ b/packages/map/src/helpers/categorySortHelpers.ts
@@ -8,6 +8,10 @@ type SortAutomaticCategoryValuesOptions<T> = {
   isSpecial?: (item: T) => boolean
 }
 
+type SortByConfiguredCategoryOrderOptions<T> = {
+  getValue?: (item: T) => unknown
+}
+
 const numericPattern = String.raw`[+-]?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?`
 const exactNumberPattern = new RegExp(`^\\s*(${numericPattern})\\s*$`)
 const boundedRangePattern = new RegExp(`^\\s*(${numericPattern})\\s*(?:-|to)\\s*(${numericPattern})\\s*$`, 'i')
@@ -117,4 +121,26 @@ export const sortAutomaticCategoryValues = <T>(
   })
 
   return [...sortedNumericValues, ...nonSortableValues, ...specialCategoryValues].map(item => item.value)
+}
+
+export const sortByConfiguredCategoryOrder = <T>(
+  values: T[],
+  configuredOrder: unknown[] = [],
+  { getValue = value => value }: SortByConfiguredCategoryOrderOptions<T> = {}
+): T[] => {
+  if (!configuredOrder.length) {
+    return values
+  }
+
+  return [...values].sort((a, b) => {
+    const aValue = getValue(a)
+    const bValue = getValue(b)
+    const aIdx = configuredOrder.indexOf(aValue)
+    const bIdx = configuredOrder.indexOf(bValue)
+
+    if (aIdx === bIdx) return 0
+    if (aIdx === -1) return 1
+    if (bIdx === -1) return -1
+    return aIdx - bIdx
+  })
 }

--- a/packages/map/src/helpers/categorySortHelpers.ts
+++ b/packages/map/src/helpers/categorySortHelpers.ts
@@ -3,10 +3,6 @@ type CategoryNumericSortKey = {
   upper: number
 }
 
-type SortAutomaticCategoryValuesOptions<T> = {
-  getValue?: (item: T) => unknown
-  isSpecial?: (item: T) => boolean
-}
 
 type SortByConfiguredCategoryOrderOptions<T> = {
   getValue?: (item: T) => unknown
@@ -87,22 +83,16 @@ export const getCategoryNumericSortKey = (value: unknown): CategoryNumericSortKe
 
 export const sortAutomaticCategoryValues = <T>(
   values: T[],
-  { getValue = value => value, isSpecial = () => false }: SortAutomaticCategoryValuesOptions<T> = {}
+  getValue: (item: T) => unknown = value => value
 ): T[] => {
-  const parsedValues = values.map((value, index) => {
-    const special = isSpecial(value)
+  const parsedValues = values.map((value, index) => ({
+    value,
+    index,
+    parsed: getCategoryNumericSortKey(getValue(value))
+  }))
 
-    return {
-      value,
-      index,
-      parsed: special ? null : getCategoryNumericSortKey(getValue(value)),
-      special
-    }
-  })
-
-  const sortableValues = parsedValues.filter(item => !item.special && item.parsed)
-  const nonSortableValues = parsedValues.filter(item => !item.special && !item.parsed)
-  const specialCategoryValues = parsedValues.filter(item => item.special)
+  const sortableValues = parsedValues.filter(item => item.parsed)
+  const nonSortableValues = parsedValues.filter(item => !item.parsed)
 
   if (!sortableValues.length) {
     return values
@@ -120,7 +110,7 @@ export const sortAutomaticCategoryValues = <T>(
     return a.index - b.index
   })
 
-  return [...sortedNumericValues, ...nonSortableValues, ...specialCategoryValues].map(item => item.value)
+  return [...sortedNumericValues, ...nonSortableValues].map(item => item.value)
 }
 
 export const sortByConfiguredCategoryOrder = <T>(

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -7,6 +7,7 @@ import { indexOfIgnoreType } from './indexOfIgnoreType'
 import { setBinNumbers } from './setBinNumbers'
 import { sortSpecialClassesLast } from './sortSpecialClassesLast'
 import { hashObj } from '@cdc/core/helpers/hashObj'
+import { filterVizData } from '@cdc/core/helpers/filterVizData'
 import { normalizeBreakpoints } from './breakpointHelpers'
 import { sortAutomaticCategoryValues } from './categorySortHelpers'
 
@@ -62,6 +63,10 @@ export const generateRuntimeLegend = (
     const { legend, columns, general } = configObj
     const primaryColName = columns.primary.name
     const geoColName = columns.geo.name
+    const isBubble = general.type === 'bubble'
+    const categoricalCol = columns.categorical ? columns.categorical.name : undefined
+    const getCategoryValue = (row: DataRow) =>
+      isBubble && categoricalCol && row[categoricalCol] ? row[categoricalCol] : row[primaryColName]
 
     // filter out rows without a geo column
     addUIDs(configObj, geoColName)
@@ -136,18 +141,28 @@ export const generateRuntimeLegend = (
     if (legend.type === 'category') {
       let uniqueValues = new Map()
       let count = 0
-
-      for (let i = 0; i < dataSet.length; i++) {
-        let row = dataSet[i]
-        let value = row[primaryColName]
-        if (undefined === value) continue
+      const addCategoryValue = (row: DataRow, includeMemo = true) => {
+        let value = getCategoryValue(row)
+        if (undefined === value) return
 
         if (false === uniqueValues.has(value)) {
-          uniqueValues.set(value, [hashObj(row)])
+          uniqueValues.set(value, includeMemo ? [hashObj(row)] : [])
           count++
-        } else {
+        } else if (includeMemo) {
           uniqueValues.get(value).push(hashObj(row))
         }
+      }
+
+      for (let i = 0; i < dataSet.length; i++) {
+        addCategoryValue(dataSet[i])
+      }
+
+      if (legend.includeNonGeoDataInDomain) {
+        const noUidRows = configObj.data.filter(row => !row.uid)
+        const domainOnlyRows =
+          legend.unified || !Array.isArray(runtimeFilters) ? noUidRows : filterVizData(runtimeFilters, noUidRows)
+
+        domainOnlyRows.forEach(row => addCategoryValue(row, false))
       }
 
       let sorted = [...uniqueValues.keys()]

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -183,7 +183,7 @@ export const generateRuntimeLegend = (
       if (configuredOrder.length) {
         sorted = sortByConfiguredCategoryOrder(sorted, configuredOrder)
       } else {
-        sorted = sortAutomaticCategoryValues(sorted, { isSpecial: value => specialValues.has(String(value)) })
+        sorted = sortAutomaticCategoryValues(sorted)
       }
 
       // Add legend item for each

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -8,6 +8,7 @@ import { setBinNumbers } from './setBinNumbers'
 import { sortSpecialClassesLast } from './sortSpecialClassesLast'
 import { hashObj } from '@cdc/core/helpers/hashObj'
 import { normalizeBreakpoints } from './breakpointHelpers'
+import { sortAutomaticCategoryValues } from './categorySortHelpers'
 
 import uniq from 'lodash/uniq'
 import * as d3 from 'd3'
@@ -150,6 +151,7 @@ export const generateRuntimeLegend = (
       }
 
       let sorted = [...uniqueValues.keys()]
+      const specialValues = new Set(result.items.filter(item => item.special).map(item => String(item.value)))
 
       if (legend.additionalCategories) {
         legend.additionalCategories.forEach(additionalCategory => {
@@ -172,7 +174,7 @@ export const generateRuntimeLegend = (
           return aVal - bVal
         })
       } else {
-        sorted.sort((a, b) => a - b)
+        sorted = sortAutomaticCategoryValues(sorted, { isSpecial: value => specialValues.has(String(value)) })
       }
 
       // Add legend item for each

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -9,7 +9,7 @@ import { sortSpecialClassesLast } from './sortSpecialClassesLast'
 import { hashObj } from '@cdc/core/helpers/hashObj'
 import { filterVizData } from '@cdc/core/helpers/filterVizData'
 import { normalizeBreakpoints } from './breakpointHelpers'
-import { sortAutomaticCategoryValues } from './categorySortHelpers'
+import { sortAutomaticCategoryValues, sortByConfiguredCategoryOrder } from './categorySortHelpers'
 
 import uniq from 'lodash/uniq'
 import * as d3 from 'd3'
@@ -180,14 +180,7 @@ export const generateRuntimeLegend = (
       let configuredOrder = legend.categoryValuesOrder ?? []
 
       if (configuredOrder.length) {
-        sorted.sort((a, b) => {
-          let aVal = configuredOrder.indexOf(a)
-          let bVal = configuredOrder.indexOf(b)
-          if (aVal === bVal) return 0
-          if (aVal === -1) return 1
-          if (bVal === -1) return -1
-          return aVal - bVal
-        })
+        sorted = sortByConfiguredCategoryOrder(sorted, configuredOrder)
       } else {
         sorted = sortAutomaticCategoryValues(sorted, { isSpecial: value => specialValues.has(String(value)) })
       }

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -141,9 +141,11 @@ export const generateRuntimeLegend = (
     if (legend.type === 'category') {
       let uniqueValues = new Map()
       let count = 0
+      const specialValues = new Set(result.items.filter(item => item.special).map(item => String(item.value)))
       const addCategoryValue = (row: DataRow, includeMemo = true) => {
         let value = getCategoryValue(row)
         if (undefined === value) return
+        if (specialValues.has(String(value))) return
 
         if (false === uniqueValues.has(value)) {
           uniqueValues.set(value, includeMemo ? [hashObj(row)] : [])
@@ -166,7 +168,6 @@ export const generateRuntimeLegend = (
       }
 
       let sorted = [...uniqueValues.keys()]
-      const specialValues = new Set(result.items.filter(item => item.special).map(item => String(item.value)))
 
       if (legend.additionalCategories) {
         legend.additionalCategories.forEach(additionalCategory => {

--- a/packages/map/src/helpers/generateRuntimeLegendHash.ts
+++ b/packages/map/src/helpers/generateRuntimeLegendHash.ts
@@ -16,6 +16,7 @@ export const generateRuntimeLegendHash = (config: MapConfig, runtimeFilters) => 
     primary: config.columns.primary.name,
     bubbleLayers: config.bubble?.layers,
     categoryValuesOrder: config.legend.categoryValuesOrder,
+    additionalCategories: config.legend.additionalCategories,
     specialClasses: config.legend.specialClasses,
     geoType: config.general.geoType,
     data: config.data,

--- a/packages/map/src/helpers/generateRuntimeLegendHash.ts
+++ b/packages/map/src/helpers/generateRuntimeLegendHash.ts
@@ -17,6 +17,7 @@ export const generateRuntimeLegendHash = (config: MapConfig, runtimeFilters) => 
     bubbleLayers: config.bubble?.layers,
     categoryValuesOrder: config.legend.categoryValuesOrder,
     additionalCategories: config.legend.additionalCategories,
+    includeNonGeoDataInDomain: config.legend.includeNonGeoDataInDomain ?? false,
     specialClasses: config.legend.specialClasses,
     geoType: config.general.geoType,
     data: config.data,

--- a/packages/map/src/helpers/tests/categorySortHelpers.test.ts
+++ b/packages/map/src/helpers/tests/categorySortHelpers.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { getCategoryNumericSortKey } from '../categorySortHelpers'
+
+describe('getCategoryNumericSortKey', () => {
+  it('parses supported automatic category range formats', () => {
+    expect(getCategoryNumericSortKey('1 to 4')).toEqual({ lower: 1, upper: 4 })
+    expect(getCategoryNumericSortKey('>10')).toEqual({ lower: 10, upper: Number.POSITIVE_INFINITY })
+    expect(getCategoryNumericSortKey('<10')).toEqual({ lower: 0, upper: 10 })
+    expect(getCategoryNumericSortKey('30+')).toEqual({ lower: 30, upper: Number.POSITIVE_INFINITY })
+  })
+
+  it('does not treat descending numeric strings as valid ranges', () => {
+    expect(getCategoryNumericSortKey('2024-01')).toBeNull()
+  })
+})

--- a/packages/map/src/helpers/tests/categorySortHelpers.test.ts
+++ b/packages/map/src/helpers/tests/categorySortHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getCategoryNumericSortKey } from '../categorySortHelpers'
+import { getCategoryNumericSortKey, sortByConfiguredCategoryOrder } from '../categorySortHelpers'
 
 describe('getCategoryNumericSortKey', () => {
   it('parses supported automatic category range formats', () => {
@@ -11,5 +11,26 @@ describe('getCategoryNumericSortKey', () => {
 
   it('does not treat descending numeric strings as valid ranges', () => {
     expect(getCategoryNumericSortKey('2024-01')).toBeNull()
+  })
+})
+
+describe('sortByConfiguredCategoryOrder', () => {
+  it('sorts known values by configured order and places unknown values last', () => {
+    const values = ['Unknown', '0', '1 - 14']
+
+    expect(sortByConfiguredCategoryOrder(values, ['1 - 14', '0'])).toEqual(['1 - 14', '0', 'Unknown'])
+  })
+
+  it('supports custom value extraction for object arrays', () => {
+    const values = [
+      { label: '0', rawLabel: 'Zero' },
+      { label: '1 - 14', rawLabel: 'One to Fourteen' }
+    ]
+
+    expect(
+      sortByConfiguredCategoryOrder(values, ['One to Fourteen', 'Zero'], {
+        getValue: item => item.rawLabel ?? item.label
+      }).map(item => item.label)
+    ).toEqual(['1 - 14', '0'])
   })
 })

--- a/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
+++ b/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
@@ -101,7 +101,38 @@ const buildConfig = () => {
   return config
 }
 
-describe('generateRuntimeLegend — manual breakpoints', () => {
+const buildCategoryConfig = (values: Array<string | number>) => {
+  const config = buildConfig()
+
+  config.legend.type = 'category'
+  config.legend.categoryValuesOrder = []
+  config.legend.additionalCategories = []
+  config.data = values.map((value, index) => ({
+    state: ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware'][index],
+    value
+  }))
+
+  return config
+}
+
+const getCategoryLegendValues = config => {
+  const legendMemo = { current: new Map<string, number>() }
+  const legendSpecialClassLastMemo = { current: new Map<string, number>() }
+
+  const runtimeLegend = generateRuntimeLegend(
+    config,
+    config.data,
+    'category-legend',
+    () => undefined,
+    { fromHash: 7 } as any,
+    legendMemo,
+    legendSpecialClassLastMemo
+  )
+
+  return runtimeLegend.items.map(item => item.value)
+}
+
+describe('generateRuntimeLegend', () => {
   it('builds manual breakpoint bins from authored legend breakpoints', () => {
     const config = buildConfig()
     const legendMemo = { current: new Map<string, number>() }
@@ -139,5 +170,51 @@ describe('generateRuntimeLegend — manual breakpoints', () => {
     config.legend.breakpoints = [10, 30, 50, 70]
 
     expect(generateRuntimeLegendHash(config, {})).not.toBe(baselineHash)
+  })
+
+  it('automatically orders numeric and range category values', () => {
+    const config = buildCategoryConfig(['1,000 - 1,999', '1.5', '1 - 14', '0', '1,000.5', '15-29', '1,000'])
+
+    expect(getCategoryLegendValues(config)).toEqual([
+      '0',
+      '1 - 14',
+      '1.5',
+      '15-29',
+      '1,000',
+      '1,000 - 1,999',
+      '1,000.5'
+    ])
+  })
+
+  it('keeps automatic category ordering stable for numeric ties', () => {
+    const config = buildCategoryConfig(['1.0', '1', '1 - 1', '2'])
+
+    expect(getCategoryLegendValues(config)).toEqual(['1.0', '1', '1 - 1', '2'])
+  })
+
+  it('automatically orders numeric categories before non-numeric categories', () => {
+    const config = buildCategoryConfig(['15 - 29', 'Unknown', '0', 'N/A', '1 - 14'])
+
+    expect(getCategoryLegendValues(config)).toEqual(['0', '1 - 14', '15 - 29', 'Unknown', 'N/A'])
+  })
+
+  it('automatically orders common open-ended and to-range category values', () => {
+    const config = buildCategoryConfig(['30+', '10 to 19', '<10', '20 to 29', '0', '>40'])
+
+    expect(getCategoryLegendValues(config)).toEqual(['0', '<10', '10 to 19', '20 to 29', '30+', '>40'])
+  })
+
+  it('uses populated categoryValuesOrder instead of automatic category ordering', () => {
+    const config = buildCategoryConfig(['0', '1 - 14', '15 - 29'])
+    config.legend.categoryValuesOrder = ['15 - 29', '1 - 14', '0']
+
+    expect(getCategoryLegendValues(config)).toEqual(['15 - 29', '1 - 14', '0'])
+  })
+
+  it('includes additionalCategories in automatic category ordering after adding them to the domain', () => {
+    const config = buildCategoryConfig(['15 - 29', '0'])
+    config.legend.additionalCategories = ['1 - 14', '30 - 44']
+
+    expect(getCategoryLegendValues(config)).toEqual(['0', '1 - 14', '15 - 29', '30 - 44'])
   })
 })

--- a/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
+++ b/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { hashObj } from '@cdc/core/helpers/hashObj'
 import initialState from '../../data/initial-state'
+import { addUIDs } from '../addUIDs'
+import generateRuntimeData from '../generateRuntimeData'
 import { generateRuntimeLegend } from '../generateRuntimeLegend'
 import { generateRuntimeLegendHash } from '../generateRuntimeLegendHash'
 
@@ -116,20 +120,36 @@ const buildCategoryConfig = (values: Array<string | number>) => {
 }
 
 const getCategoryLegendValues = config => {
+  const { runtimeLegend } = getRuntimeLegend(config, config.data)
+
+  return runtimeLegend.items.map(item => item.value)
+}
+
+const getRuntimeLegend = (
+  config,
+  runtimeData = config.data,
+  runtimeFilters = Object.assign([], { fromHash: 7 }) as any
+) => {
   const legendMemo = { current: new Map<string, number>() }
   const legendSpecialClassLastMemo = { current: new Map<string, number>() }
 
   const runtimeLegend = generateRuntimeLegend(
     config,
-    config.data,
+    runtimeData,
     'category-legend',
     () => undefined,
-    { fromHash: 7 } as any,
+    runtimeFilters,
     legendMemo,
     legendSpecialClassLastMemo
   )
 
-  return runtimeLegend.items.map(item => item.value)
+  return { runtimeLegend, legendMemo, legendSpecialClassLastMemo }
+}
+
+const buildRuntimeDataFromUidRows = config => {
+  addUIDs(config, config.columns.geo.name)
+
+  return Object.fromEntries(config.data.filter(row => row.uid).map(row => [row.uid, row]))
 }
 
 describe('generateRuntimeLegend', () => {
@@ -216,5 +236,92 @@ describe('generateRuntimeLegend', () => {
     config.legend.additionalCategories = ['1 - 14', '30 - 44']
 
     expect(getCategoryLegendValues(config)).toEqual(['0', '1 - 14', '15 - 29', '30 - 44'])
+  })
+
+  it('excludes no-UID rows from category domains by default', () => {
+    const config = buildCategoryConfig(['0'])
+    config.data.push({ state: 'Bin 1', value: '1 - 14' })
+
+    const runtimeData = buildRuntimeDataFromUidRows(config)
+    const { runtimeLegend } = getRuntimeLegend(config, runtimeData)
+
+    expect(runtimeLegend.items.map(item => item.value)).toEqual(['0'])
+  })
+
+  it('includes no-UID category values in the domain when opted in', () => {
+    const config = buildCategoryConfig(['0'])
+    config.legend.includeNonGeoDataInDomain = true
+    config.data.push({ state: 'Bin 1', value: '1 - 14' })
+
+    const runtimeData = buildRuntimeDataFromUidRows(config)
+    const { runtimeLegend } = getRuntimeLegend(config, runtimeData)
+
+    expect(runtimeLegend.items.map(item => item.value)).toEqual(['0', '1 - 14'])
+  })
+
+  it('does not create legendMemo mappings for included no-UID category values', () => {
+    const config = buildCategoryConfig(['0'])
+    config.legend.includeNonGeoDataInDomain = true
+    const domainOnlyRow = { state: 'Bin 1', value: '1 - 14' }
+    config.data.push(domainOnlyRow)
+
+    const runtimeData = buildRuntimeDataFromUidRows(config)
+    const { legendMemo } = getRuntimeLegend(config, runtimeData)
+
+    expect(legendMemo.current.size).toBe(1)
+    expect(legendMemo.current.has(hashObj(domainOnlyRow))).toBe(false)
+  })
+
+  it('does not apply includeNonGeoDataInDomain to non-category legends', () => {
+    const config = buildConfig()
+    config.legend.includeNonGeoDataInDomain = true
+    config.data = [
+      { state: 'Alabama', value: 5 },
+      { state: 'Bin 1', value: 999 }
+    ]
+
+    const runtimeData = buildRuntimeDataFromUidRows(config)
+    const { runtimeLegend, legendMemo } = getRuntimeLegend(config, runtimeData)
+
+    expect(JSON.stringify(runtimeLegend.items)).not.toContain('999')
+    expect(legendMemo.current.size).toBe(1)
+  })
+
+  it('includes CRIDD synthetic bin rows in the category legend without adding them to runtime data', () => {
+    const criddRows = JSON.parse(
+      readFileSync(
+        `${process.cwd()}/../dashboard/examples/private/cridd/__data__/state_maps/campylobacter_state_map.json`,
+        'utf8'
+      )
+    )
+    const config = buildConfig()
+    config.columns.geo.name = 'geography'
+    config.columns.primary.name = 'bin'
+    config.legend.type = 'category'
+    config.legend.unified = true
+    config.legend.includeNonGeoDataInDomain = true
+    config.legend.categoryValuesOrder = []
+    config.legend.specialClasses = [{ key: 'bin', value: 'N/A', label: 'N/A' }]
+    config.data = criddRows
+    const runtimeFilters = [
+      {
+        columnName: 'year_dropdown_label',
+        active: '2025 (provisional data to date)',
+        values: [],
+        filterStyle: 'dropdown'
+      }
+    ] as any
+
+    const runtimeData = generateRuntimeData(config, runtimeFilters, 99, true, false)
+    const { runtimeLegend } = getRuntimeLegend(config, runtimeData, runtimeFilters)
+
+    expect(runtimeLegend.items.map(item => item.value)).toEqual([
+      '0',
+      '1 - 2,999',
+      '3,000 - 5,999',
+      '6,000 - 8,999',
+      '9,000 - 12,000'
+    ])
+    expect(Object.values(runtimeData).some(row => String(row.geography).startsWith('Bin'))).toBe(false)
   })
 })

--- a/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
+++ b/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest'
-import { readFileSync } from 'node:fs'
 import { hashObj } from '@cdc/core/helpers/hashObj'
 import initialState from '../../data/initial-state'
 import { addUIDs } from '../addUIDs'
@@ -288,12 +287,14 @@ describe('generateRuntimeLegend', () => {
   })
 
   it('includes CRIDD synthetic bin rows in the category legend without adding them to runtime data', () => {
-    const criddRows = JSON.parse(
-      readFileSync(
-        `${process.cwd()}/../dashboard/examples/private/cridd/__data__/state_maps/campylobacter_state_map.json`,
-        'utf8'
-      )
-    )
+    const criddRows = [
+      { geography: 'Alabama', bin: '0', year_dropdown_label: '2025 (provisional data to date)' },
+      { geography: 'Alaska', bin: '1 - 2,999', year_dropdown_label: '2025 (provisional data to date)' },
+      { geography: 'Arizona', bin: '3,000 - 5,999', year_dropdown_label: '2025 (provisional data to date)' },
+      { geography: 'Arkansas', bin: '6,000 - 8,999', year_dropdown_label: '2025 (provisional data to date)' },
+      { geography: 'California', bin: '9,000 - 12,000', year_dropdown_label: '2025 (provisional data to date)' },
+      { geography: 'Bin 1', bin: '1 - 2,999', year_dropdown_label: '2025 (provisional data to date)' }
+    ]
     const config = buildConfig()
     config.columns.geo.name = 'geography'
     config.columns.primary.name = 'bin'

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -246,6 +246,7 @@ export type MapConfig = Visualization & {
     additionalCategories
     breakpoints?: number[]
     categoryValuesOrder
+    includeNonGeoDataInDomain?: boolean
     description
     descriptions: {}
     specialClasses: { key; label; value }[]


### PR DESCRIPTION
## Summary

This PR has two new features:
* DEV-13410: Adds an option to include non-geographic data in a map legend
* DEV-13409: Improves the automatic numeric sorting of map legends

## Testing Steps

Open [map-legend-non-geo-numeric-sort.json](https://github.com/user-attachments/files/29712438/map-legend-non-geo-numeric-sort.json). On the `dev` branch, there will be only two legend items and they will be out of order, on this branch there will be five items in order.
