### PR TITLE
Enhancement [DEV-13413] Add categorical bubble sizing

### DIFF
--- a/docs/BUBBLE_LAYERS.md
+++ b/docs/BUBBLE_LAYERS.md
@@ -31,6 +31,8 @@ The canonical shape is `config.bubble.layers[]`. Each layer is a `BubbleLayer` (
 ```ts
 type BubbleLayer = {
   locationSource?: 'data-column' | 'latitude-longitude'
+  sizeType?: 'numeric' | 'category'
+  sizeCategoryValuesOrder?: string[]
   minBubbleSize: number
   maxBubbleSize: number
   extraBubbleBorder: boolean
@@ -69,6 +71,10 @@ The top-level fields (`bubble.migratedToBubbleAccordion`, `bubble.columns`, etc.
 
 `bubble.layers[].palette` controls category colors when `columns.primary.name` is set. When the layer has no coloring field and uses only `columns.size.name`, the same palette selector controls the fixed bubble fill color.
 
+`bubble.layers[].sizeType` defaults to `'numeric'`. In numeric mode, bubble radius uses `columns.size.name` when present and falls back to `columns.primary.name`. In categorical mode, `columns.size.name` is interpreted as a category field, blank/null category values are skipped, and categories are mapped evenly across `minBubbleSize` to `maxBubbleSize`. The exact category value `"0"` follows `showBubbleZeros`.
+
+`bubble.layers[].sizeCategoryValuesOrder` controls categorical size order. `[]` means automatic sort using `sortAutomaticCategoryValues` from `categorySortHelpers.ts`; a populated array means custom sort using `sortByConfiguredCategoryOrder`. The same ordered category list drives both rendered bubble radii and `BubbleSizeLegend`.
+
 ---
 
 ## Location Sources
@@ -90,6 +96,7 @@ Coordinate bubbles are assigned a synthetic UID (`coordinate-bubble-{rowIndex}-{
 |---|---|
 | `packages/map/src/types/MapConfig.ts` | `BubbleLayer` and `BubbleConfig` type definitions |
 | `packages/map/src/helpers/bubbleLayers.ts` | All utility functions for reading and normalizing bubble config |
+| `packages/map/src/helpers/bubbleSize.ts` | Shared numeric/categorical bubble-size ordering and scaling helpers |
 | `packages/map/src/helpers/generateRuntimeData.ts` | UID assignment, filtering, numeric conversion, and layer-scoped runtime data for bubble columns |
 | `packages/map/src/hooks/useLegendMemo.ts` | Per-layer legend memo refs |
 | `packages/map/src/context/LegendMemoContext.tsx` | Carries bubble legend memos through context |
@@ -132,7 +139,7 @@ On each data change, `generateRuntimeData` processes every row:
 
 - For geo-column layers, `addUIDs` assigns the normal geography UID (state abbreviation, FIPS code, ISO country code, etc.).
 - For coordinate layers, rows with valid lat/lng values receive a synthetic `coordinate-bubble-{rowIndex}-{label}` UID via `setRowUID` (which uses `Object.defineProperty` so the property is non-enumerable and does not appear in JSON serialization).
-- Each bubble layer's `primary`, `size`, `latitude`, and `longitude` columns are coerced from strings to numbers when they are not the same column as the top-level choropleth primary.
+- Each bubble layer's `primary`, numeric `size`, `latitude`, and `longitude` columns are coerced from strings to numbers when they are not the same column as the top-level choropleth primary. Categorical size columns are not coerced.
 
 ### 2. Legend generation (`CdcMapComponent.tsx`)
 
@@ -149,6 +156,7 @@ Per-layer legend memos are stored in `useLegendMemo` as arrays of `MutableRefObj
 `BubbleList` iterates `getConfiguredBubbleLayers(config)`. For each layer:
 
 - `generateBubbleLayerRuntimeData` creates filtered rows for that layer so each layer can use its own geography column or coordinate columns.
+- Numeric size layers scale finite numeric values linearly. Categorical size layers build an ordered unique category list with `getOrderedBubbleSizeCategories` and map category indexes evenly across the configured min/max radius range.
 - If `locationSource === 'data-column'`, the bubble is positioned at the geography centroid for the matched row UID.
 - If `locationSource === 'latitude-longitude'`, the bubble reads lat/lng from the row and projects them directly.
 - Blank coordinate values are treated as missing, not as `0`.
@@ -159,7 +167,7 @@ Per-layer legend memos are stored in `useLegendMemo` as arrays of `MutableRefObj
 After the choropleth legend block (guarded by `hasMapLegend`), the legend component iterates `bubbleLayers` and renders per-layer:
 
 - `BubbleLayerLegend` — color or category legend items drawn from `runtimeBubbleLegend[layerIndex]`.
-- `BubbleSizeLegend` — proportional circles for up to 3 representative data values from the layer-scoped filtered rows, computed via `d3-scale.scaleLinear` against the visible data range. Only shown when `layer.legend.size.show === true`.
+- `BubbleSizeLegend` — proportional circles for up to 3 representative numeric data values, or all categorical size labels in the configured category order. Only shown when `layer.legend.size.show === true`.
 
 ### 5. Data table (`dataTableHelpers.ts` → `prepareBubbleMapDataTable`)
 

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -154,20 +154,22 @@ Bubble layer settings live under `bubble.layers`. Bubble layers are supported on
 
 | Field | Type | Required | Default | Description | Allowed values / Notes |
 | --- | --- | --- | --- | --- | --- |
-| `bubble.layers` | `array` | No | One empty layer in editor defaults | Ordered bubble overlay layers. | Remove a layer to hide it. Only layers with a primary column and the configured location source columns render. |
+| `bubble.layers` | `array` | No | One empty layer in editor defaults | Ordered bubble overlay layers. | Remove a layer to hide it. Only layers with a primary or size column and the configured location source columns render. |
 | `bubble.layers[].locationSource` | `string` | No | `data-column` | Chooses how the layer positions bubbles. | `data-column`, `latitude-longitude`. The editor labels these as "Use data column" and "Use lat/long". |
 | `bubble.layers[].columns.geo.name` | `string` | Conditionally | `''` | Geography lookup or label column for bubbles. | Required when `locationSource` is `data-column`. When `locationSource` is `latitude-longitude`, this column labels tooltips and table output but does not position bubbles. |
 | `bubble.layers[].columns.geo.label` | `string` | No | Inherits `columns.geo.label` | Tooltip label for the bubble geography/label column. | Used when `bubble.layers[].columns.geo.tooltip` is `true`. |
 | `bubble.layers[].columns.geo.tooltip` | `boolean` | No | Inherits `columns.geo.tooltip` | Includes the bubble geography/label column in bubble tooltips. | `true`, `false` |
 | `bubble.layers[].columns.latitude.name` | `string` | Conditionally | `''` | Latitude column used to position bubbles directly from row coordinates. | Required with `bubble.layers[].columns.longitude.name` when `locationSource` is `latitude-longitude`. Ignored for bubble positioning when `locationSource` is `data-column`. |
 | `bubble.layers[].columns.longitude.name` | `string` | Conditionally | `''` | Longitude column used to position bubbles directly from row coordinates. | Required with `bubble.layers[].columns.latitude.name` when `locationSource` is `latitude-longitude`. Ignored for bubble positioning when `locationSource` is `data-column`. |
-| `bubble.layers[].columns.primary.name` | `string` | Yes per rendered layer | `''` | Data column used to color/classify bubbles. | Also drives bubble sizing when `bubble.layers[].columns.size.name` is omitted. |
+| `bubble.layers[].columns.primary.name` | `string` | No | `''` | Data column used to color/classify bubbles. | Also drives numeric bubble sizing when `bubble.layers[].columns.size.name` is omitted. A layer can render with only `bubble.layers[].columns.size.name`. |
 | `bubble.layers[].columns.primary.label` | `string` | No | Inherits `columns.primary.label` | Tooltip label for the bubble data column. | Used when `bubble.layers[].columns.primary.tooltip` is `true`. |
 | `bubble.layers[].columns.primary.tooltip` | `boolean` | No | Inherits `columns.primary.tooltip` | Includes the bubble data column in bubble tooltips. | `true`, `false` |
-| `bubble.layers[].columns.size.name` | `string` | No | Same as layer primary column | Data column used for bubble radius. | Use when bubble size should differ from bubble color/category. |
+| `bubble.layers[].columns.size.name` | `string` | No | Same as layer primary column for numeric sizing | Data column used for bubble radius. | When `bubble.layers[].sizeType` is `category`, this column is interpreted as categorical labels instead of numbers. Blank/null category values do not render bubbles. |
 | `bubble.layers[].columns.size.label` | `string` | No | Size column name | Tooltip label for the bubble size column. | Used when `bubble.layers[].columns.size.tooltip` is `true`. |
 | `bubble.layers[].columns.size.tooltip` | `boolean` | No | `false` | Includes the bubble size column in bubble tooltips. | Only meaningful when `bubble.layers[].columns.size.name` is set. |
 | `bubble.layers[].columns.categorical.name` | `string` | No | None | Category column used when the layer legend type is `category`. | Only meaningful for categorical bubble legends. |
+| `bubble.layers[].sizeType` | `string` | No | `numeric` | Chooses how `bubble.layers[].columns.size.name` is interpreted. | `numeric`, `category`. Missing values preserve existing numeric behavior. The editor shows this only after a size column is selected. |
+| `bubble.layers[].sizeCategoryValuesOrder` | `array` | No | `[]` | Custom category order for categorical bubble sizing. | Empty array means automatic sort. A populated array pins listed categories first, with any new/unlisted values appended after them. The same order controls rendered bubble radii and the bubble-size legend. |
 | `bubble.layers[].minBubbleSize` | `number` | No | `10` | Minimum bubble radius. | Pixel radius used by the runtime scale. |
 | `bubble.layers[].maxBubbleSize` | `number` | No | `30` | Maximum bubble radius. | Pixel radius used by the runtime scale. |
 | `bubble.layers[].extraBubbleBorder` | `boolean` | No | `false` | Adds an extra white border ring around bubbles. | `true`, `false` |
@@ -183,6 +185,8 @@ Bubble layer settings live under `bubble.layers`. Bubble layers are supported on
 | `bubble.layers[].legend.size.show` | `boolean` | No | `false` | Shows a separate bubble-size legend with representative circle sizes. | Uses the layer size column when set, otherwise the layer primary column. |
 | `bubble.layers[].legend.size.title` | `string` | No | Layer size column name | Heading shown above the bubble-size legend. | Empty string hides the heading. Supports markup-variable processing when enabled. |
 | `bubble.layers[].legend.size.description` | `string` | No | `''` | Description shown below the bubble-size legend title. | Supports markup-variable processing when enabled. |
+
+Categorical bubble sizing maps ordered categories evenly across `minBubbleSize` to `maxBubbleSize`. Automatic sort places numeric values and ranges first by numeric bounds, then leaves non-numeric categories in data order. The exact category value `"0"` follows `bubble.layers[].showBubbleZeros`: it renders when zero bubbles are enabled and is hidden otherwise.
 
 ### `map.layers`
 

--- a/packages/map/src/_stories/CdcMap.BubbleLegend.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.BubbleLegend.stories.tsx
@@ -71,6 +71,28 @@ export const Bubble_Size_Legend_Custom_Text: Story = {
   }
 }
 
+export const Bubble_Size_Legend_Categorical: Story = {
+  args: {
+    config: editConfigKeys(worldBubbleDiseaseType, [
+      { path: ['bubble', 'layers', 0, 'sizeType'], value: 'category' },
+      { path: ['bubble', 'layers', 0, 'columns', 'size', 'name'], value: 'diseaseType' },
+      { path: ['bubble', 'layers', 0, 'sizeCategoryValuesOrder'], value: ['Measles', 'COVID-19', 'Influenza'] },
+      { path: ['bubble', 'layers', 0, 'legend', 'size', 'show'], value: true },
+      { path: ['bubble', 'layers', 0, 'legend', 'size', 'title'], value: 'Disease size category' }
+    ]),
+    isEditor: true
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+    await waitForPresence('circle.bubble', canvasElement)
+    const sizeLegend = await waitForPresence('ul[aria-label="Bubble size legend items"]', canvasElement)
+    const labels = Array.from(sizeLegend.querySelectorAll('li')).map(item => item.textContent?.trim())
+
+    expect(canvasElement).toHaveTextContent('Disease size category')
+    expect(labels).toEqual(['Measles', 'COVID-19', 'Influenza'])
+  }
+}
+
 export const Bubble_Size_Legend_Hidden_By_Default: Story = {
   args: {
     config: worldBubbleDiseaseType,
@@ -244,7 +266,57 @@ export const Bubble_Layer_Field_Groups: Story = {
     expect(newLayerColoringField.selectedOptions[0]?.textContent).toBe('- None -')
     expect(newLayerSizeColumn.value).toBe('')
     expect(newLayerSizeColumn.selectedOptions[0]?.textContent).toBe('- None -')
+    expect(newLayerDataItem).not.toHaveTextContent('Bubble Size Type')
     expect(newLayerMinBubbleSize.value).toBe('10')
     expect(newLayerMaxBubbleSize.value).toBe('30')
+  }
+}
+
+export const Bubble_Layer_Categorical_Size_Editor: Story = {
+  args: {
+    config: editConfigKeys(usBubble, [{ path: ['version'], value: '4.26.7' }]),
+    isEditor: true
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await assertVisualizationRendered(canvasElement)
+    await waitForEditor(canvas)
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Bubble Layers' }))
+    const bubbleLayersButton = canvas.getByRole('button', { name: 'Bubble Layers' })
+    const bubbleLayersItem = bubbleLayersButton.closest('[data-accordion-component="AccordionItem"], .accordion__item')
+    const layerButton = Array.from(bubbleLayersItem?.querySelectorAll('.accordion__button') ?? []).find(
+      button => button.textContent?.trim() === 'Layer 1: Cases'
+    ) as HTMLElement | undefined
+
+    await userEvent.click(layerButton as HTMLElement)
+    const layerItem = layerButton?.closest('[data-accordion-component="AccordionItem"], .accordion__item')
+    const dataButton = Array.from(layerItem?.querySelectorAll('.accordion__button') ?? []).find(
+      button => button.textContent?.trim() === 'Data'
+    ) as HTMLElement | undefined
+
+    await userEvent.click(dataButton as HTMLElement)
+    const dataItem = dataButton?.closest('[data-accordion-component="AccordionItem"], .accordion__item')
+    const dataCanvas = within(dataItem as HTMLElement)
+
+    expect(dataItem).not.toHaveTextContent('Bubble Size Type')
+    await userEvent.selectOptions(dataCanvas.getByLabelText('Size Column'), 'Category')
+    expect(dataCanvas.getByLabelText('Bubble Size Type')).toBeInTheDocument()
+    expect(dataItem).toHaveTextContent('This size column contains non-numeric values')
+    expect(dataItem).not.toHaveTextContent('Bubble Size Sort')
+    expect(dataItem).not.toHaveTextContent('Category Order')
+
+    await userEvent.selectOptions(dataCanvas.getByLabelText('Bubble Size Type'), 'category')
+    const sizeSort = dataCanvas.getByLabelText('Bubble Size Sort') as HTMLSelectElement
+    expect(sizeSort.value).toBe('automatic')
+    expect(dataItem).not.toHaveTextContent('This size column contains non-numeric values')
+    expect(dataItem).not.toHaveTextContent('Category Order')
+
+    await userEvent.selectOptions(sizeSort, 'custom')
+    expect(dataItem).toHaveTextContent('Category Order')
+
+    await userEvent.selectOptions(sizeSort, 'automatic')
+    expect(dataItem).not.toHaveTextContent('Category Order')
   }
 }

--- a/packages/map/src/components/BubbleList.tsx
+++ b/packages/map/src/components/BubbleList.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react'
-import { scaleLinear } from 'd3-scale'
 import { countryCoordinates } from '../data/country-coordinates'
 import stateCoordinates from '../data/state-coordinates'
 import ConfigContext, { MapDispatchContext } from '../context'
@@ -21,6 +20,14 @@ import {
   isBubbleLayerUsingCoordinates,
   mapConfigForBubbleLayer
 } from '../helpers/bubbleLayers'
+import {
+  createCategoricalBubbleSizeScale,
+  createNumericBubbleSizeScale,
+  getBubbleSizeCategoryValue,
+  getNumericBubbleSizeValues,
+  getOrderedBubbleSizeCategories,
+  isCategoricalBubbleSize
+} from '../helpers/bubbleSize'
 import { generateBubbleLayerRuntimeData } from '../helpers/generateRuntimeData'
 import type { BubbleLayer } from '../types/MapConfig'
 
@@ -278,7 +285,6 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
       return null
     }
 
-    const hasBubblesWithZeroOnMap = showBubbleZeros ? 0 : 1
     const layerRuntimeData = generateBubbleLayerRuntimeData(
       config,
       layer,
@@ -290,11 +296,22 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
       geoType === 'world' && filteredCountryCode && !useExplicitCoordinateColumns
         ? layerDataRows.filter(row => row.uid === filteredCountryCode)
         : layerDataRows
-    const finiteSizeValues = visibleLayerDataRows
-      .map(d => getFiniteBubbleNumber(d[sizeColumnName]))
-      .filter((value): value is number => value !== null)
-    const maxDataValue = Math.max(...finiteSizeValues, hasBubblesWithZeroOnMap)
-    const size = scaleLinear().domain([hasBubblesWithZeroOnMap, maxDataValue]).range([minBubbleSize, maxBubbleSize])
+    const usesCategoricalSize = isCategoricalBubbleSize(layer)
+    const orderedSizeCategories = usesCategoricalSize
+      ? getOrderedBubbleSizeCategories(
+          visibleLayerDataRows,
+          sizeColumnName,
+          layer.sizeCategoryValuesOrder ?? [],
+          showBubbleZeros
+        )
+      : []
+    const categoricalSize = createCategoricalBubbleSizeScale(orderedSizeCategories, minBubbleSize, maxBubbleSize)
+    const numericSize = createNumericBubbleSizeScale(
+      getNumericBubbleSizeValues(visibleLayerDataRows, sizeColumnName, true),
+      minBubbleSize,
+      maxBubbleSize,
+      showBubbleZeros
+    )
     const layerLegend = bubbleLegends[layerIndex]
     const hasLayerLegend = !Array.isArray(layerLegend) && Boolean(layerLegend?.items?.length)
     const effectiveLegend = hasLayerLegend ? layerLegend : runtimeLegend
@@ -304,8 +321,15 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
       : legendSpecialClassLastMemo
     const bubbleLayerConfig = mapConfigForBubbleLayer(config, layer)
     const legendConfig = hasLayerLegend ? bubbleLayerConfig : config
+    const getBubbleRadius = (value: unknown): number | null => {
+      if (usesCategoricalSize) return categoricalSize(value)
+      const numericSizeValue = getFiniteBubbleNumber(value)
+      if (numericSizeValue === null) return null
+      if (Math.floor(numericSizeValue) === 0 && !showBubbleZeros) return null
+      return Number(numericSize(numericSizeValue))
+    }
     const sortedRuntimeData: DataRow[] = visibleLayerDataRows.sort((a: DataRow, b: DataRow) =>
-      (getFiniteBubbleNumber(a[sizeColumnName]) ?? 0) < (getFiniteBubbleNumber(b[sizeColumnName]) ?? 0) ? 1 : -1
+      (getBubbleRadius(a[sizeColumnName]) ?? 0) < (getBubbleRadius(b[sizeColumnName]) ?? 0) ? 1 : -1
     )
 
     if (!sortedRuntimeData) return null
@@ -313,9 +337,13 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
     if (geoType !== 'world' && geoType !== 'us') return null
 
     return sortedRuntimeData.map((dataRow, index) => {
-      const numericSizeValue = getFiniteBubbleNumber(dataRow[sizeColumnName])
-      if (numericSizeValue === null) return null
-      if ((Math.floor(numericSizeValue) === 0 || dataRow[sizeColumnName] === '') && !showBubbleZeros) return null
+      const sizeValue = dataRow[sizeColumnName]
+      const categorySizeValue = usesCategoricalSize ? getBubbleSizeCategoryValue(sizeValue) : null
+      if (usesCategoricalSize && (categorySizeValue === null || (categorySizeValue === '0' && !showBubbleZeros))) {
+        return null
+      }
+      const radius = getBubbleRadius(sizeValue)
+      if (radius === null) return null
 
       const location = getBubbleLocation(
         dataRow,
@@ -359,7 +387,7 @@ const BubbleList: React.FC<BubbleListProps> = ({ customProjection }) => {
           geoClickHandler(location.displayName, location.clickData)
         },
         onPointerDown: handleBubblePointerDown,
-        radius: Number(size(numericSizeValue)),
+        radius,
         tooltipHtml: toolTip,
         tooltipId
       })

--- a/packages/map/src/components/EditorPanel/components/BubbleLayerFields.tsx
+++ b/packages/map/src/components/EditorPanel/components/BubbleLayerFields.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
 import { mapColorPalettes as colorPalettes } from '@cdc/core/data/colorPalettes'
 import { CheckBox, Select, TextField } from '@cdc/core/components/EditorPanel/Inputs'
 import { PaletteSelector } from '@cdc/core/components/PaletteSelector'
-import { DEFAULT_MAX_BUBBLE_SIZE, DEFAULT_MIN_BUBBLE_SIZE } from '../../../helpers/bubbleLayers'
+import { DEFAULT_MAX_BUBBLE_SIZE, DEFAULT_MIN_BUBBLE_SIZE, getFiniteBubbleNumber } from '../../../helpers/bubbleLayers'
+import { getOrderedBubbleSizeCategories } from '../../../helpers/bubbleSize'
 import type { BubbleLayer, MapConfig } from '../../../types/MapConfig'
 
 type PaletteSection = {
@@ -22,6 +24,29 @@ type BubbleLayerFieldsProps = {
 }
 
 type BubbleTooltipColumnKey = 'geo' | 'primary' | 'size'
+type BubbleSizeSortMode = 'automatic' | 'custom'
+
+const BubbleSizeCategoryList = ({ values }: { values: string[] }) => (
+  <>
+    {values.map((value, valueIndex) => (
+      <Draggable key={value} draggableId={`bubble-size-category-${value}`} index={valueIndex}>
+        {(provided, snapshot) => (
+          <li style={{ position: 'relative' }}>
+            <div
+              className={snapshot.isDragging ? 'currently-dragging' : ''}
+              style={provided.draggableProps.style}
+              ref={provided.innerRef}
+              {...provided.draggableProps}
+              {...provided.dragHandleProps}
+            >
+              {value}
+            </div>
+          </li>
+        )}
+      </Draggable>
+    ))}
+  </>
+)
 
 const BubbleLayerFields = ({
   columnNames,
@@ -36,6 +61,44 @@ const BubbleLayerFields = ({
   const getPaletteClassName = (p: string) => (layer.palette?.name === p ? 'selected' : '')
   const locationSource = layer.locationSource ?? 'data-column'
   const usesLatLong = locationSource === 'latitude-longitude'
+  const sizeColumnName = layer.columns.size?.name ?? ''
+  const sizeType = layer.sizeType ?? 'numeric'
+  const bubbleSizeSortMode: BubbleSizeSortMode = layer.sizeCategoryValuesOrder?.length ? 'custom' : 'automatic'
+  const hasNonNumericSizeValues =
+    Boolean(sizeColumnName) &&
+    sizeType === 'numeric' &&
+    (config.data ?? []).some(row => {
+      const value = row[sizeColumnName]
+      if (value === null || value === undefined || String(value).trim() === '') return false
+      return getFiniteBubbleNumber(value) === null
+    })
+  const getBubbleSizeCategoryValuesOrder = () =>
+    getOrderedBubbleSizeCategories(
+      config.data ?? [],
+      sizeColumnName,
+      layer.sizeCategoryValuesOrder ?? [],
+      layer.showBubbleZeros
+    )
+
+  const setBubbleSizeSortMode = (mode: BubbleSizeSortMode) => {
+    updateBubbleLayer(index, draft => {
+      draft.sizeCategoryValuesOrder =
+        mode === 'custom'
+          ? getOrderedBubbleSizeCategories(config.data ?? [], sizeColumnName, [], draft.showBubbleZeros)
+          : []
+    })
+  }
+
+  const moveBubbleSizeCategory = (sourceIndex: number, destinationIndex?: number) => {
+    if (destinationIndex === undefined || sourceIndex === destinationIndex) return
+
+    updateBubbleLayer(index, draft => {
+      const categoryValuesOrder = getBubbleSizeCategoryValuesOrder()
+      const [movedItem] = categoryValuesOrder.splice(sourceIndex, 1)
+      categoryValuesOrder.splice(destinationIndex, 0, movedItem)
+      draft.sizeCategoryValuesOrder = categoryValuesOrder
+    })
+  }
 
   const updateLayerColumn = (
     columnKey: BubbleTooltipColumnKey,
@@ -170,10 +233,81 @@ const BubbleLayerFields = ({
                 draft.columns.size = { ...(draft.columns.size ?? {}), name: e.target.value }
               } else {
                 delete draft.columns.size
+                draft.sizeType = 'numeric'
+                draft.sizeCategoryValuesOrder = []
               }
             })
           }}
         />
+        {sizeColumnName && (
+          <Select
+            label='Bubble Size Type'
+            section='bubble'
+            subsection={`layer-${index}`}
+            fieldName='sizeType'
+            value={sizeType}
+            options={[
+              { label: 'Numeric', value: 'numeric' },
+              { label: 'Categorical', value: 'category' }
+            ]}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+              updateBubbleLayer(index, draft => {
+                draft.sizeType = e.target.value as BubbleLayer['sizeType']
+                if (draft.sizeType === 'numeric') {
+                  draft.sizeCategoryValuesOrder = []
+                }
+              })
+            }}
+          />
+        )}
+        {hasNonNumericSizeValues && (
+          <section className='error-box my-2' role='alert'>
+            <div>
+              <strong className='pt-1'>Warning</strong>
+              <p>
+                This size column contains non-numeric values. Switch Bubble Size Type to Categorical to use these values
+                for sizing.
+              </p>
+            </div>
+          </section>
+        )}
+        {sizeColumnName && sizeType === 'category' && (
+          <>
+            <Select
+              label='Bubble Size Sort'
+              section='bubble'
+              subsection={`layer-${index}`}
+              fieldName='sizeCategorySortMode'
+              value={bubbleSizeSortMode}
+              options={[
+                { label: 'Automatic sort', value: 'automatic' },
+                { label: 'Custom sort', value: 'custom' }
+              ]}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                setBubbleSizeSortMode(e.target.value as BubbleSizeSortMode)
+              }
+            />
+            {bubbleSizeSortMode === 'custom' && (
+              <React.Fragment>
+                <label>
+                  <span className='edit-label'>Category Order</span>
+                </label>
+                <DragDropContext
+                  onDragEnd={({ source, destination }) => moveBubbleSizeCategory(source.index, destination?.index)}
+                >
+                  <Droppable droppableId={`bubble_size_category_order_${index}`}>
+                    {provided => (
+                      <ul {...provided.droppableProps} className='sort-list' ref={provided.innerRef}>
+                        <BubbleSizeCategoryList values={getBubbleSizeCategoryValuesOrder()} />
+                        {provided.placeholder}
+                      </ul>
+                    )}
+                  </Droppable>
+                </DragDropContext>
+              </React.Fragment>
+            )}
+          </>
+        )}
         {renderTooltipControls('size', 'Size', Boolean(layer.columns.size?.name))}
         <TextField
           type='number'

--- a/packages/map/src/components/Legend/components/BubbleSizeLegend.tsx
+++ b/packages/map/src/components/Legend/components/BubbleSizeLegend.tsx
@@ -6,7 +6,7 @@ const BUBBLE_SIZE_LEGEND_COLOR = '#000000'
 export type BubbleSizeLegendItem = {
   label: string
   radius: number
-  value: number
+  value: number | string
 }
 
 type BubbleSizeLegendProps = {

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -1,6 +1,5 @@
 //TODO: Move legends to core
 import { Fragment, forwardRef, useContext, useMemo } from 'react'
-import { scaleLinear } from 'd3-scale'
 import parse from 'html-react-parser'
 import { processMarkupVariables } from '@cdc/core/helpers/markupProcessor'
 import { sanitizeToSvgId } from '@cdc/core/helpers/cove/string'
@@ -30,6 +29,13 @@ import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
 import { getConfiguredBubbleLayers, getFiniteBubbleNumber } from '../../../helpers/bubbleLayers'
 import { generateBubbleLayerRuntimeData } from '../../../helpers/generateRuntimeData'
+import {
+  createCategoricalBubbleSizeScale,
+  createNumericBubbleSizeScale,
+  getNumericBubbleSizeValues,
+  getOrderedBubbleSizeCategories,
+  isCategoricalBubbleSize
+} from '../../../helpers/bubbleSize'
 import BubbleLayerLegend from './BubbleLayerLegend'
 import BubbleSizeLegend from './BubbleSizeLegend'
 
@@ -305,10 +311,26 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
         runtimeFilters?.fromHash ?? 0
       )
       const layerDataRows = Object.values(layerRuntimeData ?? {}) as Record<string, any>[]
+      if (isCategoricalBubbleSize(layer)) {
+        const orderedCategories = getOrderedBubbleSizeCategories(
+          layerDataRows,
+          bubbleSizeColumnName,
+          layer.sizeCategoryValuesOrder ?? [],
+          showBubbleZeros
+        )
+        const bubbleScale = createCategoricalBubbleSizeScale(orderedCategories, minBubbleSize, maxBubbleSize)
+
+        return orderedCategories.map(value => ({
+          value,
+          radius: Number(bubbleScale(value) ?? minBubbleSize),
+          label: value
+        }))
+      }
+
       const finiteValues = layerDataRows
         .map(row => getFiniteBubbleNumber(row[bubbleSizeColumnName]))
         .filter((value): value is number => value !== null && value >= 0)
-      const visibleValues = showBubbleZeros ? finiteValues : finiteValues.filter(value => value > 0)
+      const visibleValues = getNumericBubbleSizeValues(layerDataRows, bubbleSizeColumnName, showBubbleZeros)
 
       if (!visibleValues.length) return []
 
@@ -325,12 +347,7 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
         return samples
       }, [])
 
-      const domainMin = showBubbleZeros ? 0 : 1
-      const domainMax = Math.max(...finiteValues, domainMin)
-      const bubbleScale =
-        domainMax === domainMin
-          ? () => minBubbleSize
-          : scaleLinear().domain([domainMin, domainMax]).range([minBubbleSize, maxBubbleSize])
+      const bubbleScale = createNumericBubbleSizeScale(finiteValues, minBubbleSize, maxBubbleSize, showBubbleZeros)
       const numberFormatter = new Intl.NumberFormat(config.locale, { maximumFractionDigits: 2 })
 
       return sampleValues.map(value => ({

--- a/packages/map/src/helpers/bubbleLayers.ts
+++ b/packages/map/src/helpers/bubbleLayers.ts
@@ -42,6 +42,8 @@ export const createDefaultBubbleLayer = (overrides: BubbleLayerOverrides = {}): 
 
   return {
     locationSource: 'data-column',
+    sizeType: 'numeric',
+    sizeCategoryValuesOrder: [],
     minBubbleSize: DEFAULT_MIN_BUBBLE_SIZE,
     maxBubbleSize: DEFAULT_MAX_BUBBLE_SIZE,
     extraBubbleBorder: false,

--- a/packages/map/src/helpers/bubbleSize.ts
+++ b/packages/map/src/helpers/bubbleSize.ts
@@ -40,12 +40,14 @@ export const createCategoricalBubbleSizeScale = (
   maxBubbleSize: number
 ) => {
   const categoryCount = categories.length
+  const categoryIndexByValue = new Map(categories.map((category, index) => [category, index]))
+
   return (value: unknown): number | null => {
     const categoryValue = getBubbleSizeCategoryValue(value)
     if (categoryValue === null) return null
 
-    const categoryIndex = categories.indexOf(categoryValue)
-    if (categoryIndex === -1) return null
+    const categoryIndex = categoryIndexByValue.get(categoryValue)
+    if (categoryIndex === undefined) return null
     if (categoryCount <= 1) return minBubbleSize
 
     return minBubbleSize + ((maxBubbleSize - minBubbleSize) * categoryIndex) / (categoryCount - 1)

--- a/packages/map/src/helpers/bubbleSize.ts
+++ b/packages/map/src/helpers/bubbleSize.ts
@@ -1,0 +1,79 @@
+import { scaleLinear } from 'd3-scale'
+import type { BubbleLayer, DataRow } from '../types/MapConfig'
+import { sortAutomaticCategoryValues, sortByConfiguredCategoryOrder } from './categorySortHelpers'
+import { getFiniteBubbleNumber } from './bubbleLayers'
+
+export const getBubbleSizeType = (layer?: BubbleLayer): NonNullable<BubbleLayer['sizeType']> =>
+  layer?.sizeType ?? 'numeric'
+
+export const isCategoricalBubbleSize = (layer?: BubbleLayer): boolean => getBubbleSizeType(layer) === 'category'
+
+export const getBubbleSizeCategoryValue = (value: unknown): string | null => {
+  if (value === null || value === undefined) return null
+  const stringValue = String(value)
+  return stringValue.trim() === '' ? null : stringValue
+}
+
+export const getOrderedBubbleSizeCategories = (
+  rows: DataRow[],
+  sizeColumnName: string,
+  sizeCategoryValuesOrder: string[] = [],
+  showBubbleZeros = false
+): string[] => {
+  const values = rows.reduce<string[]>((categoryValues, row) => {
+    const value = getBubbleSizeCategoryValue(row[sizeColumnName])
+    if (value === null) return categoryValues
+    if (value === '0' && !showBubbleZeros) return categoryValues
+    if (!categoryValues.includes(value)) categoryValues.push(value)
+    return categoryValues
+  }, [])
+
+  const automaticallySortedValues = sortAutomaticCategoryValues(values)
+  return sizeCategoryValuesOrder.length
+    ? sortByConfiguredCategoryOrder(automaticallySortedValues, sizeCategoryValuesOrder)
+    : automaticallySortedValues
+}
+
+export const createCategoricalBubbleSizeScale = (
+  categories: string[],
+  minBubbleSize: number,
+  maxBubbleSize: number
+) => {
+  const categoryCount = categories.length
+  return (value: unknown): number | null => {
+    const categoryValue = getBubbleSizeCategoryValue(value)
+    if (categoryValue === null) return null
+
+    const categoryIndex = categories.indexOf(categoryValue)
+    if (categoryIndex === -1) return null
+    if (categoryCount <= 1) return minBubbleSize
+
+    return minBubbleSize + ((maxBubbleSize - minBubbleSize) * categoryIndex) / (categoryCount - 1)
+  }
+}
+
+export const getNumericBubbleSizeValues = (
+  rows: DataRow[],
+  sizeColumnName: string,
+  showBubbleZeros = false
+): number[] => {
+  const values = rows
+    .map(row => getFiniteBubbleNumber(row[sizeColumnName]))
+    .filter((value): value is number => value !== null && value >= 0)
+
+  return showBubbleZeros ? values : values.filter(value => value > 0)
+}
+
+export const createNumericBubbleSizeScale = (
+  values: number[],
+  minBubbleSize: number,
+  maxBubbleSize: number,
+  showBubbleZeros = false
+) => {
+  const domainMin = showBubbleZeros ? 0 : 1
+  const domainMax = Math.max(...values, domainMin)
+
+  return domainMax === domainMin
+    ? () => minBubbleSize
+    : scaleLinear().domain([domainMin, domainMax]).range([minBubbleSize, maxBubbleSize])
+}

--- a/packages/map/src/helpers/bubbleSize.ts
+++ b/packages/map/src/helpers/bubbleSize.ts
@@ -10,8 +10,8 @@ export const isCategoricalBubbleSize = (layer?: BubbleLayer): boolean => getBubb
 
 export const getBubbleSizeCategoryValue = (value: unknown): string | null => {
   if (value === null || value === undefined) return null
-  const stringValue = String(value)
-  return stringValue.trim() === '' ? null : stringValue
+  const stringValue = String(value).trim()
+  return stringValue === '' ? null : stringValue
 }
 
 export const getOrderedBubbleSizeCategories = (

--- a/packages/map/src/helpers/generateRuntimeData.ts
+++ b/packages/map/src/helpers/generateRuntimeData.ts
@@ -11,6 +11,7 @@ import {
   isBubbleLayerUsingCoordinates,
   mapConfigForBubbleLayer
 } from './bubbleLayers'
+import { isCategoricalBubbleSize } from './bubbleSize'
 import type { BubbleLayer } from '../types/MapConfig'
 
 const setRowUID = (row: DataRow, uid: string): void => {
@@ -84,7 +85,6 @@ const generateRuntimeData = (
     const coordinateBubbleLayers = bubbleLayers.filter(
       layer => isBubbleLayerUsingCoordinates(layer) && hasBubbleLayerCoordinateColumns(layer)
     )
-
     addUIDs(configObj, geoColName)
 
     configObj.data.forEach((row: DataRow, rowIndex: number) => {
@@ -123,10 +123,11 @@ const generateRuntimeData = (
           }
         }
 
-        if (layerSize) {
+        if (layerSize && !isCategoricalBubbleSize(layer)) {
           const sizeValue = row[layerSize]
-          if (sizeValue && typeof sizeValue === 'string') {
-            row[layerSize] = numberFromString(sizeValue)
+          const numericSizeValue = getFiniteBubbleNumber(sizeValue)
+          if (numericSizeValue !== null && typeof sizeValue === 'string') {
+            row[layerSize] = numericSizeValue
           }
         }
 

--- a/packages/map/src/helpers/tests/bubbleSize.test.ts
+++ b/packages/map/src/helpers/tests/bubbleSize.test.ts
@@ -40,10 +40,13 @@ describe('bubbleSize', () => {
     expect(scale('High')).toBe(28)
   })
 
-  it('omits blank values and respects showBubbleZeros for exact zero categories', () => {
-    const rows = [{ size: '0' }, { size: 0 }, { size: 'A' }, { size: '' }]
+  it('normalizes category whitespace before ordering and zero suppression', () => {
+    const rows = [{ size: ' 0 ' }, { size: 0 }, { size: ' A ' }, { size: 'A' }, { size: '   ' }]
 
     expect(getOrderedBubbleSizeCategories(rows, 'size', [], false)).toEqual(['A'])
     expect(getOrderedBubbleSizeCategories(rows, 'size', [], true)).toEqual(['0', 'A'])
+
+    const scale = createCategoricalBubbleSizeScale(['A'], 4, 28)
+    expect(scale(' A ')).toBe(4)
   })
 })

--- a/packages/map/src/helpers/tests/bubbleSize.test.ts
+++ b/packages/map/src/helpers/tests/bubbleSize.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { createCategoricalBubbleSizeScale, getBubbleSizeType, getOrderedBubbleSizeCategories } from '../bubbleSize'
+
+describe('bubbleSize', () => {
+  it('defaults bubble size type to numeric', () => {
+    expect(getBubbleSizeType()).toBe('numeric')
+    expect(getBubbleSizeType({} as any)).toBe('numeric')
+  })
+
+  it('uses automatic numeric and range sorting for categorical size values', () => {
+    const rows = [
+      { size: '10+' },
+      { size: '1 - 4' },
+      { size: 'Other' },
+      { size: '5 - 9' },
+      { size: '0' },
+      { size: '' },
+      { size: null }
+    ]
+
+    expect(getOrderedBubbleSizeCategories(rows, 'size', [], true)).toEqual(['0', '1 - 4', '5 - 9', '10+', 'Other'])
+  })
+
+  it('uses custom category order ahead of automatic order', () => {
+    const rows = [{ size: '1 - 4' }, { size: '5 - 9' }, { size: '10+' }, { size: 'Other' }]
+
+    expect(getOrderedBubbleSizeCategories(rows, 'size', ['Other', '10+'], true)).toEqual([
+      'Other',
+      '10+',
+      '1 - 4',
+      '5 - 9'
+    ])
+  })
+
+  it('maps categorical size values evenly across the configured radius range', () => {
+    const scale = createCategoricalBubbleSizeScale(['Low', 'Medium', 'High'], 4, 28)
+
+    expect(scale('Low')).toBe(4)
+    expect(scale('Medium')).toBe(16)
+    expect(scale('High')).toBe(28)
+  })
+
+  it('omits blank values and respects showBubbleZeros for exact zero categories', () => {
+    const rows = [{ size: '0' }, { size: 0 }, { size: 'A' }, { size: '' }]
+
+    expect(getOrderedBubbleSizeCategories(rows, 'size', [], false)).toEqual(['A'])
+    expect(getOrderedBubbleSizeCategories(rows, 'size', [], true)).toEqual(['0', 'A'])
+  })
+})

--- a/packages/map/src/helpers/tests/generateRuntimeData.test.ts
+++ b/packages/map/src/helpers/tests/generateRuntimeData.test.ts
@@ -152,4 +152,128 @@ describe('generateRuntimeData', () => {
     expect(Object.keys(result)).toEqual(['BRA'])
     expect(result.BRA.cases).toBe(5)
   })
+
+  it('does not coerce categorical bubble size column values to numbers', () => {
+    const config: any = {
+      columns: {
+        geo: { name: '' },
+        primary: { name: '' },
+        latitude: { name: '' },
+        longitude: { name: '' },
+        navigate: { name: '' },
+        categorical: { name: '' }
+      },
+      general: {
+        displayAsHex: false,
+        geoType: 'world',
+        type: 'data'
+      },
+      legend: {
+        type: 'equalnumber'
+      },
+      bubble: {
+        layers: [
+          {
+            sizeType: 'category',
+            minBubbleSize: 1,
+            maxBubbleSize: 20,
+            extraBubbleBorder: false,
+            showBubbleZeros: false,
+            columns: {
+              geo: { name: 'country' },
+              primary: { name: '' },
+              size: { name: 'caseRange' }
+            }
+          }
+        ]
+      },
+      data: [{ country: 'Brazil', caseRange: '1 - 4' }]
+    }
+
+    const result = generateBubbleLayerRuntimeData(config, config.bubble.layers[0], [], 3)
+
+    expect(result.BRA.caseRange).toBe('1 - 4')
+  })
+
+  it('continues coercing numeric bubble size column values to numbers', () => {
+    const config: any = {
+      columns: {
+        geo: { name: '' },
+        primary: { name: '' },
+        latitude: { name: '' },
+        longitude: { name: '' },
+        navigate: { name: '' },
+        categorical: { name: '' }
+      },
+      general: {
+        displayAsHex: false,
+        geoType: 'world',
+        type: 'data'
+      },
+      legend: {
+        type: 'equalnumber'
+      },
+      bubble: {
+        layers: [
+          {
+            minBubbleSize: 1,
+            maxBubbleSize: 20,
+            extraBubbleBorder: false,
+            showBubbleZeros: false,
+            columns: {
+              geo: { name: 'country' },
+              primary: { name: '' },
+              size: { name: 'cases' }
+            }
+          }
+        ]
+      },
+      data: [{ country: 'Brazil', cases: '1234' }]
+    }
+
+    const result = generateBubbleLayerRuntimeData(config, config.bubble.layers[0], [], 4)
+
+    expect(result.BRA.cases).toBe(1234)
+  })
+
+  it('does not partially coerce non-numeric bubble size values while size type is numeric', () => {
+    const config: any = {
+      columns: {
+        geo: { name: '' },
+        primary: { name: '' },
+        latitude: { name: '' },
+        longitude: { name: '' },
+        navigate: { name: '' },
+        categorical: { name: '' }
+      },
+      general: {
+        displayAsHex: false,
+        geoType: 'world',
+        type: 'data'
+      },
+      legend: {
+        type: 'equalnumber'
+      },
+      bubble: {
+        layers: [
+          {
+            minBubbleSize: 1,
+            maxBubbleSize: 20,
+            extraBubbleBorder: false,
+            showBubbleZeros: false,
+            columns: {
+              geo: { name: 'country' },
+              primary: { name: '' },
+              size: { name: 'caseRange' }
+            }
+          }
+        ]
+      },
+      data: [{ country: 'Brazil', caseRange: '1-10' }]
+    }
+
+    const result = generateBubbleLayerRuntimeData(config, config.bubble.layers[0], [], 5)
+
+    expect(result.BRA.caseRange).toBe('1-10')
+  })
 })

--- a/packages/map/src/types/MapConfig.ts
+++ b/packages/map/src/types/MapConfig.ts
@@ -53,6 +53,10 @@ type MapVisualSettings = {
 export type BubbleLayer = {
   /** Chooses whether bubbles are positioned by geography lookup or explicit coordinates. */
   locationSource?: 'data-column' | 'latitude-longitude'
+  /** Chooses whether the size column is interpreted as numeric values or categories. */
+  sizeType?: 'numeric' | 'category'
+  /** Custom category order for categorical bubble sizing; empty means automatic sorting. */
+  sizeCategoryValuesOrder?: string[]
   minBubbleSize: number
   maxBubbleSize: number
   extraBubbleBorder: boolean


### PR DESCRIPTION
## Summary

Adds support for categorical bubble sizes in addition to the existing numeric sizing approach.

## Testing Steps

Open [bird-flu3.json](https://github.com/user-attachments/files/29752549/bird-flu3.json), see how it is configured in the editor.
