### PR TITLE
Fix [DEV-13408] Fixes

### DIFF
--- a/packages/core/components/EditorPanel/VizFilterEditor/NestedDropdownEditor.test.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/NestedDropdownEditor.test.tsx
@@ -7,6 +7,88 @@ vi.mock('../../ui/Icon', () => ({
 }))
 
 describe('NestedDropdownEditor', () => {
+  it('keeps the current subgroup column available while excluding other filter columns', () => {
+    render(
+      <NestedDropdownEditor
+        config={
+          {
+            filters: [
+              {
+                id: 1,
+                label: 'Location',
+                filterStyle: 'combobox',
+                columnName: 'location',
+                values: ['North Clinic'],
+                order: 'asc'
+              },
+              {
+                id: 2,
+                label: 'Category and Type',
+                filterStyle: 'nested-dropdown',
+                columnName: 'category',
+                values: ['A'],
+                order: 'asc',
+                subGrouping: {
+                  columnName: 'otherSubgroup',
+                  valuesLookup: {
+                    A: { values: ['One'] }
+                  }
+                }
+              },
+              {
+                id: 3,
+                label: 'Region and Location Type',
+                filterStyle: 'nested-dropdown',
+                columnName: 'region',
+                values: ['North', 'South'],
+                order: 'asc',
+                subGrouping: {
+                  columnName: 'locationType',
+                  valuesLookup: {
+                    North: { values: ['Clinic', 'Mobile Unit'] },
+                    South: { values: ['Clinic', 'Community Site'] }
+                  }
+                }
+              }
+            ]
+          } as any
+        }
+        dataColumns={[
+          'location',
+          'locationDescription',
+          'category',
+          'otherSubgroup',
+          'region',
+          'locationType',
+          'locationTypeDescription'
+        ]}
+        filterIndex={2}
+        handleGroupingCustomOrder={vi.fn()}
+        handleNameChange={vi.fn()}
+        rawData={[
+          { location: 'North Clinic', region: 'North', locationType: 'Clinic' },
+          { location: 'North Mobile Unit', region: 'North', locationType: 'Mobile Unit' },
+          { location: 'South Community Site', region: 'South', locationType: 'Community Site' }
+        ]}
+        updateField={vi.fn()}
+        updateFilterStyle={vi.fn()}
+      />
+    )
+
+    const subgroupSelect = screen
+      .getAllByLabelText('Filter SubGrouping')
+      .find((field): field is HTMLSelectElement => field instanceof HTMLSelectElement)
+
+    if (!subgroupSelect) throw new Error('Filter SubGrouping select not found')
+
+    const optionValues = Array.from(subgroupSelect.options).map(option => option.value)
+
+    expect(optionValues).toContain('locationType')
+    expect(optionValues).not.toContain('location')
+    expect(optionValues).not.toContain('category')
+    expect(optionValues).not.toContain('otherSubgroup')
+  })
+
   it('renders the subgroup-only checkbox below Create query parameters and defaults it to unchecked', () => {
     const updateField = vi.fn()
 

--- a/packages/core/components/EditorPanel/VizFilterEditor/NestedDropdownEditor.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/NestedDropdownEditor.tsx
@@ -265,7 +265,6 @@ const NestedDropdownEditor: React.FC<NestedDropdownEditorProps> = ({
       )}
 
       <div className='mt-2'>
-        <div className='edit-label column-heading float-right'>{filter.columnName} </div>
         <Select
           label='Group Order'
           value={filter.order}
@@ -283,7 +282,6 @@ const NestedDropdownEditor: React.FC<NestedDropdownEditorProps> = ({
 
       {subGrouping?.columnName && (
         <div className='mt-2'>
-          <div className='edit-label column-heading float-right'>{subGrouping.columnName} </div>
           <Select
             label='SubGrouping Order'
             value={subGrouping.order ? subGrouping.order : 'asc'}

--- a/packages/core/components/EditorPanel/VizFilterEditor/NestedDropdownEditor.tsx
+++ b/packages/core/components/EditorPanel/VizFilterEditor/NestedDropdownEditor.tsx
@@ -38,8 +38,8 @@ const NestedDropdownEditor: React.FC<NestedDropdownEditorProps> = ({
 
   config.filters.forEach((filter: VizFilter, index) => {
     if (filterIndex === index) return
-    listOfUsedColumnNames.push(filter.columnName)
-    if (subGrouping?.columnName) listOfUsedColumnNames.push(subGrouping.columnName)
+    if (filter.columnName) listOfUsedColumnNames.push(filter.columnName)
+    if (filter.subGrouping?.columnName) listOfUsedColumnNames.push(filter.subGrouping.columnName)
   })
 
   const updateGroupingFilterProp = (prop, value) => {


### PR DESCRIPTION
## Summary

Fix old bug limiting subgrouping options and remove excess labels.

## Testing Steps

Open [combobox-filter-descriptions.json](https://github.com/user-attachments/files/29892856/combobox-filter-descriptions.json), make sure LocationType appears in the second filter's Subgrouping field.

