### PR TITLE
fix: image download

### DIFF
--- a/packages/core/assets/logo2.svg
+++ b/packages/core/assets/logo2.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 27.9.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="135 160 228 147" xml:space="preserve">
+	 width="228" height="147" viewBox="0 0 228 147" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#0055B8;}
 	.st1{fill:#FFFFFF;}
 </style>
-<g>
+<g transform="translate(-135 -160)">
 	<path class="st0" d="M141.22,300.14H186h151.44c10.88,0,19.84-8.27,20.91-18.87c0.07-0.71,0.11-1.42,0.11-2.15V165.04H188.93
 		h-26.68c-7.26,0-13.65,3.68-17.43,9.27c-0.76,1.12-1.41,2.31-1.94,3.57c-1.06,2.52-1.65,5.28-1.65,8.18V300.14z"/>
 	<path class="st1" d="M162.25,160.83c-13.91,0-25.23,11.32-25.23,25.23v118.28h31.62h6.95h161.85c13.91,0,25.23-11.32,25.23-25.23

--- a/packages/core/components/MediaControls.tsx
+++ b/packages/core/components/MediaControls.tsx
@@ -49,6 +49,38 @@ const saveImageAs = (uri, filename) => {
   }
 }
 
+const waitForClonedImages = async (container, timeoutMs = 3000) => {
+  const images = Array.from(container.querySelectorAll('img'))
+
+  if (images.length === 0) return
+
+  const withTimeout = promise =>
+    new Promise(resolve => {
+      const timer = setTimeout(() => resolve(undefined), timeoutMs)
+      promise.finally(() => {
+        clearTimeout(timer)
+        resolve(undefined)
+      })
+    })
+
+  await Promise.all(
+    images.map(img => {
+      if (img.complete && img.naturalWidth > 0) return Promise.resolve()
+
+      if (typeof img.decode === 'function') {
+        return withTimeout(img.decode())
+      }
+
+      return withTimeout(
+        new Promise(resolve => {
+          img.onload = () => resolve(undefined)
+          img.onerror = () => resolve(undefined)
+        })
+      )
+    })
+  )
+}
+
 const generateMedia = (state, type, elementToCapture, interactionLabel, includeContextInDownload = false) => {
   // Identify Selector
   const baseSvg = document.querySelector(`[data-download-id=${elementToCapture}]`)
@@ -111,29 +143,30 @@ const generateMedia = (state, type, elementToCapture, interactionLabel, includeC
           }
         })
 
-        import(/* webpackChunkName: "html2canvas" */ 'html2canvas').then(mod => {
-          mod
-            .default(container, {
-              ignoreElements: el =>
-                el.className?.indexOf &&
-                el.className.search(/download-buttons|download-links|data-table-container/) !== -1,
-              useCORS: true,
-              scale: 2, // Better quality
-              allowTaint: true
-            })
-            .then(canvas => {
-              targetElement.removeChild(container) // Clean up container from wherever we appended it
-              saveImageAs(canvas.toDataURL(), filename + '.png')
-              publishAnalyticsEvent({
-                vizType: state.type,
-                vizSubType: getVizSubType(state),
-                eventType: `image_download`,
-                eventAction: 'click',
-                eventLabel: interactionLabel,
-                vizTitle: getTitle(state)
-              })
-            })
-        })
+        try {
+          await waitForClonedImages(container)
+
+          const html2canvas = (await import(/* webpackChunkName: "html2canvas" */ 'html2canvas')).default
+          const canvas = await html2canvas(container, {
+            ignoreElements: el =>
+              el.className?.indexOf && el.className.search(/download-buttons|download-links|data-table-container/) !== -1,
+            useCORS: true,
+            scale: 2, // Better quality
+            allowTaint: true
+          })
+
+          saveImageAs(canvas.toDataURL(), filename + '.png')
+          publishAnalyticsEvent({
+            vizType: state.type,
+            vizSubType: getVizSubType(state),
+            eventType: `image_download`,
+            eventAction: 'click',
+            eventLabel: interactionLabel,
+            vizTitle: getTitle(state)
+          })
+        } finally {
+          targetElement.removeChild(container) // Clean up container from wherever we appended it
+        }
       }
       downloadImage()
 

--- a/packages/map/src/_stories/CdcMap.Logo.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Logo.stories.tsx
@@ -2,7 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect } from 'storybook/test'
 import CdcMap from '../CdcMap'
 import MultiCountry from './_mock/multi-country.json'
-import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import MultiState from './_mock/multi-state.json'
+import StateMapWithTerritories from './_mock/example-city-state.json'
+import CountyMapConfig from './_mock/county-patterns.json'
+import RegionMapConfig from '../../examples/default-usa-regions.json'
+import { assertVisualizationRendered, waitForPresence } from '@cdc/core/helpers/testing'
+import { editConfigKeys } from '@cdc/core/helpers/configHelpers'
 import CdcLogo from '@cdc/core/assets/logo2.svg?url'
 
 const meta: Meta<typeof CdcMap> = {
@@ -14,24 +19,56 @@ export default meta
 
 type Story = StoryObj<typeof CdcMap>
 
-export const ShowsLogo: Story = {
+const assertLogoRendered = async (canvasElement: HTMLElement) => {
+  await assertVisualizationRendered(canvasElement)
+
+  const logo = (await waitForPresence('img.map-logo', canvasElement)) as HTMLImageElement | null
+  expect(logo).toBeInTheDocument()
+  expect(logo?.getAttribute('src')).toBe(CdcLogo)
+
+  const downloadPngLink = await waitForPresence('a[aria-label="Download Map as Image"]', canvasElement)
+  expect(downloadPngLink).toBeInTheDocument()
+}
+
+const logoStory = (config: NonNullable<Story['args']>['config'], description: string): Story => ({
   args: {
-    config: MultiCountry,
+    config: editConfigKeys(config, [{ path: ['general', 'showDownloadImgButton'], value: true }]),
     logo: CdcLogo,
     isEditor: false
   },
   parameters: {
     docs: {
       description: {
-        story: 'Verifies that passing a logo URL renders the map logo image.'
+        story: description
       }
     }
   },
   play: async ({ canvasElement }) => {
-    await assertVisualizationRendered(canvasElement)
-
-    const logo = canvasElement.querySelector('img.map-logo') as HTMLImageElement | null
-    expect(logo).toBeInTheDocument()
-    expect(logo?.getAttribute('src')).toBe(CdcLogo)
+    await assertLogoRendered(canvasElement)
   }
-}
+})
+
+export const ShowsLogo: Story = logoStory(
+  MultiCountry,
+  'Verifies that passing a logo URL renders the map logo image on a world map.'
+)
+
+export const StateMap: Story = logoStory(
+  StateMapWithTerritories,
+  'Verifies that passing a logo URL renders the map logo image on a U.S. state map.'
+)
+
+export const CountyMap: Story = logoStory(
+  CountyMapConfig,
+  'Verifies that passing a logo URL renders the map logo image on a U.S. county map.'
+)
+
+export const RegionMap: Story = logoStory(
+  RegionMapConfig,
+  'Verifies that passing a logo URL renders the map logo image on a U.S. region map.'
+)
+
+export const SingleStateMap: Story = logoStory(
+  MultiState,
+  'Verifies that passing a logo URL renders the map logo image on a single-state map.'
+)

--- a/packages/map/src/_stories/CdcMap.Logo.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Logo.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
+import CdcMap from '../CdcMap'
+import MultiCountry from './_mock/multi-country.json'
+import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import CdcLogo from '@cdc/core/assets/logo2.svg?url'
+
+const meta: Meta<typeof CdcMap> = {
+  title: 'Components/Templates/Map/Logo',
+  component: CdcMap
+}
+
+export default meta
+
+type Story = StoryObj<typeof CdcMap>
+
+export const ShowsLogo: Story = {
+  args: {
+    config: MultiCountry,
+    logo: CdcLogo,
+    isEditor: false
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Verifies that passing a logo URL renders the map logo image.'
+      }
+    }
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    const logo = canvasElement.querySelector('img.map-logo') as HTMLImageElement | null
+    expect(logo).toBeInTheDocument()
+    expect(logo?.getAttribute('src')).toBe(CdcLogo)
+  }
+}

--- a/packages/map/src/components/MapContainer.tsx
+++ b/packages/map/src/components/MapContainer.tsx
@@ -3,7 +3,7 @@ import Modal from './Modal'
 import UsaMap from './UsaMap'
 import WorldMap from './WorldMap'
 import { MapConfig } from '../types/MapConfig'
-import { LOGO_MAX_WIDTH } from '../helpers/constants'
+import { LOGO_HEIGHT } from '../helpers/constants'
 
 interface MapContainerProps {
   config: MapConfig
@@ -38,7 +38,7 @@ const MapContainer: React.FC<MapContainerProps> = ({
             /* logo is handled in UsaMap.State when applicable */
             // prettier-ignore
             'data' === general.type && logo && ('us' !== geoType || 'us-geocode' === general.type) && (
-              <img src={logo} alt='' className='map-logo' style={{ maxWidth: LOGO_MAX_WIDTH }} />
+              <img src={logo} alt='' className='map-logo' style={{ height: LOGO_HEIGHT, width: 'auto' }} />
             )
           }
         </>

--- a/packages/map/src/components/UsaMap/components/TerritoriesSection.tsx
+++ b/packages/map/src/components/UsaMap/components/TerritoriesSection.tsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react'
 import ConfigContext from '../../../context'
 import { isMobileTerritoryViewport } from '@cdc/core/helpers/viewports'
 import { TERRITORY_DESKTOP_SVG_WIDTH, TERRITORY_MOBILE_SVG_WIDTH } from './Territory/constants'
+import { LOGO_HEIGHT } from '../../../helpers/constants'
 
 type TerritoriesSectionProps = {
   territories: JSX.Element[]
@@ -51,7 +52,7 @@ const TerritoriesSection: React.FC<TerritoriesSectionProps> = ({ territories, lo
         <div>
           <div className='d-flex mt-4'>
             {'data' === config.general.type && logo && (
-              <img src={logo} alt='' className='map-logo' style={{ maxWidth: '50px' }} />
+              <img src={logo} alt='' className='map-logo' style={{ height: LOGO_HEIGHT, width: 'auto' }} />
             )}
           </div>
           <div className='d-flex flex-wrap' style={{ columnGap: '1.5rem' }}>

--- a/packages/map/src/components/WorldMap/worldMap.styles.css
+++ b/packages/map/src/components/WorldMap/worldMap.styles.css
@@ -20,7 +20,7 @@
     .map-logo {
       display: block;
       margin: 0 0 0 auto;
-      max-height: 35px;
+      max-width: 100%;
     }
   }
 }

--- a/packages/map/src/helpers/constants.ts
+++ b/packages/map/src/helpers/constants.ts
@@ -32,7 +32,7 @@ export const DEFAULT_MAP_BACKGROUND = '#DFE1E2'
 export const DISABLED_MAP_COLOR = '#FFFFFF'
 
 // Component constants
-export const LOGO_MAX_WIDTH = '50px'
+export const LOGO_HEIGHT = '40px'
 
 // CSV Parsing Configuration
 export const CSV_PARSE_CONFIG = {

--- a/packages/map/src/test/CdcMapComponent.logo.test.tsx
+++ b/packages/map/src/test/CdcMapComponent.logo.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import CdcMapComponent from '../CdcMapComponent'
+
+vi.hoisted(() => {
+  Object.defineProperty((globalThis as any).HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: () => ({
+      measureText: (text = '') => ({ width: String(text).length * 8 })
+    })
+  })
+})
+
+vi.mock('../hooks/useResizeObserver', () => ({
+  default: () => ({
+    resizeObserver: null,
+    dimensions: [640, 480],
+    currentViewport: 'lg',
+    vizViewport: 'lg',
+    outerContainerRef: () => {},
+    container: null
+  })
+}))
+
+vi.mock('../components/UsaMap', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  const stub = (name: string) => () => React.createElement('div', { 'data-testid': name })
+
+  return {
+    default: {
+      State: stub('mock-usa-state'),
+      Region: stub('mock-usa-region'),
+      County: stub('mock-usa-county'),
+      SingleState: stub('mock-usa-single-state')
+    }
+  }
+})
+
+vi.mock('../components/WorldMap', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    default: () => React.createElement('div', { 'data-testid': 'mock-world-map' })
+  }
+})
+
+const buildConfig = (overrides: any = {}) =>
+  ({
+    type: 'map',
+    data: [
+      { Country: 'Canada', Rate: 10 },
+      { Country: 'Mexico', Rate: 20 }
+    ],
+    general: {
+      title: 'Logo Test Map',
+      geoType: 'world',
+      type: 'data',
+      showTitle: true,
+      ...overrides.general
+    },
+    columns: {
+      geo: { name: 'Country', label: 'Location', dataTable: true },
+      primary: { name: 'Rate', label: 'Rate', dataTable: true, prefix: '', suffix: '' },
+      navigate: { name: '' },
+      latitude: { name: '' },
+      longitude: { name: '' }
+    },
+    legend: {
+      type: 'equalnumber',
+      numberOfItems: 3,
+      specialClasses: [],
+      unified: false
+    },
+    table: {
+      forceDisplay: false,
+      expanded: false,
+      download: false,
+      label: 'Data Table',
+      indexLabel: '',
+      showNonGeoData: false
+    },
+    filters: []
+  } as any)
+
+const renderMap = (props: any = {}) =>
+  render(
+    <CdcMapComponent
+      config={buildConfig(props.configOverrides)}
+      interactionLabel='map-logo-test'
+      navigationHandler={vi.fn()}
+      setSharedFilter={vi.fn()}
+      setSharedFilterValue={vi.fn()}
+      {...props}
+    />
+  )
+
+describe('CdcMapComponent logo prop', () => {
+  it('renders the passed-in logo image on a data map', async () => {
+    const { container } = renderMap({ logo: 'cdc-logo.svg' })
+
+    await waitFor(() => {
+      const logoImg = container.querySelector('img.map-logo') as HTMLImageElement
+      expect(logoImg).toBeInTheDocument()
+      expect(logoImg.getAttribute('src')).toBe('cdc-logo.svg')
+    })
+  })
+
+  it('does not render a logo image when no logo is passed', async () => {
+    const { container, findByTestId } = renderMap()
+
+    await findByTestId('mock-world-map')
+
+    expect(container.querySelector('img.map-logo')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
This pull request improves the rendering and testing of the map logo in the `map` package, standardizing the logo's appearance and adding automated tests and Storybook documentation to ensure correct behavior.

**Logo rendering improvements:**

* The logo image now uses a consistent height (`LOGO_HEIGHT`) and `width: auto` instead of `max-width`, ensuring uniform appearance across different map types and screen sizes. (`MapContainer.tsx`, `TerritoriesSection.tsx`, `constants.ts`, `worldMap.styles.css`) [[1]](diffhunk://#diff-91e8ac6093fc3f96a04d3277a44eae2eb3382321a56bdd85e7d04016309e6f1aL6-R6) [[2]](diffhunk://#diff-91e8ac6093fc3f96a04d3277a44eae2eb3382321a56bdd85e7d04016309e6f1aL41-R41) [[3]](diffhunk://#diff-6472cfeca8efd025c11df257b7b0595dffc413dffa70c1a56f319bfb81038558R6) [[4]](diffhunk://#diff-6472cfeca8efd025c11df257b7b0595dffc413dffa70c1a56f319bfb81038558L54-R55) [[5]](diffhunk://#diff-3f91e4da51d66243cc5975357d105a0cdfa68c360db88e9d859d4e757738c729L35-R35) [[6]](diffhunk://#diff-f6dc40a7cada127ec2070584a2a77f8dceefa5729fbb628661c5e85edb57bfe5L23-R23)

**Testing and documentation:**

* Added a Storybook story (`CdcMap.Logo.stories.tsx`) that verifies the logo is rendered when a logo URL is provided.
* Introduced a unit test (`CdcMapComponent.logo.test.tsx`) that checks both the presence and absence of the logo image based on the prop.

**Other improvements:**

* Updated references from `LOGO_MAX_WIDTH` to `LOGO_HEIGHT` throughout the codebase for consistency. [[1]](diffhunk://#diff-91e8ac6093fc3f96a04d3277a44eae2eb3382321a56bdd85e7d04016309e6f1aL6-R6) [[2]](diffhunk://#diff-3f91e4da51d66243cc5975357d105a0cdfa68c360db88e9d859d4e757738c729L35-R35)

These changes collectively ensure that the map logo is rendered consistently and reliably, with automated verification in both tests and Storybook.