### PR TITLE
Fix: add markup variable support to chart legends and map dynamic legends

### DIFF
--- a/packages/chart/CONFIG.md
+++ b/packages/chart/CONFIG.md
@@ -241,7 +241,7 @@ These fields are chart-owned. They are applied by chart number-format helpers fo
 | `legend.hide` | `boolean` | No | `false` | Hides the chart legend. | Shared field; charts may still render specialized legends such as warming-stripes gradients separately. |
 | `legend.position` | `left \| bottom \| top \| right \| side` | No | `top` | Places the legend relative to the chart. | Small viewports may force bottom placement. |
 | `legend.behavior` | `highlight \| isolate` | No | `isolate` | Controls click behavior for series legends. | `highlight` emphasizes clicked series; `isolate` narrows display to selected legend entries where supported. |
-| `legend.label`, `legend.description` | `string` | No | `''` | Legend heading and supporting description. | Rendered as authored legend copy. |
+| `legend.label`, `legend.description` | `string` | No | `''` | Legend heading and supporting description. | Supports HTML parsing and markup-variable processing when `enableMarkupVariables` is `true`. Standard chart legends support this behavior; HeatMap and Warming Stripes gradient legends render these fields as authored copy. |
 | `legend.singleRow` | `boolean` | No | `true` | Requests a single-row legend layout. | Runtime may wrap when space is limited. |
 | `legend.unified` | `boolean` | No | Package defaults | Combines legend handling for supported chart families. | Common in pie and specialized legend flows. |
 | `legend.axisAlign` | `boolean` | No | `true` | Aligns the legend with the plot/axis area. | Chart-specific layout option. |

--- a/packages/chart/src/components/Legend/Legend.Component.tsx
+++ b/packages/chart/src/components/Legend/Legend.Component.tsx
@@ -21,6 +21,7 @@ import { getHorizonLayerColors, getHorizonMaxValue } from '../../components/Hori
 import { getSeriesWithData } from '../../helpers/dataHelpers'
 import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
+import { processMarkupVariables } from '@cdc/core/helpers/markupProcessor'
 
 const LEGEND_PADDING = 36
 
@@ -61,6 +62,42 @@ const Legend: React.FC<LegendProps> = forwardRef(
     const { innerClasses, containerClasses } = getLegendClasses(config)
     const { runtime, legend } = config
     const { series } = runtime
+    const processedLegendText = useMemo(() => {
+      if (!config.enableMarkupVariables || !config.markupVariables?.length) {
+        return {
+          label: legend?.label,
+          description: legend?.description
+        }
+      }
+
+      const markupOptions = {
+        isEditor: false,
+        filters: config.filters || [],
+        locale: config.locale,
+        dataMetadata: config.dataMetadata
+      }
+
+      return {
+        label: legend?.label
+          ? processMarkupVariables(legend.label, data || config.data || [], config.markupVariables, markupOptions)
+              .processedContent
+          : legend?.label,
+        description: legend?.description
+          ? processMarkupVariables(legend.description, data || config.data || [], config.markupVariables, markupOptions)
+              .processedContent
+          : legend?.description
+      }
+    }, [
+      config.enableMarkupVariables,
+      config.markupVariables,
+      config.filters,
+      config.locale,
+      config.dataMetadata,
+      config.data,
+      data,
+      legend?.label,
+      legend?.description
+    ])
 
     const seriesWithData = getSeriesWithData(config)
     // For Radar charts, seriesWithData contains dimension keys but legend shows entity names
@@ -114,10 +151,12 @@ const Legend: React.FC<LegendProps> = forwardRef(
         aria-label='legend'
         tabIndex={0}
       >
-        {(legend.label || legend.description) && (
-          <div className={legend.description ? 'mb-3' : 'mb-2'}>
-            {legend.label && <h3 className='fw-bold cove-prose'>{parse(legend.label)}</h3>}
-            {legend.description && <p className='mt-2 cove-prose'>{parse(legend.description)}</p>}
+        {(processedLegendText.label || processedLegendText.description) && (
+          <div className={processedLegendText.description ? 'mb-3' : 'mb-2'}>
+            {processedLegendText.label && <h3 className='fw-bold cove-prose'>{parse(processedLegendText.label)}</h3>}
+            {processedLegendText.description && (
+              <p className='mt-2 cove-prose'>{parse(processedLegendText.description)}</p>
+            )}
           </div>
         )}
         <LegendGradient

--- a/packages/chart/src/test/CdcChart.dataTable.test.tsx
+++ b/packages/chart/src/test/CdcChart.dataTable.test.tsx
@@ -127,6 +127,10 @@ describe('CdcChart data table dataset wiring', () => {
       visualizationType: 'Bar',
       title: 'Chart {{source}}',
       introText: 'Intro {{source}}',
+      legend: {
+        label: 'Legend <strong>{{source}}</strong>',
+        description: 'Legend description <strong>{{source}}</strong>'
+      },
       data,
       dataMetadata: {},
       enableMarkupVariables: true,
@@ -150,7 +154,7 @@ describe('CdcChart data table dataset wiring', () => {
       }
     } as any
 
-    const { rerender } = render(<CdcChart config={config} interactionLabel='chart-metadata-test' />)
+    const { container, rerender } = render(<CdcChart config={config} interactionLabel='chart-metadata-test' />)
 
     expect(await screen.findByText('Chart')).toBeInTheDocument()
 
@@ -166,5 +170,8 @@ describe('CdcChart data table dataset wiring', () => {
 
     expect(await screen.findByText('Chart June file')).toBeInTheDocument()
     expect(screen.getByText('Intro June file')).toBeInTheDocument()
+    expect(container.textContent).toContain('Legend June file')
+    expect(container.textContent).toContain('Legend description June file')
+    expect(screen.getAllByText('June file', { selector: 'strong' }).length).toBeGreaterThanOrEqual(2)
   })
 })

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -107,7 +107,7 @@ Legend configuration is shared with core. The map package honors the shared lege
 | `legend.style` | `string` | No | `gradient` | Legend marker or gradient style. | `circles`, `boxes`, `gradient` |
 | `legend.subStyle` | `string` | No | `linear blocks` | Gradient legend treatment. | `linear blocks`, `smooth` |
 | `legend.title`, `legend.description` | `string` | No | `''` | Legend heading and description. | Supports markup-variable processing in supported map flows. |
-| `legend.descriptions` | `Record<string, string \| string[]>` | No | `{}` | Dynamic legend-description lookup used when `legend.dynamicDescription` is `true`. | Keys use the filter index and selected filter-value index, such as `0,0`. Editor-saved values may be strings or one-item string arrays. |
+| `legend.descriptions` | `Record<string, string \| string[]>` | No | `{}` | Dynamic legend-description lookup used when `legend.dynamicDescription` is `true`. | Keys use the filter index and selected filter-value index, such as `0,0`. Values support HTML parsing and markup-variable processing when `enableMarkupVariables` is `true`. Editor-saved values may be strings or one-item string arrays. |
 | `legend.specialClasses` | `{ key; label; value }[]` | No | `[]` | Extra legend classes for special cases. | Used for no-data or other override classes. |
 | `legend.unified` | `boolean` | No | `false` | Uses unified legend behavior for compatible map modes. | `true`, `false` |
 | `legend.singleColumn`, `legend.singleRow`, `legend.verticalSorted` | `boolean` | No | `false` | Layout and sorting controls for legend items. | Runtime may still adapt for available space. |

--- a/packages/map/src/components/Legend/components/Legend.tsx
+++ b/packages/map/src/components/Legend/components/Legend.tsx
@@ -49,6 +49,14 @@ const LEGEND_PADDING = 30
 
 const isFiniteNumber = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value)
 
+const normalizeLegendDescription = (description: string | string[] | undefined): string => {
+  if (Array.isArray(description)) {
+    return description.join('')
+  }
+
+  return description ?? ''
+}
+
 const formatManualRangeLabel = (entry, idx: number, items, config) => {
   const min = entry.min
   const max = entry.max
@@ -490,15 +498,24 @@ const Legend = forwardRef<HTMLDivElement, LegendProps>((props, ref) => {
                     const lookupStr = `${idx},${filter.values.indexOf(String(filter.active))}`
 
                     // Do we have a custom description for this?
-                    const desc = legend.descriptions[lookupStr] || ''
+                    const desc = normalizeLegendDescription(legend.descriptions?.[lookupStr])
 
                     if (desc.length > 0) {
                       return (
                         <p
                           key={`dynamic-description-${lookupStr}`}
-                          className={`dynamic-legend-description-${lookupStr} mt-2`}
+                          className={`dynamic-legend-description-${lookupStr} mt-2 cove-prose`}
                         >
-                          {desc}
+                          {parse(
+                            config.enableMarkupVariables && config.markupVariables?.length > 0
+                              ? processMarkupVariables(desc, config.data || [], config.markupVariables, {
+                                  isEditor: false,
+                                  filters: runtimeFilters || [],
+                                  locale: config.locale,
+                                  dataMetadata: config.dataMetadata
+                                }).processedContent
+                              : desc
+                          )}
                         </p>
                       )
                     }

--- a/packages/map/src/test/CdcMapComponent.dataTable.test.tsx
+++ b/packages/map/src/test/CdcMapComponent.dataTable.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CdcMapComponent from '../CdcMapComponent'
+import ConfigContext, { MapDispatchContext } from '../context'
+import Legend from '../components/Legend/components/Legend'
 
 const dataTableProps = vi.hoisted(() => {
   Object.defineProperty((globalThis as any).HTMLCanvasElement.prototype, 'getContext', {
@@ -175,8 +177,8 @@ describe('CdcMapComponent data table wiring', () => {
 
   it('updates metadata-backed map title and text when dataMetadata changes and data does not', async () => {
     const data = [
-      { 'FIPS Codes': '01', Rate: 10 },
-      { 'FIPS Codes': '02', Rate: 20 }
+      { 'FIPS Codes': '01', Rate: 10, Year: '2024' },
+      { 'FIPS Codes': '02', Rate: 20, Year: '2025' }
     ]
     const config = {
       type: 'map',
@@ -213,7 +215,11 @@ describe('CdcMapComponent data table wiring', () => {
         type: 'equalnumber',
         numberOfItems: 3,
         specialClasses: [],
-        unified: false
+        unified: false,
+        title: 'Static <strong>{{source}}</strong>',
+        description: 'Static description {{source}}',
+        dynamicDescription: false,
+        descriptions: {}
       },
       table: {
         forceDisplay: false,
@@ -223,7 +229,16 @@ describe('CdcMapComponent data table wiring', () => {
         indexLabel: '',
         showNonGeoData: false
       },
-      filters: []
+      filters: [
+        {
+          columnName: 'Year',
+          active: '2024',
+          values: ['2024', '2025'],
+          type: 'data',
+          showDropdown: false,
+          order: 'cust'
+        }
+      ]
     } as any
 
     const renderMap = mapConfig => (
@@ -246,5 +261,137 @@ describe('CdcMapComponent data table wiring', () => {
 
     expect(await screen.findByText('Map June file')).toBeInTheDocument()
     expect(await screen.findByText('Subtext June file')).toBeInTheDocument()
+  })
+
+  it('processes markup variables and HTML in static and dynamic map legend descriptions', async () => {
+    const config = {
+      data: [
+        { Year: '2024', Rate: 10 },
+        { Year: '2025', Rate: 20 }
+      ],
+      dataMetadata: { source: 'July file' },
+      enableMarkupVariables: true,
+      markupVariables: [
+        {
+          sourceType: 'metadata',
+          name: 'Source',
+          tag: '{{source}}',
+          metadataKey: 'source',
+          conditions: [],
+          addCommas: false
+        },
+        {
+          sourceType: 'column',
+          name: 'Year',
+          tag: '{{year}}',
+          columnName: 'Year',
+          conditions: [],
+          addCommas: false,
+          selectionMode: 'first'
+        }
+      ],
+      columns: {
+        primary: { name: 'Rate' }
+      },
+      map: {
+        patterns: []
+      },
+      visual: {
+        additionalCityStyles: [],
+        cityStyleLabel: ''
+      },
+      legend: {
+        type: 'equalnumber',
+        numberOfItems: 3,
+        specialClasses: [],
+        unified: false,
+        title: 'Static <strong>{{source}}</strong>',
+        description: 'Static description <strong>{{source}}</strong>',
+        dynamicDescription: false,
+        descriptions: {
+          '0,1': ['Updated <strong>{{source}}</strong> for {{year}}']
+        }
+      },
+      filters: [
+        {
+          columnName: 'Year',
+          active: '2024',
+          values: ['2024', '2025'],
+          type: 'data',
+          showDropdown: false,
+          order: 'cust'
+        }
+      ]
+    } as any
+
+    const renderLegend = legendConfig =>
+      render(
+        <ConfigContext.Provider
+          value={
+            {
+              config: legendConfig,
+              currentViewport: 'lg',
+              dimensions: [640, 360],
+              mapId: 'legend-markup-test',
+              runtimeBubbleLegend: [],
+              runtimeFilters: [{ active: '2024', values: ['2024', '2025'] }],
+              runtimeLegend: {
+                disabledAmt: 0,
+                items: [{ color: '#075290', label: '0 - 10', rawLabel: '0 - 10', special: false }]
+              }
+            } as any
+          }
+        >
+          <MapDispatchContext.Provider value={vi.fn()}>
+            <Legend
+              bubbleLegendScale={1}
+              containerWidthPadding={0}
+              currentViewport='lg'
+              dimensions={[640, 360]}
+              interactionLabel='map-legend-markup-test'
+              skipId='legend-markup-test'
+            />
+          </MapDispatchContext.Provider>
+        </ConfigContext.Provider>
+      )
+
+    const { container, rerender } = renderLegend(config)
+
+    await waitFor(() => expect(container.textContent).toContain('Static July file'))
+    expect(container.textContent).toContain('Static description July file')
+    expect(screen.getAllByText('July file', { selector: 'strong' }).length).toBeGreaterThanOrEqual(2)
+
+    rerender(
+      <ConfigContext.Provider
+        value={
+          {
+            config: { ...config, legend: { ...config.legend, dynamicDescription: true } },
+            currentViewport: 'lg',
+            dimensions: [640, 360],
+            mapId: 'legend-markup-test',
+            runtimeBubbleLegend: [],
+            runtimeFilters: [{ active: '2025', columnName: 'Year', values: ['2024', '2025'] }],
+            runtimeLegend: {
+              disabledAmt: 0,
+              items: [{ color: '#075290', label: '0 - 10', rawLabel: '0 - 10', special: false }]
+            }
+          } as any
+        }
+      >
+        <MapDispatchContext.Provider value={vi.fn()}>
+          <Legend
+            bubbleLegendScale={1}
+            containerWidthPadding={0}
+            currentViewport='lg'
+            dimensions={[640, 360]}
+            interactionLabel='map-legend-markup-test'
+            skipId='legend-markup-test'
+          />
+        </MapDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+
+    await waitFor(() => expect(container.textContent).toContain('Updated July file for 2025'))
+    expect(screen.getAllByText('July file', { selector: 'strong' }).length).toBeGreaterThanOrEqual(2)
   })
 })


### PR DESCRIPTION
## Summary

Adds markup variable support to chart legends and map dynamic legends.

## Testing Steps

Open [this chart config](https://github.com/user-attachments/files/30090888/metadata-variables.json) and add {{lastUpdated}} to the legend description, see that it renders the variable text.
