### PR TITLE
DEV-12746 Fix for thousands abbreviation not showing up in certain cases

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -1060,6 +1060,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
         rightSuffix,
         bottomPrefix,
         bottomSuffix,
+        bottomCommas,
         bottomAbbreviated,
         preserveOriginalDecimals
       }
@@ -1155,7 +1156,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
 
     if (
       (axis === 'left' && commas && abbreviated && shouldAbbreviate) ||
-      (axis === 'bottom' && commas && abbreviated && shouldAbbreviate)
+      (axis === 'bottom' && bottomCommas && bottomAbbreviated && shouldAbbreviate)
     ) {
       num = num // eslint-disable-line
     } else {

--- a/packages/chart/src/_stories/ChartPrefixSuffix.smoke.stories.tsx
+++ b/packages/chart/src/_stories/ChartPrefixSuffix.smoke.stories.tsx
@@ -17,10 +17,9 @@ const meta: Meta<typeof Chart> = {
 
 type Story = StoryObj<typeof Chart>
 
-const getSvgTextValues = (canvasElement: HTMLElement) => {
-  const svg = canvasElement.querySelector('svg')
-  if (!svg) return []
-  return Array.from(svg.querySelectorAll('text')).map(node => node.textContent?.trim() || '')
+const getSvgTextValues = (root: ParentNode | null, selector: string = 'text') => {
+  if (!root) return []
+  return Array.from(root.querySelectorAll(selector)).map(node => node.textContent?.trim() || '')
 }
 
 export const Inline_Label: Story = {
@@ -217,9 +216,9 @@ export const ScatterPlot_Bottom_Commas_And_Abbreviated: Story = {
   },
   play: async ({ canvasElement }) => {
     await assertVisualizationRendered(canvasElement)
-    await waitForPresence('svg', canvasElement)
+    await waitForPresence('svg g.bottom-axis', canvasElement)
 
-    const svgText = getSvgTextValues(canvasElement)
+    const svgText = getSvgTextValues(canvasElement, 'svg g.bottom-axis text')
     const hasBottomAxisCurrencyAbbreviation = svgText.some(text => /^\$\d+(\.\d+)?K$/.test(text))
 
     expect(hasBottomAxisCurrencyAbbreviation).toBe(true)

--- a/packages/chart/src/_stories/ChartPrefixSuffix.smoke.stories.tsx
+++ b/packages/chart/src/_stories/ChartPrefixSuffix.smoke.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
 import barConfig from './_mock/line_chart_two_points_new_chart.json'
 import annotationConfig from './_mock/annotation_category_mock.json'
 import areaPrefix from './_mock/annotation_category_mock.json'
@@ -7,7 +8,7 @@ import scatterPlotConfig from './_mock/scatterplot_mock.json'
 
 import Chart from '../CdcChartComponent'
 import { editConfigKeys } from '@cdc/core/helpers/configHelpers'
-import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import { assertVisualizationRendered, waitForPresence } from '@cdc/core/helpers/testing'
 
 const meta: Meta<typeof Chart> = {
   title: 'Components/Templates/Chart/Prefix Suffix',
@@ -15,6 +16,12 @@ const meta: Meta<typeof Chart> = {
 }
 
 type Story = StoryObj<typeof Chart>
+
+const getSvgTextValues = (canvasElement: HTMLElement) => {
+  const svg = canvasElement.querySelector('svg')
+  if (!svg) return []
+  return Array.from(svg.querySelectorAll('text')).map(node => node.textContent?.trim() || '')
+}
 
 export const Inline_Label: Story = {
   args: {
@@ -195,6 +202,27 @@ export const ScatterPlot_Bottom_Commas: Story = {
   },
   play: async ({ canvasElement }) => {
     await assertVisualizationRendered(canvasElement)
+  }
+}
+
+export const ScatterPlot_Bottom_Commas_And_Abbreviated: Story = {
+  args: {
+    config: editConfigKeys(scatterPlotConfig, [
+      { path: ['dataFormat', 'bottomCommas'], value: true },
+      { path: ['dataFormat', 'bottomAbbreviated'], value: true },
+      { path: ['dataFormat', 'bottomPrefix'], value: '$' },
+      { path: ['dataFormat', 'commas'], value: false },
+      { path: ['dataFormat', 'abbreviated'], value: false }
+    ])
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+    await waitForPresence('svg', canvasElement)
+
+    const svgText = getSvgTextValues(canvasElement)
+    const hasBottomAxisCurrencyAbbreviation = svgText.some(text => /^\$\d+(\.\d+)?K$/.test(text))
+
+    expect(hasBottomAxisCurrencyAbbreviation).toBe(true)
   }
 }
 

--- a/packages/core/helpers/cove/number.ts
+++ b/packages/core/helpers/cove/number.ts
@@ -59,7 +59,7 @@ const formatNumber = (num, axis, shouldAbbreviate = false, config = null, addCol
       bottomPrefix,
       bottomRoundTo,
       bottomSuffix,
-      bottomComas,
+      bottomCommas,
       commas,
       prefix,
       preserveOriginalDecimals,
@@ -173,7 +173,7 @@ const formatNumber = (num, axis, shouldAbbreviate = false, config = null, addCol
 
   if (
     (axis === 'left' && commas && abbreviated && shouldAbbreviate) ||
-    (axis === 'bottom' && commas && abbreviated && shouldAbbreviate)
+    (axis === 'bottom' && bottomCommas && bottomAbbreviated && shouldAbbreviate)
   ) {
     num = num // eslint-disable-line
   } else {

--- a/packages/core/helpers/tests/number.test.ts
+++ b/packages/core/helpers/tests/number.test.ts
@@ -39,4 +39,21 @@ describe('formatNumber', () => {
   it('falls back to configured right-axis formatting when no override is present', () => {
     expect(formatNumber(1234.5, 'right', false, baseConfig as any)).toBe('R$1,234.50%')
   })
+
+  it('keeps bottom-axis abbreviations when bottom commas are enabled', () => {
+    const config = {
+      ...baseConfig,
+      dataFormat: {
+        ...baseConfig.dataFormat,
+        bottomCommas: true,
+        bottomAbbreviated: true,
+        bottomPrefix: '$'
+      }
+    }
+
+    const result = formatNumber(50000, 'bottom', true, config as any)
+
+    expect(result).toBe('$50K')
+    expect(result).not.toBe('$50')
+  })
 })


### PR DESCRIPTION
## Summary
Fix for thousands abbreviation not showing up in certain cases

## Testing Steps
Can use config attached to ticket. All combinations of left axis and bottom axis using abbreviations and commas should work properly now.
