### PR TITLE
DEV-13355 Update table screen reader so it only reads once for headers

### DIFF
--- a/packages/core/components/DataTable/DataTable.test.tsx
+++ b/packages/core/components/DataTable/DataTable.test.tsx
@@ -1089,16 +1089,18 @@ describe('DataTable sort control accessibility', () => {
       const labelledBy = header.getAttribute('aria-labelledby')
       // Every sortable header exposes its column label as the accessible name...
       expect(labelledBy).toBeTruthy()
-      const labelEl = container.querySelector(`#${CSS.escape(labelledBy!)}`)
+      const labelEl = document.getElementById(labelledBy!)
       expect(labelEl).not.toBeNull()
+      expect(container.contains(labelEl)).toBe(true)
       // ...and that name must NOT include the sort-control instruction, so it is not
       // re-read when a screen reader steps through associated data cells.
       expect(labelEl!.textContent || '').not.toMatch(instructionPattern)
 
       const describedBy = header.getAttribute('aria-describedby')
       if (describedBy) {
-        const descEl = container.querySelector(`#${CSS.escape(describedBy)}`)
+        const descEl = document.getElementById(describedBy)
         expect(descEl).not.toBeNull()
+        expect(container.contains(descEl)).toBe(true)
         // The dynamic instruction stays available as a description (announced when the
         // header cell itself is focused), so the sort affordance is preserved.
         expect(descEl!.textContent || '').toMatch(instructionPattern)
@@ -1251,7 +1253,9 @@ describe('DataTable sort control accessibility', () => {
     const descriptionFor = (label: string) => {
       const header = screen.getByText(label).closest('th') as HTMLElement
       const descId = header.getAttribute('aria-describedby') as string
-      return container.querySelector(`#${CSS.escape(descId)}`)?.textContent || ''
+      const descEl = document.getElementById(descId)
+      expect(container.contains(descEl)).toBe(true)
+      return descEl?.textContent || ''
     }
 
     const locationHeader = screen.getByText('Location').closest('th') as HTMLElement

--- a/packages/core/components/DataTable/DataTable.test.tsx
+++ b/packages/core/components/DataTable/DataTable.test.tsx
@@ -1089,27 +1089,53 @@ describe('DataTable sort control accessibility', () => {
       const labelledBy = header.getAttribute('aria-labelledby')
       // Every sortable header exposes its column label as the accessible name...
       expect(labelledBy).toBeTruthy()
-      const labelEl = document.getElementById(labelledBy!)
-      expect(labelEl).not.toBeNull()
-      expect(container.contains(labelEl)).toBe(true)
+      const labelIds = (labelledBy || '').split(/\s+/).filter(Boolean)
+      expect(labelIds.length).toBeGreaterThan(0)
+      
+      const labelEls = labelIds.map(id => {
+        const el = container.querySelector(`[id="${id}"]`)
+        expect(el).not.toBeNull()
+        expect(container.contains(el)).toBe(true)
+        return el
+      })
+      
+      // Concatenate text content from all label elements (accessible name)
+      const labelText = labelEls.map(el => el!.textContent || '').join(' ')
       // ...and that name must NOT include the sort-control instruction, so it is not
       // re-read when a screen reader steps through associated data cells.
-      expect(labelEl!.textContent || '').not.toMatch(instructionPattern)
+      expect(labelText).not.toMatch(instructionPattern)
 
       const describedBy = header.getAttribute('aria-describedby')
       if (describedBy) {
-        const descEl = document.getElementById(describedBy)
-        expect(descEl).not.toBeNull()
-        expect(container.contains(descEl)).toBe(true)
+        const descIds = describedBy.split(/\s+/).filter(Boolean)
+        expect(descIds.length).toBeGreaterThan(0)
+        
+        const descEls = descIds.map(id => {
+          const el = container.querySelector(`[id="${id}"]`)
+          expect(el).not.toBeNull()
+          expect(container.contains(el)).toBe(true)
+          return el
+        })
+        
+        // Concatenate text content from all description elements
+        const descText = descEls.map(el => el!.textContent || '').join(' ')
         // The dynamic instruction stays available as a description (announced when the
         // header cell itself is focused), so the sort affordance is preserved.
-        expect(descEl!.textContent || '').toMatch(instructionPattern)
-        // It is aria-hidden so screen readers do not stop on it a second time while
-        // swiping the header, and it is excluded from the header text content that
+        expect(descText).toMatch(instructionPattern)
+        
+        // All description elements should be aria-hidden so screen readers do not stop on them
+        // while swiping the header, and they are excluded from the header text content that
         // gets re-announced on associated data cells.
-        expect(descEl!.getAttribute('aria-hidden')).toBe('true')
-        // The description must live outside the label element that provides the name.
-        expect(labelEl!.contains(descEl)).toBe(false)
+        descEls.forEach(el => {
+          expect(el!.getAttribute('aria-hidden')).toBe('true')
+        })
+        
+        // Description elements must live outside the label elements that provide the name.
+        labelEls.forEach(labelEl => {
+          descEls.forEach(descEl => {
+            expect(labelEl!.contains(descEl)).toBe(false)
+          })
+        })
       }
     })
   }
@@ -1253,9 +1279,13 @@ describe('DataTable sort control accessibility', () => {
     const descriptionFor = (label: string) => {
       const header = screen.getByText(label).closest('th') as HTMLElement
       const descId = header.getAttribute('aria-describedby') as string
-      const descEl = document.getElementById(descId)
-      expect(container.contains(descEl)).toBe(true)
-      return descEl?.textContent || ''
+      const descIds = descId.split(/\s+/).filter(Boolean)
+      const descEls = descIds.map(id => {
+        const el = container.querySelector(`[id="${id}"]`)
+        expect(container.contains(el)).toBe(true)
+        return el
+      })
+      return descEls.map(el => el!.textContent || '').join(' ')
     }
 
     const locationHeader = screen.getByText('Location').closest('th') as HTMLElement

--- a/packages/core/components/DataTable/DataTable.test.tsx
+++ b/packages/core/components/DataTable/DataTable.test.tsx
@@ -1076,3 +1076,133 @@ describe('DataTable search', () => {
     expect(screen.queryByText('Cook')).not.toBeInTheDocument()
   })
 })
+
+describe('DataTable sort control accessibility', () => {
+  const assertHeaderSortWiring = (
+    container: HTMLElement,
+    instructionPattern: RegExp
+  ) => {
+    const headers = Array.from(container.querySelectorAll('th[role="columnheader"]'))
+    expect(headers.length).toBeGreaterThan(0)
+
+    headers.forEach(header => {
+      const labelledBy = header.getAttribute('aria-labelledby')
+      // Every sortable header exposes its column label as the accessible name...
+      expect(labelledBy).toBeTruthy()
+      const labelEl = container.querySelector(`#${CSS.escape(labelledBy!)}`)
+      expect(labelEl).not.toBeNull()
+      // ...and that name must NOT include the sort-control instruction, so it is not
+      // re-read when a screen reader steps through associated data cells.
+      expect(labelEl!.textContent || '').not.toMatch(instructionPattern)
+
+      const describedBy = header.getAttribute('aria-describedby')
+      if (describedBy) {
+        const descEl = container.querySelector(`#${CSS.escape(describedBy)}`)
+        expect(descEl).not.toBeNull()
+        // The dynamic instruction stays available as a description (announced when the
+        // header cell itself is focused), so the sort affordance is preserved.
+        expect(descEl!.textContent || '').toMatch(instructionPattern)
+        // It is aria-hidden so screen readers do not stop on it a second time while
+        // swiping the header, and it is excluded from the header text content that
+        // gets re-announced on associated data cells.
+        expect(descEl!.getAttribute('aria-hidden')).toBe('true')
+        // The description must live outside the label element that provides the name.
+        expect(labelEl!.contains(descEl)).toBe(false)
+      }
+    })
+  }
+
+  it('keeps chart data-table sort instructions out of the header name but available as a description', () => {
+    const runtimeData = [
+      { location: 'São Tomé and Príncipe', site_id: 'SITE-001' },
+      { location: 'Junín', site_id: 'SITE-002' }
+    ]
+    const config = {
+      type: 'table',
+      visualizationType: 'Data Table',
+      general: {},
+      columns: {
+        location: { name: 'location', label: 'Location', dataTable: true },
+        siteId: { name: 'site_id', label: 'Site ID', dataTable: true }
+      },
+      dataFormat: {},
+      table: {
+        label: 'Data Table',
+        search: false,
+        expanded: true,
+        collapsible: false,
+        showDownloadLinkBelow: false,
+        download: false,
+        showVertical: true,
+        indexLabel: '',
+        cellMinWidth: 0
+      },
+      runtime: {},
+      preliminaryData: []
+    } as any
+
+    const { container } = render(
+      <DataTable
+        config={config}
+        columns={config.columns}
+        rawData={runtimeData}
+        runtimeData={runtimeData as any}
+        expandDataTable={true}
+        tableTitle='Data Table'
+        viewport='lg'
+        tabbingId='sort-a11y-chart-data-table'
+      />
+    )
+
+    assertHeaderSortWiring(container, /Press command, modifier, or enter key to sort by/i)
+  })
+
+  it('keeps map data-table sort instructions out of the header name but available as a description', () => {
+    const runtimeData = {
+      AZ: { geo: 'AZ', value: '10' },
+      CA: { geo: 'CA', value: '20' }
+    }
+
+    const config = {
+      type: 'map',
+      visualizationType: 'Map',
+      general: { geoType: 'us', type: 'map' },
+      columns: {
+        geo: { name: 'geo', label: 'Location', dataTable: true },
+        value: { name: 'value', label: 'Value', dataTable: true, prefix: '', suffix: '', useCommas: false }
+      },
+      legend: { specialClasses: [] },
+      table: {
+        label: 'Data Table',
+        search: false,
+        expanded: true,
+        collapsible: false,
+        showDownloadLinkBelow: false,
+        download: false,
+        indexLabel: '',
+        cellMinWidth: 0
+      },
+      runtime: { uniqueId: 'test-map' },
+      preliminaryData: []
+    } as any
+
+    const { container } = render(
+      <DataTable
+        config={config}
+        columns={config.columns}
+        rawData={Object.values(runtimeData)}
+        runtimeData={runtimeData as any}
+        expandDataTable={true}
+        tableTitle='Data Table'
+        viewport='lg'
+        tabbingId='sort-a11y-map-data-table'
+        displayGeoName={row => (row === 'AZ' ? 'Arizona' : row === 'CA' ? 'California' : row)}
+        formatLegendLocation={row => row}
+        applyLegendToRow={() => ['#000']}
+        getPatternForRow={() => null}
+      />
+    )
+
+    assertHeaderSortWiring(container, /Sort by .+ in (ascending|descending) order/i)
+  })
+})

--- a/packages/core/components/DataTable/DataTable.test.tsx
+++ b/packages/core/components/DataTable/DataTable.test.tsx
@@ -1106,8 +1106,8 @@ describe('DataTable sort control accessibility', () => {
       expect(labelText).not.toMatch(instructionPattern)
 
       const describedBy = header.getAttribute('aria-describedby')
+      expect(describedBy).toBeTruthy()
       if (describedBy) {
-        const descIds = describedBy.split(/\s+/).filter(Boolean)
         expect(descIds.length).toBeGreaterThan(0)
         
         const descEls = descIds.map(id => {

--- a/packages/core/components/DataTable/DataTable.test.tsx
+++ b/packages/core/components/DataTable/DataTable.test.tsx
@@ -1108,6 +1108,7 @@ describe('DataTable sort control accessibility', () => {
       const describedBy = header.getAttribute('aria-describedby')
       expect(describedBy).toBeTruthy()
       if (describedBy) {
+        const descIds = describedBy.split(/\s+/).filter(Boolean)
         expect(descIds.length).toBeGreaterThan(0)
         
         const descEls = descIds.map(id => {

--- a/packages/core/components/DataTable/DataTable.test.tsx
+++ b/packages/core/components/DataTable/DataTable.test.tsx
@@ -1205,4 +1205,72 @@ describe('DataTable sort control accessibility', () => {
 
     assertHeaderSortWiring(container, /Sort by .+ in (ascending|descending) order/i)
   })
+
+  it('announces the pending sort action in the header description as the sort cycles', () => {
+    const runtimeData = [
+      { location: 'Alpha', site_id: 'SITE-002' },
+      { location: 'Bravo', site_id: 'SITE-001' }
+    ]
+    const config = {
+      type: 'table',
+      visualizationType: 'Data Table',
+      general: {},
+      columns: {
+        location: { name: 'location', label: 'Location', dataTable: true },
+        siteId: { name: 'site_id', label: 'Site ID', dataTable: true }
+      },
+      dataFormat: {},
+      table: {
+        label: 'Data Table',
+        search: false,
+        expanded: true,
+        collapsible: false,
+        showDownloadLinkBelow: false,
+        download: false,
+        showVertical: true,
+        indexLabel: '',
+        cellMinWidth: 0
+      },
+      runtime: {},
+      preliminaryData: []
+    } as any
+
+    const { container } = render(
+      <DataTable
+        config={config}
+        columns={config.columns}
+        rawData={runtimeData}
+        runtimeData={runtimeData as any}
+        expandDataTable={true}
+        tableTitle='Data Table'
+        viewport='lg'
+        tabbingId='sort-a11y-direction-data-table'
+      />
+    )
+
+    const descriptionFor = (label: string) => {
+      const header = screen.getByText(label).closest('th') as HTMLElement
+      const descId = header.getAttribute('aria-describedby') as string
+      return container.querySelector(`#${CSS.escape(descId)}`)?.textContent || ''
+    }
+
+    const locationHeader = screen.getByText('Location').closest('th') as HTMLElement
+
+    // No column sorted yet: activating any header will sort ascending first, so that is what
+    // the description announces.
+    expect(descriptionFor('Location')).toMatch(/in ascending order/)
+    expect(descriptionFor('Site ID')).toMatch(/in ascending order/)
+
+    // After sorting ascending, activating again will sort descending — the description must
+    // reflect the pending action, not the current state.
+    fireEvent.click(locationHeader)
+    expect(descriptionFor('Location')).toMatch(/in descending order/)
+
+    // After sorting descending, activating again clears the sort.
+    fireEvent.click(locationHeader)
+    expect(descriptionFor('Location')).toMatch(/remove the sort/i)
+
+    // A column that is not the active sort still announces the default ascending action.
+    expect(descriptionFor('Site ID')).toMatch(/in ascending order/)
+  })
 })

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { getChartCellValue } from '../helpers/getChartCellValue'
 import { getSeriesName } from '../helpers/getSeriesName'
 import { getDataSeriesColumns } from '../helpers/getDataSeriesColumns'
@@ -34,6 +35,7 @@ const ChartHeader = ({
   interactionLabel,
   dataSeriesColumns: providedDataSeriesColumns
 }: ChartHeaderProps) => {
+  const headerIdBase = useId()
   const groupBy = config.table?.groupBy
   if (!data) return
   let dataSeriesColumns = [...(providedDataSeriesColumns || getDataSeriesColumns(config, isVertical, data))]
@@ -46,12 +48,12 @@ const ChartHeader = ({
     }
   }
 
-  const ScreenReaderSortByText = ({ text, config, sortBy }) => {
+  // Builds the dynamic sort-control instruction text for a column header, or null when the
+  // control is not applicable. Returned as a string (not an element) so callers can decide
+  // whether to render it and reference it via aria-describedby on the header cell.
+  const getSortInstructionText = (text, config, sortBy): string | null => {
     const notApplicableText = 'Not Applicable'
     let columnHeaderText = `${text} `
-    if (text !== '__series__' || text !== '') {
-      columnHeaderText = `${text} `
-    }
 
     if ((text === '__series__' || text === '') && !config.table.indexLabel) {
       columnHeaderText = notApplicableText
@@ -61,13 +63,12 @@ const ChartHeader = ({
       columnHeaderText = config.table.indexLabel
     }
 
-    if (columnHeaderText === notApplicableText) return
+    if (columnHeaderText === notApplicableText) return null
 
-    return (
-      <span className='cdcdataviz-sr-only'>{`Press command, modifier, or enter key to sort by ${columnHeaderText} in ${
-        sortBy.column !== columnHeaderText ? 'ascending' : sortBy.column === 'desc' ? 'descending' : 'ascending'
-      }  order`}</span>
-    )
+    const order =
+      sortBy.column !== columnHeaderText ? 'ascending' : sortBy.column === 'desc' ? 'descending' : 'ascending'
+
+    return `Press command, modifier, or enter key to sort by ${columnHeaderText} in ${order}  order`
   }
 
   const ColumnHeadingText = ({ text, config }: { text: string; config: ChartConfig }) => {
@@ -104,6 +105,9 @@ const ChartHeader = ({
           const text = getSeriesName(column, config)
           const newSortBy = getNewSortBy(sortBy, column, index)
           const sortByAsc = sortBy.column === column ? sortBy.asc : undefined
+          const headingId = `${headerIdBase}-heading-${index}`
+          const descId = `${headerIdBase}-desc-${index}`
+          const sortInstruction = getSortInstructionText(text, config, sortBy)
 
           return (
             <th
@@ -116,6 +120,8 @@ const ChartHeader = ({
               tabIndex={0}
               role='columnheader'
               scope='col'
+              aria-labelledby={headingId}
+              aria-describedby={sortInstruction ? descId : undefined}
               onClick={() => {
                 if (hasRowType) return
                 publishAnalyticsEvent({
@@ -155,9 +161,15 @@ const ChartHeader = ({
                   : { 'aria-sort': 'descending' }
                 : null)}
             >
-              <ColumnHeadingText text={text} config={config} />
+              <span id={headingId}>
+                <ColumnHeadingText text={text} config={config} />
+              </span>
               <SortIcon ascending={sortByAsc} />
-              <ScreenReaderSortByText sortBy={sortBy} config={config} text={text} />
+              {sortInstruction && (
+                <span id={descId} className='cdcdataviz-sr-only' aria-hidden='true'>
+                  {sortInstruction}
+                </span>
+              )}
             </th>
           )
         })}
@@ -176,6 +188,9 @@ const ChartHeader = ({
             row !== '__series__' ? getChartCellValue(row, column, config, data, rightAxisItemsMap) : '__series__'
           const newSortBy = getNewSortBy(sortBy, column, index)
           const sortByAsc = sortBy.colIndex === index ? sortBy.asc : undefined
+          const headingId = `${headerIdBase}-heading-${index}`
+          const descId = `${headerIdBase}-desc-${index}`
+          const sortInstruction = getSortInstructionText(text, config, sortBy)
           return (
             <th
               style={{
@@ -187,6 +202,8 @@ const ChartHeader = ({
               tabIndex={0}
               role='columnheader'
               scope='col'
+              aria-labelledby={headingId}
+              aria-describedby={sortInstruction ? descId : undefined}
               onClick={() => {
                 if (hasRowType) return
                 publishAnalyticsEvent({
@@ -225,10 +242,16 @@ const ChartHeader = ({
                   : { 'aria-sort': 'descending' }
                 : null)}
             >
-              <ColumnHeadingText text={text} config={config} />
+              <span id={headingId}>
+                <ColumnHeadingText text={text} config={config} />
+              </span>
               <SortIcon ascending={sortByAsc} />
 
-              <ScreenReaderSortByText text={text} config={config} sortBy={sortBy} />
+              {sortInstruction && (
+                <span id={descId} className='cdcdataviz-sr-only' aria-hidden='true'>
+                  {sortInstruction}
+                </span>
+              )}
             </th>
           )
         })}

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -46,6 +46,12 @@ export const SortInstructionDescription = ({ descId, sortInstruction }: { descId
 // non-string or empty input, ensuring sort instructions are never built
 // from raw markup or undefined values.
 const toPlainText = (value: unknown): string => {
+  if (value === null || value === undefined) return ''
+
+  // Preserve primitive header labels (e.g., numeric axis values), but avoid turning objects/React nodes
+  // into "[object Object]".
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value)
+
   if (typeof value !== 'string' || !value) return ''
   return new DOMParser().parseFromString(value, 'text/html').body.textContent?.trim() ?? ''
 }

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -29,6 +29,50 @@ const ColumnHeadingText = ({ text, config }: { text: string; config: ChartConfig
   return parse(text)
 }
 
+// Renders the sort instruction description span, exposed via aria-describedby on the header cell.
+// Intentionally aria-hidden to exclude from header swiping and data cell re-announcements, while
+// still readable on header focus per the accessible description spec. An automated review may flag
+// reading a hidden element — this is deliberate.
+export const SortInstructionDescription = ({ descId, sortInstruction }: { descId: string; sortInstruction: string | null }) => {
+  if (!sortInstruction) return null
+  return (
+    <span id={descId} className='cdcdataviz-sr-only' aria-hidden='true'>
+      {sortInstruction}
+    </span>
+  )
+}
+
+// Builds the dynamic sort-control instruction text for a column header, or null when the
+// control is not applicable. Returned as a string (not an element) so callers can decide
+// whether to render it and reference it via aria-describedby on the header cell.
+// `nextSortAsc` is the direction that activating the control WILL apply (the `getNewSortBy`
+// result): `true` -> ascending, `false` -> descending, `undefined` -> clears the sort. Using
+// the pending direction keeps the description in sync with what pressing the header does,
+// instead of restating the column's current state.
+const getSortInstructionText = (text: string, config: ChartConfig, nextSortAsc: boolean | undefined): string | null => {
+  const notApplicableText = 'Not Applicable'
+  let columnHeaderText = `${text}`
+
+  if ((text === '__series__' || text === '') && !config.table.indexLabel) {
+    columnHeaderText = notApplicableText
+  }
+
+  if ((text === '__series__' || text === '') && config.table.indexLabel) {
+    columnHeaderText = String(config.table.indexLabel)
+  }
+
+  if (columnHeaderText === notApplicableText) return null
+
+  const action =
+    nextSortAsc === true
+      ? `sort by ${columnHeaderText} in ascending order`
+      : nextSortAsc === false
+        ? `sort by ${columnHeaderText} in descending order`
+        : `remove the sort from ${columnHeaderText}`
+
+  return `Press command, modifier, or enter key to ${action}`
+}
+
 type ChartHeaderProps = {
   data
   isVertical
@@ -65,37 +109,6 @@ const ChartHeader = ({
       // assign headers with groupHeaderRemoved
       dataSeriesColumns = groupHeaderRemoved
     }
-  }
-
-  // Builds the dynamic sort-control instruction text for a column header, or null when the
-  // control is not applicable. Returned as a string (not an element) so callers can decide
-  // whether to render it and reference it via aria-describedby on the header cell.
-  // `nextSortAsc` is the direction that activating the control WILL apply (the `getNewSortBy`
-  // result): `true` -> ascending, `false` -> descending, `undefined` -> clears the sort. Using
-  // the pending direction keeps the description in sync with what pressing the header does,
-  // instead of restating the column's current state.
-  const getSortInstructionText = (text, config, nextSortAsc: boolean | undefined): string | null => {
-    const notApplicableText = 'Not Applicable'
-    let columnHeaderText = `${text}`
-
-    if ((text === '__series__' || text === '') && !config.table.indexLabel) {
-      columnHeaderText = notApplicableText
-    }
-
-    if ((text === '__series__' || text === '') && config.table.indexLabel) {
-      columnHeaderText = config.table.indexLabel
-    }
-
-    if (columnHeaderText === notApplicableText) return null
-
-    const action =
-      nextSortAsc === true
-        ? `sort by ${columnHeaderText} in ascending order`
-        : nextSortAsc === false
-          ? `sort by ${columnHeaderText} in descending order`
-          : `remove the sort from ${columnHeaderText}`
-
-    return `Press command, modifier, or enter key to ${action}`
   }
 
   if (isVertical) {
@@ -176,17 +189,7 @@ const ChartHeader = ({
                 <ColumnHeadingText text={text} config={config} />
               </span>
               <SortIcon ascending={sortByAsc} />
-              {sortInstruction && (
-                // Sort instruction text. It is intentionally aria-hidden so screen readers do NOT
-                // stop on it while swiping the header, and so it is excluded from the header cell's
-                // text content that gets re-announced on every associated data cell. It is still
-                // exposed on purpose: the th references it via aria-describedby, and per the
-                // accessible description spec a hidden element referenced by aria-describedby is
-                // still read when the header itself receives focus.
-                <span id={descId} className='cdcdataviz-sr-only' aria-hidden='true'>
-                  {sortInstruction}
-                </span>
-              )}
+              <SortInstructionDescription descId={descId} sortInstruction={sortInstruction} />
             </th>
           )
         })}
@@ -263,19 +266,7 @@ const ChartHeader = ({
                 <ColumnHeadingText text={text} config={config} />
               </span>
               <SortIcon ascending={sortByAsc} />
-
-              {sortInstruction && (
-                // Sort instruction text. It is intentionally aria-hidden so screen readers do NOT
-                // stop on it while swiping the header, and so it is excluded from the header cell's
-                // text content that gets re-announced on every associated data cell. It is still
-                // exposed on purpose: the th references it via aria-describedby, and per the
-                // accessible description spec a hidden element referenced by aria-describedby is
-                // still read when the header itself receives focus. This is why an automated review
-                // may flag reading a hidden element — it is deliberate.
-                <span id={descId} className='cdcdataviz-sr-only' aria-hidden='true'>
-                  {sortInstruction}
-                </span>
-              )}
+              <SortInstructionDescription descId={descId} sortInstruction={sortInstruction} />
             </th>
           )
         })}

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -10,6 +10,25 @@ import { ChartConfig } from '@cdc/chart/src/types/ChartConfig'
 import { publishAnalyticsEvent } from '../../../helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
 
+const ColumnHeadingText = ({ text, config }: { text: string; config: ChartConfig }) => {
+  const notApplicableText = 'Not Applicable'
+  if (text === '_pivotedFrom') return ''
+  if (text === '__series__') {
+    if (config.table.indexLabel) {
+      return parse(String(config.table.indexLabel))
+    } else {
+      return <ScreenReaderText as='span'>{notApplicableText}</ScreenReaderText>
+    }
+  }
+
+  //  handle any unexpected values
+  if (typeof text !== 'string') {
+    return parse('')
+  }
+
+  return parse(text)
+}
+
 type ChartHeaderProps = {
   data
   isVertical
@@ -71,24 +90,6 @@ const ChartHeader = ({
     return `Press command, modifier, or enter key to sort by ${columnHeaderText} in ${order}  order`
   }
 
-  const ColumnHeadingText = ({ text, config }: { text: string; config: ChartConfig }) => {
-    const notApplicableText = 'Not Applicable'
-    if (text === '_pivotedFrom') return ''
-    if (text === '__series__') {
-      if (config.table.indexLabel) {
-        return parse(String(config.table.indexLabel))
-      } else {
-        return <ScreenReaderText as='span'>{notApplicableText}</ScreenReaderText>
-      }
-    }
-
-    //  handle any unexpected values
-    if (typeof text !== 'string') {
-      return parse('')
-    }
-
-    return parse(text)
-  }
   if (isVertical) {
     if (hasRowType) {
       // find the row type column and place it at the beginning of the array

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -42,6 +42,14 @@ export const SortInstructionDescription = ({ descId, sortInstruction }: { descId
   )
 }
 
+// Strips HTML tags from a value and returns plain text. Returns '' for
+// non-string or empty input, ensuring sort instructions are never built
+// from raw markup or undefined values.
+const toPlainText = (value: unknown): string => {
+  if (typeof value !== 'string' || !value) return ''
+  return new DOMParser().parseFromString(value, 'text/html').body.textContent?.trim() ?? ''
+}
+
 // Builds the dynamic sort-control instruction text for a column header, or null when the
 // control is not applicable. Returned as a string (not an element) so callers can decide
 // whether to render it and reference it via aria-describedby on the header cell.
@@ -50,18 +58,17 @@ export const SortInstructionDescription = ({ descId, sortInstruction }: { descId
 // the pending direction keeps the description in sync with what pressing the header does,
 // instead of restating the column's current state.
 const getSortInstructionText = (text: string, config: ChartConfig, nextSortAsc: boolean | undefined): string | null => {
-  const notApplicableText = 'Not Applicable'
-  let columnHeaderText = `${text}`
+  let columnHeaderText: string
 
-  if ((text === '__series__' || text === '') && !config.table.indexLabel) {
-    columnHeaderText = notApplicableText
+  if (text === '__series__' || text === '') {
+    if (!config.table.indexLabel) return null
+    columnHeaderText = toPlainText(config.table.indexLabel)
+  } else {
+    columnHeaderText = toPlainText(text)
   }
 
-  if ((text === '__series__' || text === '') && config.table.indexLabel) {
-    columnHeaderText = String(config.table.indexLabel)
-  }
-
-  if (columnHeaderText === notApplicableText) return null
+  // If the label reduces to empty after stripping markup (or was non-string), bail out.
+  if (!columnHeaderText) return null
 
   const action =
     nextSortAsc === true
@@ -256,7 +263,7 @@ const ChartHeader = ({
                 }
               }}
               className={sortBy.colIndex === index ? (sortBy.asc ? 'sort sort-asc' : 'sort sort-desc') : 'sort'}
-              {...(sortBy.column === text
+              {...(sortBy.colIndex === index
                 ? sortBy.asc
                   ? { 'aria-sort': 'ascending' }
                   : { 'aria-sort': 'descending' }

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -116,7 +116,9 @@ const ChartHeader = ({
           const sortByAsc = sortBy.column === column ? sortBy.asc : undefined
           const headingId = `${headerIdBase}-heading-${index}`
           const descId = `${headerIdBase}-desc-${index}`
-          const sortInstruction = getSortInstructionText(text, config, newSortBy.asc)
+          // hasRowType tables are not sortable — omit the instruction so screen readers
+          // don't announce a sort action that the click/keydown handler will ignore.
+          const sortInstruction = hasRowType ? null : getSortInstructionText(text, config, newSortBy.asc)
 
           return (
             <th
@@ -126,7 +128,7 @@ const ChartHeader = ({
                 paddingRight: '1.8em'
               }}
               key={`col-header-${column}__${index}`}
-              tabIndex={0}
+              tabIndex={hasRowType ? undefined : 0}
               role='columnheader'
               scope='col'
               aria-labelledby={headingId}
@@ -164,7 +166,7 @@ const ChartHeader = ({
                 }
               }}
               className={sortBy.column === column ? (sortBy.asc ? 'sort sort-asc' : 'sort sort-desc') : 'sort'}
-              {...(sortBy.column === column
+              {...(!hasRowType && sortBy.column === column
                 ? sortBy.asc
                   ? { 'aria-sort': 'ascending' }
                   : { 'aria-sort': 'descending' }

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -70,9 +70,13 @@ const ChartHeader = ({
   // Builds the dynamic sort-control instruction text for a column header, or null when the
   // control is not applicable. Returned as a string (not an element) so callers can decide
   // whether to render it and reference it via aria-describedby on the header cell.
-  const getSortInstructionText = (text, config, sortBy): string | null => {
+  // `nextSortAsc` is the direction that activating the control WILL apply (the `getNewSortBy`
+  // result): `true` -> ascending, `false` -> descending, `undefined` -> clears the sort. Using
+  // the pending direction keeps the description in sync with what pressing the header does,
+  // instead of restating the column's current state.
+  const getSortInstructionText = (text, config, nextSortAsc: boolean | undefined): string | null => {
     const notApplicableText = 'Not Applicable'
-    let columnHeaderText = `${text} `
+    let columnHeaderText = `${text}`
 
     if ((text === '__series__' || text === '') && !config.table.indexLabel) {
       columnHeaderText = notApplicableText
@@ -84,10 +88,14 @@ const ChartHeader = ({
 
     if (columnHeaderText === notApplicableText) return null
 
-    const order =
-      sortBy.column !== columnHeaderText ? 'ascending' : sortBy.column === 'desc' ? 'descending' : 'ascending'
+    const action =
+      nextSortAsc === true
+        ? `sort by ${columnHeaderText} in ascending order`
+        : nextSortAsc === false
+          ? `sort by ${columnHeaderText} in descending order`
+          : `remove the sort from ${columnHeaderText}`
 
-    return `Press command, modifier, or enter key to sort by ${columnHeaderText} in ${order}  order`
+    return `Press command, modifier, or enter key to ${action}`
   }
 
   if (isVertical) {
@@ -108,7 +116,7 @@ const ChartHeader = ({
           const sortByAsc = sortBy.column === column ? sortBy.asc : undefined
           const headingId = `${headerIdBase}-heading-${index}`
           const descId = `${headerIdBase}-desc-${index}`
-          const sortInstruction = getSortInstructionText(text, config, sortBy)
+          const sortInstruction = getSortInstructionText(text, config, newSortBy.asc)
 
           return (
             <th
@@ -167,6 +175,12 @@ const ChartHeader = ({
               </span>
               <SortIcon ascending={sortByAsc} />
               {sortInstruction && (
+                // Sort instruction text. It is intentionally aria-hidden so screen readers do NOT
+                // stop on it while swiping the header, and so it is excluded from the header cell's
+                // text content that gets re-announced on every associated data cell. It is still
+                // exposed on purpose: the th references it via aria-describedby, and per the
+                // accessible description spec a hidden element referenced by aria-describedby is
+                // still read when the header itself receives focus.
                 <span id={descId} className='cdcdataviz-sr-only' aria-hidden='true'>
                   {sortInstruction}
                 </span>
@@ -191,7 +205,7 @@ const ChartHeader = ({
           const sortByAsc = sortBy.colIndex === index ? sortBy.asc : undefined
           const headingId = `${headerIdBase}-heading-${index}`
           const descId = `${headerIdBase}-desc-${index}`
-          const sortInstruction = getSortInstructionText(text, config, sortBy)
+          const sortInstruction = getSortInstructionText(text, config, newSortBy.asc)
           return (
             <th
               style={{
@@ -249,6 +263,13 @@ const ChartHeader = ({
               <SortIcon ascending={sortByAsc} />
 
               {sortInstruction && (
+                // Sort instruction text. It is intentionally aria-hidden so screen readers do NOT
+                // stop on it while swiping the header, and so it is excluded from the header cell's
+                // text content that gets re-announced on every associated data cell. It is still
+                // exposed on purpose: the th references it via aria-describedby, and per the
+                // accessible description spec a hidden element referenced by aria-describedby is
+                // still read when the header itself receives focus. This is why an automated review
+                // may flag reading a hidden element — it is deliberate.
                 <span id={descId} className='cdcdataviz-sr-only' aria-hidden='true'>
                   {sortInstruction}
                 </span>

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -46,12 +46,12 @@ export const SortInstructionDescription = ({ descId, sortInstruction }: { descId
 // non-string or empty input, ensuring sort instructions are never built
 // from raw markup or undefined values.
 const toPlainText = (value: unknown): string => {
-  if (value === null || value === undefined) return ''
-
-  // Preserve primitive header labels (e.g., numeric axis values), but avoid turning objects/React nodes
-  // into "[object Object]".
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value)
-
+  if (value === null || value === undefined) return ''
+
+  // Preserve primitive header labels (e.g., numeric axis values), but avoid turning objects/React nodes
+  // into "[object Object]".
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value)
+
   if (typeof value !== 'string' || !value) return ''
   return new DOMParser().parseFromString(value, 'text/html').body.textContent?.trim() ?? ''
 }
@@ -153,7 +153,7 @@ const ChartHeader = ({
                 textAlign: rightAlignedCols && rightAlignedCols[index] ? 'right' : '',
                 paddingRight: '1.8em'
               }}
-              key={`col-header-${column}__${index}`}
+              key={`col-header-${column}`}
               tabIndex={hasRowType ? undefined : 0}
               role='columnheader'
               scope='col'
@@ -233,7 +233,7 @@ const ChartHeader = ({
                 textAlign: rightAlignedCols && rightAlignedCols[index] ? 'right' : '',
                 paddingRight: '1.8em'
               }}
-              key={`col-header-${text}__${index}`}
+              key={`col-header-${row}`}
               tabIndex={hasRowType ? undefined : 0}
               role='columnheader'
               scope='col'

--- a/packages/core/components/DataTable/components/ChartHeader.tsx
+++ b/packages/core/components/DataTable/components/ChartHeader.tsx
@@ -217,7 +217,9 @@ const ChartHeader = ({
           const sortByAsc = sortBy.colIndex === index ? sortBy.asc : undefined
           const headingId = `${headerIdBase}-heading-${index}`
           const descId = `${headerIdBase}-desc-${index}`
-          const sortInstruction = getSortInstructionText(text, config, newSortBy.asc)
+          // hasRowType tables are not sortable — omit the instruction so screen readers
+          // don't announce a sort action that the click/keydown handler will ignore.
+          const sortInstruction = hasRowType ? null : getSortInstructionText(text, config, newSortBy.asc)
           return (
             <th
               style={{
@@ -226,7 +228,7 @@ const ChartHeader = ({
                 paddingRight: '1.8em'
               }}
               key={`col-header-${text}__${index}`}
-              tabIndex={0}
+              tabIndex={hasRowType ? undefined : 0}
               role='columnheader'
               scope='col'
               aria-labelledby={headingId}
@@ -247,6 +249,7 @@ const ChartHeader = ({
                 setSortBy(newSortBy)
               }}
               onKeyDown={e => {
+                if (hasRowType) return
                 if (e.key === 'Enter') {
                   publishAnalyticsEvent({
                     vizType: config.type,
@@ -263,7 +266,7 @@ const ChartHeader = ({
                 }
               }}
               className={sortBy.colIndex === index ? (sortBy.asc ? 'sort sort-asc' : 'sort sort-desc') : 'sort'}
-              {...(sortBy.colIndex === index
+              {...(!hasRowType && sortBy.colIndex === index
                 ? sortBy.asc
                   ? { 'aria-sort': 'ascending' }
                   : { 'aria-sort': 'descending' }

--- a/packages/core/components/DataTable/components/MapHeader.tsx
+++ b/packages/core/components/DataTable/components/MapHeader.tsx
@@ -60,9 +60,15 @@ const MapHeader = ({
           const sortByAsc = sortBy.column === column ? sortBy.asc : undefined
           const headingId = `${headerIdBase}-heading-${index}`
           const descId = `${headerIdBase}-desc-${index}`
-          const sortInstruction = `Sort by ${sortLabel} in ${
-            sortBy.column === column ? (!sortBy.asc ? 'descending' : 'ascending') : 'descending'
-          } order`
+          // Describe what activating the control WILL do next (the pending `getNewSortBy`
+          // direction), so the description updates as the sort cycles instead of restating the
+          // current state. `asc` true -> ascending, false -> descending, undefined -> clears sort.
+          const sortInstruction =
+            newSortBy.asc === true
+              ? `Sort by ${sortLabel} in ascending order`
+              : newSortBy.asc === false
+                ? `Sort by ${sortLabel} in descending order`
+                : `Remove the sort from ${sortLabel}`
           return (
             <th
               style={{
@@ -118,6 +124,14 @@ const MapHeader = ({
                 <ColumnHeadingText text={text} config={config} />
               </span>
               <SortIcon ascending={sortByAsc} />
+              {/*
+                Sort instruction text. It is intentionally aria-hidden so screen readers do NOT
+                stop on it while swiping the header, and so it is excluded from the header cell's
+                text content that gets re-announced on every associated data cell. It is still
+                exposed on purpose: the th references it via aria-describedby, and per the
+                accessible description spec a hidden element referenced by aria-describedby is
+                still read when the header itself receives focus.
+              */}
               <span id={descId} className='cdcdataviz-sr-only' aria-hidden='true'>
                 {sortInstruction}
               </span>

--- a/packages/core/components/DataTable/components/MapHeader.tsx
+++ b/packages/core/components/DataTable/components/MapHeader.tsx
@@ -77,7 +77,6 @@ const MapHeader = ({
                 paddingRight: '1.8em'
               }}
               key={`col-header-${column}__${index}`}
-              id={column}
               tabIndex={0}
               role='columnheader'
               scope='col'

--- a/packages/core/components/DataTable/components/MapHeader.tsx
+++ b/packages/core/components/DataTable/components/MapHeader.tsx
@@ -76,7 +76,7 @@ const MapHeader = ({
                 textAlign: rightAlignedCols && rightAlignedCols[index] ? 'right' : '',
                 paddingRight: '1.8em'
               }}
-              key={`col-header-${column}__${index}`}
+              key={`col-header-${column}`}
               tabIndex={0}
               role='columnheader'
               scope='col'

--- a/packages/core/components/DataTable/components/MapHeader.tsx
+++ b/packages/core/components/DataTable/components/MapHeader.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { DataTableProps } from '../DataTable'
 import ScreenReaderText from '../../elements/ScreenReaderText'
 import { SortIcon } from './SortIcon'
@@ -38,6 +39,7 @@ const MapHeader = ({
   rightAlignedCols,
   interactionLabel = ''
 }: MapHeaderProps) => {
+  const headerIdBase = useId()
   const orderedColumnKeys = getMapDataTableColumnKeys(columns)
 
   return (
@@ -56,6 +58,11 @@ const MapHeader = ({
           const sortLabel = typeof text === 'string' ? new DOMParser().parseFromString(text, 'text/html').body.textContent?.trim() || '' : ''
           const newSortBy = getNewSortBy(sortBy, column, index)
           const sortByAsc = sortBy.column === column ? sortBy.asc : undefined
+          const headingId = `${headerIdBase}-heading-${index}`
+          const descId = `${headerIdBase}-desc-${index}`
+          const sortInstruction = `Sort by ${sortLabel} in ${
+            sortBy.column === column ? (!sortBy.asc ? 'descending' : 'ascending') : 'descending'
+          } order`
           return (
             <th
               style={{
@@ -68,6 +75,8 @@ const MapHeader = ({
               tabIndex={0}
               role='columnheader'
               scope='col'
+              aria-labelledby={headingId}
+              aria-describedby={descId}
               onClick={() => {
                 publishAnalyticsEvent({
                   vizType: config.type,
@@ -105,11 +114,13 @@ const MapHeader = ({
                   : { 'aria-sort': 'descending' }
                 : null)}
             >
-              <ColumnHeadingText text={text} config={config} />
+              <span id={headingId}>
+                <ColumnHeadingText text={text} config={config} />
+              </span>
               <SortIcon ascending={sortByAsc} />
-              <span className='cdcdataviz-sr-only'>{`Sort by ${sortLabel} in ${
-                sortBy.column === column ? (!sortBy.asc ? 'descending' : 'ascending') : 'descending'
-              } order`}</span>
+              <span id={descId} className='cdcdataviz-sr-only' aria-hidden='true'>
+                {sortInstruction}
+              </span>
             </th>
           )
         })}


### PR DESCRIPTION
## Summary
Update the aria label for table headers so it's only read when the table header is highlighted, and not when the table cells below are highlighted. This ended up being a little tricky as by default the entire content of the header is read, so this updates depending on whats highlighted or not.

Rebased for test from dev

## Testing Steps
Checking with screenreader on any datatable such as the default chart should work as expected.
