### PR TITLE
DEV-13405 Multi-Dash - Filter selections Persist between Tabs

### DIFF
--- a/packages/dashboard/CONFIG.md
+++ b/packages/dashboard/CONFIG.md
@@ -230,6 +230,7 @@ The dashboard initial state still contains a rollback-friendly root `table` obje
 | --- | --- | --- | --- | --- | --- |
 | `multiDashboards` | `MultiDashboard[]` | No | None | Optional tabbed dashboard set. | Each entry contains its own `dashboard`, `rows`, `visualizations`, and `label`. |
 | `multiDashboards[].label` | `string` | Yes | None | Label shown on the dashboard tab. | Required for each dashboard slot. |
+| `persistFiltersAcrossTabs` | `boolean` | No | `false` | Carries filter selections across tabs. | Matches filters by stable identity (`columnName || setByQueryParameter || key`) and validates values against target options. |
 
 ## Fields You Can Ignore
 

--- a/packages/dashboard/src/components/Header/Header.tsx
+++ b/packages/dashboard/src/components/Header/Header.tsx
@@ -138,6 +138,11 @@ const Header = (props: HeaderProps) => {
     }
   }
 
+  const handlePersistFiltersCheck = e => {
+    const { checked } = e.currentTarget
+    dispatch({ type: 'UPDATE_CONFIG', payload: [{ ...config, persistFiltersAcrossTabs: checked }] })
+  }
+
   if (!config) return null
 
   const multiInitialized = !!config.multiDashboards
@@ -265,6 +270,18 @@ const Header = (props: HeaderProps) => {
                         </label>
                       )}
                     </div>
+                    {multiInitialized && (
+                      <label className='persist-filters-toggle checkbox column-heading'>
+                        <span className='persist-filters-toggle__control'>
+                          <input
+                            type='checkbox'
+                            onChange={handlePersistFiltersCheck}
+                            checked={!!config.persistFiltersAcrossTabs}
+                          />
+                        </span>
+                        <span className='edit-label column-heading'>Keep filter selections when switching tabs</span>
+                      </label>
+                    )}
                     <label className='dashboard-settings__field dashboard-settings__field--wide'>
                       <span className='edit-label column-heading'>Dashboard description</span>
                       <input

--- a/packages/dashboard/src/helpers/crossTabFilterValues.ts
+++ b/packages/dashboard/src/helpers/crossTabFilterValues.ts
@@ -1,0 +1,52 @@
+import { SharedFilter } from '../types/SharedFilter'
+
+/**
+ * Stable identity used to match "the same" shared filter across dashboard tabs.
+ * `key` is not reliable because each tab can assign a different key to an
+ * equivalent filter (e.g. "State/Territory (1)" vs "State/Territory"), so we
+ * prefer the underlying data column, then the URL parameter, then the key.
+ */
+const getFilterIdentity = (filter: SharedFilter): string =>
+  filter.columnName || filter.setByQueryParameter || filter.key
+
+/**
+ * Carries user-selected filter values from one dashboard tab's shared filters
+ * onto another tab's matching shared filters. Filters are matched by identity,
+ * and carried values are validated against the target filter's values.
+ *
+ * @param fromFilters - shared filters of the tab being left
+ * @param toFilters - shared filters of the tab being entered
+ * @returns the target filters with matching `active`/`queuedActive` values carried over
+ */
+export const crossTabFilterValues = (
+  fromFilters: SharedFilter[] = [],
+  toFilters: SharedFilter[] = []
+): SharedFilter[] => {
+  if (!toFilters.length || !fromFilters.length) return toFilters
+
+  const sourceByIdentity = new Map<string, SharedFilter>()
+  fromFilters.forEach(filter => {
+    const identity = getFilterIdentity(filter)
+    if (identity && !sourceByIdentity.has(identity)) sourceByIdentity.set(identity, filter)
+  })
+
+  return toFilters.map(target => {
+    const source = sourceByIdentity.get(getFilterIdentity(target))
+    if (!source || source.active === undefined) return target
+
+    const values = target.values
+    const isValidValue = (value: string) => !values?.length || values.includes(value)
+
+    let active: string | string[]
+    if (Array.isArray(source.active)) {
+      active = source.active.filter(isValidValue)
+    } else if (isValidValue(source.active)) {
+      active = source.active
+    } else {
+      // Carried value does not exist in the target tab; keep the target default.
+      return target
+    }
+
+    return { ...target, active, queuedActive: source.queuedActive }
+  })
+}

--- a/packages/dashboard/src/helpers/crossTabFilterValues.ts
+++ b/packages/dashboard/src/helpers/crossTabFilterValues.ts
@@ -12,7 +12,12 @@ const getFilterIdentity = (filter: SharedFilter): string =>
 /**
  * Carries user-selected filter values from one dashboard tab's shared filters
  * onto another tab's matching shared filters. Filters are matched by identity,
- * and carried values are validated against the target filter's values.
+ * and carried values are validated against the target filter's values and type.
+ *
+ * Type safety: enforces active-value compatibility based on target filter style.
+ * Multi-select targets receive arrays; single-select targets receive strings.
+ * When the source and target have different filter styles, carried values are
+ * adapted or skipped (e.g., first valid value from source array → single-select string).
  *
  * @param fromFilters - shared filters of the tab being left
  * @param toFilters - shared filters of the tab being entered
@@ -36,15 +41,33 @@ export const crossTabFilterValues = (
 
     const values = target.values
     const isValidValue = (value: string) => !values?.length || values.includes(value)
+    const isMultiSelect = target.filterStyle === 'multi-select'
 
     let active: string | string[]
-    if (Array.isArray(source.active)) {
-      active = source.active.filter(isValidValue)
-    } else if (isValidValue(source.active)) {
-      active = source.active
+
+    if (isMultiSelect) {
+      // Target is multi-select: ensure active is an array
+      if (Array.isArray(source.active)) {
+        const filtered = source.active.filter(isValidValue)
+        if (!filtered.length) return target // Keep target default if filtering leaves nothing
+        active = filtered
+      } else if (isValidValue(source.active)) {
+        active = [source.active]
+      } else {
+        return target // Carried value invalid; keep target default
+      }
     } else {
-      // Carried value does not exist in the target tab; keep the target default.
-      return target
+      // Target is single-select: ensure active is a string
+      if (Array.isArray(source.active)) {
+        // Find first valid value from the array
+        const firstValid = source.active.find(isValidValue)
+        if (!firstValid) return target // No valid value in array; keep target default
+        active = firstValid
+      } else if (isValidValue(source.active)) {
+        active = source.active
+      } else {
+        return target // Carried value invalid; keep target default
+      }
     }
 
     return { ...target, active, queuedActive: source.queuedActive }

--- a/packages/dashboard/src/helpers/tests/crossTabFilterValues.test.ts
+++ b/packages/dashboard/src/helpers/tests/crossTabFilterValues.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { crossTabFilterValues } from '../crossTabFilterValues'
+import { SharedFilter } from '../../types/SharedFilter'
+
+const makeFilter = (overrides: Partial<SharedFilter> = {}): SharedFilter =>
+  ({
+    key: 'State',
+    columnName: 'State/Territory',
+    type: 'datafilter',
+    order: 'asc',
+    values: ['Alabama', 'California', 'Texas'],
+    active: '',
+    ...overrides
+  } as SharedFilter)
+
+describe('crossTabFilterValues', () => {
+  it('carries the active value onto a matching filter (matched by columnName)', () => {
+    const from = [makeFilter({ key: 'State/Territory (1)', active: 'California' })]
+    const to = [makeFilter({ key: 'State/Territory', active: 'Alabama' })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toBe('California')
+  })
+
+  it('does not mutate the input filters', () => {
+    const from = [makeFilter({ active: 'California' })]
+    const to = [makeFilter({ active: 'Alabama' })]
+
+    crossTabFilterValues(from, to)
+
+    expect(to[0].active).toBe('Alabama')
+  })
+
+  it('leaves the target unchanged when no matching source filter exists', () => {
+    const from = [makeFilter({ columnName: 'Pathogen', values: ['Flu'], active: 'Flu' })]
+    const to = [makeFilter({ columnName: 'State/Territory', active: 'Alabama' })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toBe('Alabama')
+  })
+
+  it('keeps the target default when the carried value is not valid for the target', () => {
+    const from = [makeFilter({ active: 'California' })]
+    const to = [makeFilter({ values: ['Alabama', 'Texas'], active: 'Alabama' })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toBe('Alabama')
+  })
+
+  it('carries the value when the target has no configured values to validate against', () => {
+    const from = [makeFilter({ active: 'California' })]
+    const to = [makeFilter({ values: undefined, active: 'Alabama' })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toBe('California')
+  })
+
+  it('filters multi-select carried values down to those valid for the target', () => {
+    const from = [makeFilter({ multiSelect: true, active: ['California', 'Nevada'] } as Partial<SharedFilter>)]
+    const to = [
+      makeFilter({ multiSelect: true, values: ['Alabama', 'California'], active: [] } as Partial<SharedFilter>)
+    ]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toEqual(['California'])
+  })
+
+  it('matches by setByQueryParameter when columnName is absent', () => {
+    const from = [makeFilter({ columnName: undefined, setByQueryParameter: 'state', active: 'California' })]
+    const to = [makeFilter({ columnName: undefined, setByQueryParameter: 'state', active: 'Alabama' })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toBe('California')
+  })
+
+  it('carries queuedActive alongside active', () => {
+    const from = [makeFilter({ active: 'California', queuedActive: 'Texas' })]
+    const to = [makeFilter({ active: 'Alabama' })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].queuedActive).toBe('Texas')
+  })
+
+  it('returns the target list unchanged when either list is empty', () => {
+    const to = [makeFilter({ active: 'Alabama' })]
+    expect(crossTabFilterValues([], to)).toBe(to)
+    expect(crossTabFilterValues(to, [])).toEqual([])
+  })
+})

--- a/packages/dashboard/src/helpers/tests/crossTabFilterValues.test.ts
+++ b/packages/dashboard/src/helpers/tests/crossTabFilterValues.test.ts
@@ -7,6 +7,7 @@ const makeFilter = (overrides: Partial<SharedFilter> = {}): SharedFilter =>
     key: 'State',
     columnName: 'State/Territory',
     type: 'datafilter',
+    filterStyle: 'dropdown',
     order: 'asc',
     values: ['Alabama', 'California', 'Texas'],
     active: '',
@@ -60,14 +61,48 @@ describe('crossTabFilterValues', () => {
   })
 
   it('filters multi-select carried values down to those valid for the target', () => {
-    const from = [makeFilter({ multiSelect: true, active: ['California', 'Nevada'] } as Partial<SharedFilter>)]
-    const to = [
-      makeFilter({ multiSelect: true, values: ['Alabama', 'California'], active: [] } as Partial<SharedFilter>)
-    ]
+    const from = [makeFilter({ filterStyle: 'multi-select', active: ['California', 'Nevada'] })]
+    const to = [makeFilter({ filterStyle: 'multi-select', values: ['Alabama', 'California'], active: [] })]
 
     const result = crossTabFilterValues(from, to)
 
     expect(result[0].active).toEqual(['California'])
+  })
+
+  it('adapts multi-select array to single-select string by taking first valid value', () => {
+    const from = [makeFilter({ filterStyle: 'multi-select', active: ['Nevada', 'California', 'Texas'] })]
+    const to = [makeFilter({ filterStyle: 'dropdown', active: 'Alabama' })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toBe('California')
+  })
+
+  it('wraps single-select string in array for multi-select target', () => {
+    const from = [makeFilter({ filterStyle: 'dropdown', active: 'California' })]
+    const to = [makeFilter({ filterStyle: 'multi-select', active: [] })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toEqual(['California'])
+  })
+
+  it('keeps single-select default when source array has no valid values', () => {
+    const from = [makeFilter({ filterStyle: 'multi-select', active: ['Nevada', 'Wyoming'] })]
+    const to = [makeFilter({ filterStyle: 'dropdown', values: ['Alabama', 'California'], active: 'Alabama' })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toBe('Alabama')
+  })
+
+  it('keeps multi-select default when filtering an array leaves nothing', () => {
+    const from = [makeFilter({ filterStyle: 'multi-select', active: ['Nevada', 'Wyoming'] })]
+    const to = [makeFilter({ filterStyle: 'multi-select', values: ['Alabama', 'California'], active: [] })]
+
+    const result = crossTabFilterValues(from, to)
+
+    expect(result[0].active).toEqual([])
   })
 
   it('matches by setByQueryParameter when columnName is absent', () => {

--- a/packages/dashboard/src/scss/main.scss
+++ b/packages/dashboard/src/scss/main.scss
@@ -166,6 +166,34 @@ button.row-menu__btn[title*='Equal Height Rows'] {
           }
         }
 
+        label.persist-filters-toggle.checkbox {
+          align-items: center;
+          align-self: flex-end;
+          column-gap: 0.4rem;
+          display: flex;
+          flex-direction: row;
+          flex: 0 0 auto;
+          font-size: 0.8em;
+          font-weight: 600;
+          height: 32px;
+          line-height: 1.2;
+          margin-bottom: 0 !important;
+          white-space: nowrap;
+
+          > .edit-label {
+            margin-bottom: 0 !important;
+          }
+        }
+
+        .persist-filters-toggle__control {
+          align-items: center;
+          display: flex;
+
+          input[type='checkbox'] {
+            margin: 0;
+          }
+        }
+
         .dashboard-settings__field {
           display: flex;
           flex-direction: column;

--- a/packages/dashboard/src/store/dashboard.actions.ts
+++ b/packages/dashboard/src/store/dashboard.actions.ts
@@ -1,4 +1,5 @@
 import type { DashboardConfig as Config } from '../types/DashboardConfig'
+import type { MultiDashboardConfig } from '../types/MultiDashboard'
 import { type Action } from '@cdc/core/types/Action'
 import { Tab } from '../types/Tab'
 import { ConfigRow } from '../types/ConfigRow'
@@ -32,7 +33,7 @@ type MOVE_VISUALIZATION = Action<
   }
 >
 type SET_CONFIG = Action<'SET_CONFIG', Partial<Config> & { activeDashboard?: number }>
-type UPDATE_CONFIG = Action<'UPDATE_CONFIG', [Config, Object?]>
+type UPDATE_CONFIG = Action<'UPDATE_CONFIG', [MultiDashboardConfig, Object?]>
 type SET_DATA = Action<'SET_DATA', { data: Record<string, any[]>; activeDashboard?: number }>
 type SET_LOADING = Action<'SET_LOADING', boolean>
 type SET_PREVIEW = Action<'SET_PREVIEW', boolean>

--- a/packages/dashboard/src/store/dashboard.reducer.test.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.test.ts
@@ -549,3 +549,68 @@ describe('SET_SHARED_FILTERS', () => {
     })
   })
 })
+
+describe('SWITCH_CONFIG', () => {
+  const stateWithFilters = (persistFiltersAcrossTabs?: boolean): DashboardState => {
+    const tabAFilters = [
+      {
+        key: 'State/Territory (1)',
+        type: 'datafilter',
+        columnName: 'State/Territory',
+        order: 'asc',
+        values: ['Alabama', 'California', 'Texas'],
+        active: 'California'
+      }
+    ]
+    const tabBFilters = [
+      {
+        key: 'State/Territory',
+        type: 'datafilter',
+        columnName: 'State/Territory',
+        order: 'asc',
+        values: ['Alabama', 'California', 'Texas'],
+        active: 'Alabama'
+      }
+    ]
+    return makeState({
+      persistFiltersAcrossTabs,
+      dashboard: { sharedFilters: tabAFilters },
+      multiDashboards: [
+        { label: 'Tab A', dashboard: { sharedFilters: tabAFilters }, visualizations: {}, rows: [] },
+        { label: 'Tab B', dashboard: { sharedFilters: tabBFilters }, visualizations: {}, rows: [] }
+      ]
+    } as any)
+  }
+
+  it('carries the active filter value across tabs when persistFiltersAcrossTabs is enabled', () => {
+    const state = stateWithFilters(true)
+    const next = reducer(state, { type: 'SWITCH_CONFIG', payload: 1 })
+
+    expect(next.config.activeDashboard).toBe(1)
+    expect(next.config.dashboard.sharedFilters[0].active).toBe('California')
+  })
+
+  it('leaves the target tab default in place when persistFiltersAcrossTabs is disabled', () => {
+    const state = stateWithFilters(false)
+    const next = reducer(state, { type: 'SWITCH_CONFIG', payload: 1 })
+
+    expect(next.config.activeDashboard).toBe(1)
+    expect(next.config.dashboard.sharedFilters[0].active).toBe('Alabama')
+  })
+
+  it('handles undefined sharedFilters gracefully when flag is enabled', () => {
+    const state = makeState({
+      persistFiltersAcrossTabs: true,
+      dashboard: { sharedFilters: undefined } as any,
+      multiDashboards: [
+        { label: 'Tab A', dashboard: { sharedFilters: undefined } as any, visualizations: {}, rows: [] },
+        { label: 'Tab B', dashboard: { sharedFilters: undefined } as any, visualizations: {}, rows: [] }
+      ]
+    } as any)
+
+    const next = reducer(state, { type: 'SWITCH_CONFIG', payload: 1 })
+
+    expect(next.config.activeDashboard).toBe(1)
+    expect(next.config.dashboard.sharedFilters).toEqual([])
+  })
+})

--- a/packages/dashboard/src/store/dashboard.reducer.ts
+++ b/packages/dashboard/src/store/dashboard.reducer.ts
@@ -11,6 +11,7 @@ import { AnyVisualization } from '@cdc/core/types/Visualization'
 import { initialState } from '../DashboardContext'
 import { hasConditionalWidgets, normalizeConditionalColumn } from '../helpers/dashboardColumnWidgets'
 import { cloneDashboardWidget } from '../helpers/cloneDashboardWidget'
+import { crossTabFilterValues } from '../helpers/crossTabFilterValues'
 
 type BlankMultiConfig = {
   dashboard: Partial<Dashboard>
@@ -171,7 +172,17 @@ const reducer = (state: DashboardState, action: DashboardActions): DashboardStat
       const slot = action.payload
       const newConfigFields = state.config.multiDashboards[slot]
       const _newDatasets = _.cloneDeep(state.data)
-      return { ...state, data: _newDatasets, config: { ...state.config, ...newConfigFields, activeDashboard: slot } }
+      const nextConfig = { ...state.config, ...newConfigFields, activeDashboard: slot }
+      if (state.config.persistFiltersAcrossTabs) {
+        nextConfig.dashboard = {
+          ...newConfigFields.dashboard,
+          sharedFilters: crossTabFilterValues(
+            state.config.dashboard?.sharedFilters || [],
+            newConfigFields.dashboard?.sharedFilters || []
+          )
+        }
+      }
+      return { ...state, data: _newDatasets, config: nextConfig }
     }
     case 'TOGGLE_ROW': {
       const { rowIndex, colIndex } = action.payload

--- a/packages/dashboard/src/types/MultiDashboard.ts
+++ b/packages/dashboard/src/types/MultiDashboard.ts
@@ -3,9 +3,16 @@ import { Dashboard } from './Dashboard'
 import { DashboardConfig } from './DashboardConfig'
 import { ConfigRow } from './ConfigRow'
 
-export type MultiDashboard = { dashboard: Dashboard; rows: ConfigRow[]; visualizations: Record<string, AnyVisualization>; label: string }
+export type MultiDashboard = {
+  dashboard: Dashboard
+  rows: ConfigRow[]
+  visualizations: Record<string, AnyVisualization>
+  label: string
+}
 
 export type MultiDashboardConfig = DashboardConfig & {
   multiDashboards?: MultiDashboard[]
   activeDashboard?: number // index of the active MultiDashboard
+  // When enabled, shared filter selections are carried over when switching tabs
+  persistFiltersAcrossTabs?: boolean
 }


### PR DESCRIPTION
## Summary

- Adds `crossTabFilterValues` helper that persists filters across tabs.
- Add boolean config option alongside multidash download controls
- Default to current behavior of not persisting filters across tabs, they have to opt-in


## Testing Steps
Use multi-tab dash attached to this ticket or similar multi-dash with the same filters used in each tab. Turn on "Keep filter selections when switching tabs". Filters should now save when changing tabs.

## Optional
### Storybook Links
`yarn test-unit:quick -- --scope @cdc/dashboard`
