### PR TITLE
Removed excess copilot fixes from OG ticket

### DIFF
--- a/packages/core/components/ComboBox/combobox.styles.css
+++ b/packages/core/components/ComboBox/combobox.styles.css
@@ -107,6 +107,10 @@
     list-style: none;
     margin: 0;
     max-height: 20rem;
+    /* Keep the 150% menu from becoming wider than the viewport. This caps menu width only;
+       it does not account for the menu's left offset, so edge-aware positioning would still
+       require measuring available space when the menu opens. */
+    max-width: calc(100vw - var(--filter-menu-viewport-gutter, 2rem));
     overflow-y: auto;
     padding: 0;
     position: absolute;

--- a/packages/core/components/Filters/components/filter-note.css
+++ b/packages/core/components/Filters/components/filter-note.css
@@ -1,23 +1,23 @@
+.filters-section__wrapper {
+  --filters-section-noted-control-max-width: 30rem;
+}
+
+.filters-section__wrapper--multiple {
+  --filters-section-noted-control-max-width: 18rem;
+}
+
 .filters-section__note-text {
   display: block;
   flex-basis: 100%;
   font-size: 14px;
   font-weight: 400;
   line-height: 1.45;
-  max-width: 30rem;
+  max-width: var(--filters-section-noted-control-max-width);
   overflow-wrap: break-word;
   white-space: normal;
 }
 
-.filters-section__wrapper--multiple .filters-section__note-text {
-  max-width: 18rem;
-}
-
 .filters-section__select--with-note {
   box-sizing: border-box;
-  max-width: 30rem;
-}
-
-.filters-section__wrapper--multiple .filters-section__select--with-note {
-  max-width: 18rem;
+  max-width: var(--filters-section-noted-control-max-width);
 }

--- a/packages/core/components/Filters/filters.scss
+++ b/packages/core/components/Filters/filters.scss
@@ -31,6 +31,15 @@ div.single-filters {
     font-weight: 700;
   }
 
+  &:has(> div.nested-dropdown) {
+    flex: 0 0 auto;
+    max-width: 100%;
+  }
+
+  &:has(> div.nested-dropdown):has(.filters-section__note-text) {
+    max-width: var(--filters-section-noted-control-max-width);
+  }
+
   &__tab-bar {
     &:first-child {
       border-top-left-radius: 15px;
@@ -38,8 +47,8 @@ div.single-filters {
     }
   }
 
-  &>select.cove-form-select,
-  &>div.nested-dropdown {
+  & > select.cove-form-select,
+  & > div.nested-dropdown {
     width: fit-content;
   }
 }

--- a/packages/core/components/NestedDropdown/NestedDropdown.tsx
+++ b/packages/core/components/NestedDropdown/NestedDropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, useId, type FocusEvent } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef, useMemo, useId, type FocusEvent } from 'react'
 import './nesteddropdown.styles.css'
 import Icon from '@cdc/core/components/ui/Icon'
 import { filterSearchTerm, NestedOptions, ValueTextPair } from './nestedDropdownHelpers'
@@ -10,6 +10,15 @@ const getSelectableItem = (target: EventTarget | null, filterIndex: number) =>
   target instanceof HTMLElement ? target.closest<HTMLElement>(`.selectable-item-${filterIndex}`) : null
 
 const isSelectableItem = (target: EventTarget | null, filterIndex: number) => !!getSelectableItem(target, filterIndex)
+
+const getDisplayText = ([value, text]: ValueTextPair) => String(text || value)
+
+const getNestedOptionDisplayText = (group: ValueTextPair, subGroup: ValueTextPair, displaySubgroupingOnly: boolean) => {
+  const groupDisplay = getDisplayText(group)
+  const subGroupDisplay = getDisplayText(subGroup)
+
+  return displaySubgroupingOnly ? subGroupDisplay : `${groupDisplay} - ${subGroupDisplay}`
+}
 
 const highlightMatches = (text: string | number, search: PreparedSearchQuery): React.ReactNode => {
   const label = String(text)
@@ -183,13 +192,13 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
 }) => {
   const dropdownId = useId()
 
-  const [userSearchTerm, setUserSearchTerm] = useState(null)
+  const [userSearchTerm, setUserSearchTerm] = useState<string | null>(null)
 
   const selectedDisplayValues = useMemo(() => {
     const groupOption = options?.find(([[value]]) => String(value) === String(activeGroup))
-    const groupDisplay = groupOption ? String(groupOption[0][1] || groupOption[0][0]) : activeGroup
+    const groupDisplay = groupOption ? getDisplayText(groupOption[0]) : activeGroup
     const subGroupOption = groupOption?.[1]?.find(([value]) => String(value) === String(activeSubGroup))
-    const subGroupDisplay = subGroupOption ? String(subGroupOption[1] || subGroupOption[0]) : activeSubGroup
+    const subGroupDisplay = subGroupOption ? getDisplayText(subGroupOption) : activeSubGroup || ''
 
     return { groupDisplay, subGroupDisplay }
   }, [activeGroup, activeSubGroup, options])
@@ -204,6 +213,50 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
     if (loading) return 'Loading...'
     return inputValue || placeholder
   }, [inputValue, loading, placeholder])
+  const optionSizingTexts = useMemo(() => {
+    const displayedOptions = (options || []).flatMap(([group, subGroups]) =>
+      subGroups.map(subGroup => getNestedOptionDisplayText(group, subGroup, displaySubgroupingOnly))
+    )
+
+    return Array.from(new Set([loading ? 'Loading...' : placeholder, inputValue, ...displayedOptions].filter(Boolean)))
+  }, [displaySubgroupingOnly, inputValue, loading, options, placeholder])
+  const sizingContextKey = JSON.stringify([filterIndex, listLabel, displaySubgroupingOnly])
+  const [stableOptionSizing, setStableOptionSizing] = useState(() => ({
+    contextKey: sizingContextKey,
+    text: optionSizingTexts[0] || ''
+  }))
+  const stableOptionSizingText =
+    stableOptionSizing.contextKey === sizingContextKey ? stableOptionSizing.text : optionSizingTexts[0] || ''
+  const sizingCandidateTexts = useMemo(
+    () => Array.from(new Set([stableOptionSizingText, ...optionSizingTexts].filter(Boolean))),
+    [optionSizingTexts, stableOptionSizingText]
+  )
+  const sizingMeasureRef = useRef<HTMLSpanElement>(null)
+
+  // Measure rendered candidates because character count is unreliable in proportional fonts.
+  // The previous stable text remains a candidate so narrowed option sets cannot shrink the control.
+  useLayoutEffect(() => {
+    const candidates = Array.from(sizingMeasureRef.current?.children || []) as HTMLElement[]
+    let widestText = optionSizingTexts[0] || ''
+    let widestWidth = -1
+
+    candidates.forEach(candidate => {
+      const candidateWidth = candidate.getBoundingClientRect().width
+      if (candidateWidth > widestWidth) {
+        widestText = candidate.dataset.sizingCandidate || widestText
+        widestWidth = candidateWidth
+      }
+    })
+
+    setStableOptionSizing(current => {
+      if (current.contextKey === sizingContextKey && current.text === widestText) return current
+      return { contextKey: sizingContextKey, text: widestText }
+    })
+  }, [optionSizingTexts, sizingCandidateTexts, sizingContextKey])
+
+  // Search text participates in layout without becoming part of the persistent option baseline.
+  const transientSizingText =
+    userSearchTerm !== null ? userSearchTerm || inputPlaceholder : inputValue || inputPlaceholder
   const [isListOpened, setIsListOpened] = useState(false)
   const nestedDropdownRef = useRef<HTMLDivElement>(null)
   const searchInput = useRef<HTMLInputElement>(null)
@@ -395,10 +448,19 @@ const NestedDropdown: React.FC<NestedDropdownProps> = ({
       >
         <div
           className={`nested-dropdown-input-container${loading || !options?.length ? ' disabled' : ''}`}
+          data-sizing-text={stableOptionSizingText}
+          data-transient-sizing-text={transientSizingText}
           aria-label='searchInput'
           aria-disabled={loading}
           role='textbox'
         >
+          <span ref={sizingMeasureRef} className='nested-dropdown-sizing-measure' aria-hidden='true'>
+            {sizingCandidateTexts.map(text => (
+              <span key={text} data-sizing-candidate={text} />
+            ))}
+          </span>
+          <span className='nested-dropdown-input-sizer' data-sizing-value={stableOptionSizingText} aria-hidden='true' />
+          <span className='nested-dropdown-input-sizer' data-sizing-value={transientSizingText} aria-hidden='true' />
           <input
             id={`nested-dropdown-${filterIndex}`}
             className='search-input'

--- a/packages/core/components/NestedDropdown/nesteddropdown.styles.css
+++ b/packages/core/components/NestedDropdown/nesteddropdown.styles.css
@@ -6,7 +6,11 @@
 }
 
 .nested-dropdown {
+  --nested-dropdown-control-space: 1.75rem;
+
+  max-width: 100%;
   position: relative;
+  width: fit-content;
 
   [class^='nested-dropdown-group-'] {
     list-style: none;
@@ -19,12 +23,19 @@
 
   .search-input {
     border: none;
+    box-sizing: border-box;
     color: var(--cool-gray-90);
     display: inline-block;
     font-weight: 300;
+    grid-area: 1 / 1;
+    min-width: 0;
+    overflow: hidden;
     padding: 0;
+    padding-right: var(--nested-dropdown-control-space);
     position: relative;
+    text-overflow: ellipsis;
     top: 1px;
+    white-space: nowrap;
     width: 100%;
     &::placeholder {
       color: #6c757d;
@@ -109,10 +120,45 @@
   .nested-dropdown-input-container {
     background: white;
     border-radius: 0.333rem;
-    display: block;
+    display: inline-grid;
+    grid-template-columns: minmax(0, 1fr);
+    max-width: 100%;
     padding: calc(0.4rem + 1px) 0.75rem calc(0.4rem + 1px) calc(0.75rem - 4px);
     position: relative;
-    width: 100%;
+    width: fit-content;
+
+    .nested-dropdown-input-sizer {
+      font-weight: 300;
+      grid-area: 1 / 1;
+      padding-right: var(--nested-dropdown-control-space);
+      visibility: hidden;
+      white-space: pre;
+
+      &::after {
+        content: attr(data-sizing-value);
+      }
+    }
+
+    .nested-dropdown-sizing-measure {
+      align-items: flex-start;
+      display: flex;
+      flex-direction: column;
+      font-weight: 300;
+      left: 0;
+      pointer-events: none;
+      position: absolute;
+      top: 0;
+      visibility: hidden;
+      white-space: pre;
+
+      & > span {
+        display: inline-block;
+
+        &::after {
+          content: attr(data-sizing-candidate);
+        }
+      }
+    }
 
     &:focus-within:not(.disabled) {
       outline: dashed 2px rgb(0, 122, 153) !important;

--- a/packages/core/components/NestedDropdown/nesteddropdown.styles.css
+++ b/packages/core/components/NestedDropdown/nesteddropdown.styles.css
@@ -186,6 +186,10 @@
     color: var(--cool-gray-90);
     font-size: 0.833rem !important;
     max-height: 375px;
+    /* Keep the 150% menu from becoming wider than the viewport. This caps menu width only;
+       it does not account for the menu's left offset, so edge-aware positioning would still
+       require measuring available space when the menu opens. */
+    max-width: calc(100vw - var(--filter-menu-viewport-gutter, 2rem));
     min-width: 200px;
     overflow-y: auto;
     padding-top: 0;

--- a/packages/core/components/NestedDropdown/tests/NestedDropdown.test.tsx
+++ b/packages/core/components/NestedDropdown/tests/NestedDropdown.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import NestedDropdown from '../NestedDropdown'
 import { NestedOptions } from '../nestedDropdownHelpers'
 
@@ -7,19 +7,20 @@ vi.mock('../../ui/Icon', () => ({
   default: props => <span data-testid='mock-icon' {...props} />
 }))
 
+afterEach(() => vi.restoreAllMocks())
+
 const options: NestedOptions = [
   [['2023'], [['Q1'], ['Q2']]],
   [['2024'], [['Q3'], ['Q4']]]
 ]
 
 const labeledOptions: NestedOptions = [
-  [
-    ['animal', 'Animal-borne diseases'],
-    [['brucella', 'Brucellosis', 'Bacterial disease']]
-  ]
+  [['animal', 'Animal-borne diseases'], [['brucella', 'Brucellosis', 'Bacterial disease']]]
 ]
 
-const getSearchInput = () => screen.getAllByLabelText('searchInput').find(el => el.tagName === 'INPUT') as HTMLInputElement
+const getSearchInput = () =>
+  screen.getAllByLabelText('searchInput').find(el => el.tagName === 'INPUT') as HTMLInputElement
+const getInputContainer = () => getSearchInput().closest('.nested-dropdown-input-container')
 
 describe('NestedDropdown', () => {
   it('shows the default closed display as group and subgroup', () => {
@@ -124,10 +125,9 @@ describe('NestedDropdown', () => {
 
     fireEvent.focus(getSearchInput())
 
-    expect(screen.getByRole('treeitem', { name: 'Animal-borne diseases Brucellosis Bacterial disease' })).toHaveAttribute(
-      'aria-selected',
-      'true'
-    )
+    expect(
+      screen.getByRole('treeitem', { name: 'Animal-borne diseases Brucellosis Bacterial disease' })
+    ).toHaveAttribute('aria-selected', 'true')
   })
 
   it('uses subgroup display text in subgroup-only mode when labels are supplied', () => {
@@ -354,6 +354,119 @@ describe('NestedDropdown', () => {
     expect(input).toHaveAttribute('placeholder', 'Search for a disease')
   })
 
+  it('sizes from the visually widest option instead of the option with the most characters', async () => {
+    const widthByText: Record<string, number> = {
+      WWWWWW: 160,
+      iiiiiiiiiiii: 80,
+      '- Select -': 60
+    }
+    const getBoundingClientRect = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function () {
+        const width = widthByText[this.dataset.sizingCandidate || ''] || 20
+        return { width } as DOMRect
+      })
+    const proportionalFontOptions: NestedOptions = [
+      [
+        ['Group'],
+        [
+          ['wide', 'WWWWWW'],
+          ['long', 'iiiiiiiiiiii']
+        ]
+      ]
+    ]
+
+    render(
+      <NestedDropdown
+        activeGroup=''
+        activeSubGroup=''
+        displaySubgroupingOnly
+        filterIndex={0}
+        handleSelectedItems={vi.fn()}
+        listLabel='Proportional font sizing'
+        options={proportionalFontOptions}
+      />
+    )
+
+    await waitFor(() => expect(getInputContainer()).toHaveAttribute('data-sizing-text', 'WWWWWW'))
+    getBoundingClientRect.mockRestore()
+  })
+
+  it('keeps option sizing stable while allowing search text to expand only during interaction', async () => {
+    const getBoundingClientRect = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function () {
+        return { width: this.dataset.sizingCandidate?.length || 0 } as DOMRect
+      })
+    const longOption = 'A deliberately long option label'
+    const longOptions: NestedOptions = [
+      [
+        ['Group'],
+        [
+          ['long', longOption],
+          ['short', 'Short']
+        ]
+      ]
+    ]
+    const shortOptions: NestedOptions = [[['Group'], [['short', 'Short']]]]
+
+    const { rerender } = render(
+      <NestedDropdown
+        activeGroup='Group'
+        activeSubGroup='long'
+        displaySubgroupingOnly
+        filterIndex={0}
+        handleSelectedItems={vi.fn()}
+        listLabel='Stable option sizing'
+        options={longOptions}
+      />
+    )
+
+    await waitFor(() => expect(getInputContainer()).toHaveAttribute('data-sizing-text', longOption))
+
+    rerender(
+      <NestedDropdown
+        activeGroup='Group'
+        activeSubGroup='short'
+        displaySubgroupingOnly
+        filterIndex={0}
+        handleSelectedItems={vi.fn()}
+        listLabel='Stable option sizing'
+        options={shortOptions}
+      />
+    )
+
+    expect(getInputContainer()).toHaveAttribute('data-sizing-text', longOption)
+
+    const input = getSearchInput()
+    const longSearch = 'A search term that is much wider than every option in this dropdown'
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: longSearch } })
+
+    expect(getInputContainer()).toHaveAttribute('data-sizing-text', longOption)
+    expect(getInputContainer()).toHaveAttribute('data-transient-sizing-text', longSearch)
+
+    fireEvent.blur(input)
+
+    expect(getInputContainer()).toHaveAttribute('data-sizing-text', longOption)
+    expect(getInputContainer()).toHaveAttribute('data-transient-sizing-text', 'Short')
+
+    rerender(
+      <NestedDropdown
+        activeGroup='Group'
+        activeSubGroup='short'
+        displaySubgroupingOnly
+        filterIndex={0}
+        handleSelectedItems={vi.fn()}
+        listLabel='Replacement sizing context'
+        options={shortOptions}
+      />
+    )
+
+    await waitFor(() => expect(getInputContainer()).toHaveAttribute('data-sizing-text', '- Select -'))
+    getBoundingClientRect.mockRestore()
+  })
+
   it.each([false, true])('keeps search and selection behavior unchanged when displaySubgroupingOnly=%s', flag => {
     const handleSelectedItems = vi.fn()
 
@@ -488,9 +601,9 @@ describe('NestedDropdown', () => {
     const subgroup = screen.getByRole('treeitem', { name: '2023 Q1' })
 
     tree.scrollTop = 100
-    tree.getBoundingClientRect = () => ({ top: 0, bottom: 100 }) as DOMRect
-    header.getBoundingClientRect = () => ({ height: 30 }) as DOMRect
-    subgroup.getBoundingClientRect = () => ({ top: 10, bottom: 40 }) as DOMRect
+    tree.getBoundingClientRect = () => ({ top: 0, bottom: 100 } as DOMRect)
+    header.getBoundingClientRect = () => ({ height: 30 } as DOMRect)
+    subgroup.getBoundingClientRect = () => ({ top: 10, bottom: 40 } as DOMRect)
 
     fireEvent.keyUp(group, { key: 'ArrowDown' })
 
@@ -540,9 +653,9 @@ describe('NestedDropdown', () => {
     const header = group.querySelector('.nested-dropdown-group-header--sticky') as HTMLElement
 
     tree.scrollTop = 0
-    tree.getBoundingClientRect = () => ({ top: 0, bottom: 100 }) as DOMRect
-    group.getBoundingClientRect = () => ({ top: 0, bottom: 900 }) as DOMRect
-    header.getBoundingClientRect = () => ({ top: 0, bottom: 30, height: 30 }) as DOMRect
+    tree.getBoundingClientRect = () => ({ top: 0, bottom: 100 } as DOMRect)
+    group.getBoundingClientRect = () => ({ top: 0, bottom: 900 } as DOMRect)
+    header.getBoundingClientRect = () => ({ top: 0, bottom: 30, height: 30 } as DOMRect)
 
     fireEvent.keyUp(input, { key: 'ArrowDown' })
 

--- a/packages/core/components/_stories/ComboBox.stories.tsx
+++ b/packages/core/components/_stories/ComboBox.stories.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, within } from 'storybook/test'
+import ComboBox from '../ComboBox'
+
+const longConditionLabel =
+  'Paratyphoid fever (Salmonella enterica serotypes Paratyphi A, B (tartrate negative) and C (S. Paratyphi) infection)'
+
+const options = [
+  {
+    value: 'campylobacteriosis',
+    label: 'Campylobacteriosis',
+    description: 'A diarrheal disease caused by the Campylobacter bacteria'
+  },
+  {
+    value: 'paratyphoid',
+    label: longConditionLabel,
+    description: 'A systemic illness caused by Salmonella enterica serotypes Paratyphi A, B and C'
+  },
+  {
+    value: 'tuberculosis',
+    label: 'Tuberculosis',
+    description: 'Bacterial disease typically spread through the air often affecting the lungs'
+  }
+]
+
+const ComboBoxStory = args => {
+  const [selected, setSelected] = useState(args.selected || '')
+
+  return (
+    <ComboBox
+      {...args}
+      selected={selected}
+      updateField={(_section, _subsection, _fieldName, value) => setSelected(value)}
+    />
+  )
+}
+
+const meta: Meta<typeof ComboBox> = {
+  title: 'Components/Molecules/ComboBox',
+  component: ComboBox,
+  render: args => <ComboBoxStory {...args} />
+}
+
+type Story = StoryObj<typeof ComboBox>
+
+export const MobileOpenMenuWidthClamp: Story = {
+  args: {
+    fieldName: 'condition',
+    label: 'Condition',
+    options,
+    placeholder: 'Type to search for a disease'
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1'
+    }
+  },
+  render: args => (
+    <div className='cove-visualization' style={{ maxWidth: '22rem', padding: '0.5rem' }}>
+      <ComboBoxStory {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const input = within(canvasElement).getByRole('combobox')
+
+    await userEvent.click(input)
+
+    const menu = within(canvasElement).getByRole('listbox')
+    const menuRect = menu.getBoundingClientRect()
+
+    expect(parseFloat(getComputedStyle(menu).maxWidth)).toBeCloseTo(window.innerWidth - 36, 0)
+    expect(menuRect.right).toBeLessThanOrEqual(window.innerWidth)
+    expect(menuRect.width).toBeLessThanOrEqual(window.innerWidth)
+  }
+}
+
+export default meta

--- a/packages/core/components/_stories/NestedDropdown.stories.tsx
+++ b/packages/core/components/_stories/NestedDropdown.stories.tsx
@@ -1,11 +1,25 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect } from 'storybook/test'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
 import NestedDropdown from '../NestedDropdown'
 import nestedDropdownStory from './_mocks/nested-dropdown.json'
 import { useState } from 'react'
 import { getNestedOptions } from '../Filters/helpers/getNestedOptions'
+import type { NestedOptions } from '../NestedDropdown/nestedDropdownHelpers'
+import '../Filters/filters.scss'
 
 const nestedDropdownOptions = getNestedOptions(nestedDropdownStory as any)
+const proportionalSizingOptions: NestedOptions = [
+  [
+    ['Typography'],
+    [
+      ['wide', 'WWWWWWWWWW'],
+      ['long', 'iiiiiiiiiiiiiiiiiiiiiiiiiiii']
+    ]
+  ]
+]
+const wrappingOptions: NestedOptions = [
+  [['Conditions'], [['long', 'A long condition label that should move this filter onto its own flex row']]]
+]
 
 const NestedDropdownStory = args => {
   const [selection, setSelection] = useState({
@@ -15,10 +29,10 @@ const NestedDropdownStory = args => {
 
   return (
     <NestedDropdown
+      {...args}
       handleSelectedItems={([group, subGroup]) => {
         setSelection({ activeGroup: group, activeSubGroup: subGroup })
       }}
-      {...args}
       activeGroup={selection.activeGroup}
       activeSubGroup={selection.activeSubGroup}
     />
@@ -63,6 +77,82 @@ export const SubgroupOnlyDisplay: Story = {
   },
   play: async ({ canvasElement }) => {
     expect(getSearchInput(canvasElement)).toHaveValue('50-64 years')
+  }
+}
+
+export const StableRenderedWidth: Story = {
+  args: {
+    activeGroup: 'Typography',
+    activeSubGroup: 'long',
+    displaySubgroupingOnly: true,
+    filterIndex: 0,
+    handleSelectedItems: () => {},
+    listLabel: 'Rendered width',
+    options: proportionalSizingOptions
+  },
+  render: args => (
+    <div style={{ maxWidth: '60rem' }}>
+      <NestedDropdownStory {...args} />
+      <button type='button'>Finish searching</button>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = getSearchInput(canvasElement) as HTMLInputElement
+    const inputContainer = input.closest('.nested-dropdown-input-container') as HTMLElement
+    const wideCandidate = inputContainer.querySelector('[data-sizing-candidate="WWWWWWWWWW"]') as HTMLElement
+    const longCandidate = inputContainer.querySelector(
+      '[data-sizing-candidate="iiiiiiiiiiiiiiiiiiiiiiiiiiii"]'
+    ) as HTMLElement
+
+    await waitFor(() => expect(inputContainer).toHaveAttribute('data-sizing-text', 'WWWWWWWWWW'))
+    expect(wideCandidate.getBoundingClientRect().width).toBeGreaterThan(longCandidate.getBoundingClientRect().width)
+
+    const stableWidth = inputContainer.getBoundingClientRect().width
+    const longSearch = 'A search phrase that is deliberately wider than every available option'
+
+    await userEvent.click(input)
+    await userEvent.type(input, longSearch)
+    await waitFor(() => expect(inputContainer.getBoundingClientRect().width).toBeGreaterThan(stableWidth))
+    const expandedWidth = inputContainer.getBoundingClientRect().width
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Finish searching' }))
+    await waitFor(() => expect(inputContainer.getBoundingClientRect().width).toBeLessThan(expandedWidth))
+    expect(inputContainer).toHaveAttribute('data-sizing-text', 'WWWWWWWWWW')
+    expect(inputContainer).toHaveAttribute('data-transient-sizing-text', 'iiiiiiiiiiiiiiiiiiiiiiiiiiii')
+  }
+}
+
+export const FlexRowWrapping: Story = {
+  args: {
+    activeGroup: 'Conditions',
+    activeSubGroup: 'long',
+    displaySubgroupingOnly: true,
+    filterIndex: 1,
+    handleSelectedItems: () => {},
+    listLabel: 'Condition',
+    options: wrappingOptions
+  },
+  render: args => (
+    <div className='filters-section__wrapper' style={{ maxWidth: '34rem' }}>
+      <div className='single-filters'>
+        <label htmlFor='topic-filter'>Topic</label>
+        <select id='topic-filter' style={{ padding: '0.5rem', width: '14rem' }}>
+          <option>Adult</option>
+        </select>
+      </div>
+      <div className='single-filters'>
+        <label htmlFor='nested-dropdown-1'>Condition</label>
+        <NestedDropdownStory {...args} />
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const select = canvasElement.querySelector('select') as HTMLSelectElement
+    const nestedDropdown = canvasElement.querySelector('.nested-dropdown') as HTMLElement
+
+    await waitFor(() => expect(nestedDropdown.getBoundingClientRect().width).toBeGreaterThan(200))
+    expect(nestedDropdown.getBoundingClientRect().top).toBeGreaterThan(select.getBoundingClientRect().top)
   }
 }
 

--- a/packages/core/components/_stories/NestedDropdown.stories.tsx
+++ b/packages/core/components/_stories/NestedDropdown.stories.tsx
@@ -156,4 +156,40 @@ export const FlexRowWrapping: Story = {
   }
 }
 
+export const MobileOpenMenuWidthClamp: Story = {
+  args: {
+    activeGroup: '',
+    activeSubGroup: '',
+    displaySubgroupingOnly: true,
+    filterIndex: 0,
+    handleSelectedItems: () => {},
+    listLabel: 'Condition',
+    options: wrappingOptions,
+    placeholder: 'Type to search for a disease'
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1'
+    }
+  },
+  render: args => (
+    <div style={{ maxWidth: '22rem', padding: '0.5rem' }}>
+      <NestedDropdownStory {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const input = getSearchInput(canvasElement)
+
+    await userEvent.click(input as Element)
+
+    const menu = within(canvasElement).getByRole('tree')
+    const menuRect = menu.getBoundingClientRect()
+
+    expect(menu).not.toHaveClass('hide')
+    expect(parseFloat(getComputedStyle(menu).maxWidth)).toBeCloseTo(window.innerWidth - 36, 0)
+    expect(menuRect.right).toBeLessThanOrEqual(window.innerWidth)
+    expect(menuRect.width).toBeLessThanOrEqual(window.innerWidth)
+  }
+}
+
 export default meta

--- a/packages/dashboard/src/components/DashboardFilters/_stories/DashboardFilters.stories.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/_stories/DashboardFilters.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, waitFor } from 'storybook/test'
 import DashboardFilters from '../DashboardFilters'
 import '../../../scss/main.scss'
+
+const longConditionLabel = 'Paratyphoid fever (Salmonella enterica serotypes Paratyphi A, B (tartrate negative) and C)'
 
 const meta: Meta<typeof DashboardFilters> = {
   title: 'Components/Atoms/Inputs/DashboardFilters',
@@ -74,6 +77,61 @@ export const WithClearButton: Story = {
     showSubmit: true,
     applyFilters: () => {},
     handleReset: () => {}
+  }
+}
+
+export const NestedDropdownWithNoteWidthCap: Story = {
+  args: {
+    filters: [
+      {
+        type: 'datafilter',
+        key: 'Condition',
+        filterStyle: 'nested-dropdown',
+        columnName: 'category',
+        showDropdown: true,
+        active: '',
+        resetLabel: 'Type to search for a disease',
+        displaySubgroupingOnly: true,
+        values: ['Enteric diseases'],
+        orderedValues: ['Enteric diseases'],
+        subGrouping: {
+          active: '',
+          columnName: 'condition',
+          valuesLookup: {
+            'Enteric diseases': {
+              values: ['Campylobacteriosis', longConditionLabel],
+              orderedValues: ['Campylobacteriosis', longConditionLabel]
+            }
+          }
+        },
+        note: 'You can search for a disease name or for keywords.'
+      } as any,
+      {
+        type: 'datafilter',
+        key: 'Topic',
+        values: ['Adult'],
+        active: 'Adult',
+        columnName: 'topic',
+        showDropdown: true,
+        id: 1,
+        parents: []
+      } as any
+    ],
+    show: [0, 1],
+    apiFilterDropdowns: {},
+    handleOnChange: () => {}
+  },
+  play: async ({ canvasElement }) => {
+    const form = canvasElement.querySelector('.dashboard-filters__form') as HTMLElement
+    const field = canvasElement.querySelector('.dashboard-filters__field:has(.nested-dropdown)') as HTMLElement
+    const note = field.querySelector('.filters-section__note-text') as HTMLElement
+    const nestedDropdown = field.querySelector('.nested-dropdown') as HTMLElement
+    const inputContainer = field.querySelector('.nested-dropdown-input-container') as HTMLElement
+
+    expect(form).toHaveClass('filters-section__wrapper--multiple')
+    await waitFor(() => expect(inputContainer).toHaveAttribute('data-sizing-text', longConditionLabel))
+    expect(getComputedStyle(field).maxWidth).toBe(getComputedStyle(note).maxWidth)
+    expect(nestedDropdown.getBoundingClientRect().width).toBeLessThanOrEqual(field.getBoundingClientRect().width + 1)
   }
 }
 

--- a/packages/dashboard/src/components/DashboardFilters/_stories/DashboardFilters.stories.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/_stories/DashboardFilters.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, waitFor, within } from 'storybook/test'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
 import DashboardFilters from '../DashboardFilters'
 import '../../../scss/main.scss'
 
@@ -121,6 +121,11 @@ export const NestedDropdownWithNoteWidthCap: Story = {
     apiFilterDropdowns: {},
     handleOnChange: () => {}
   },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1'
+    }
+  },
   render: args => {
     const [conditionFilter, topicFilter] = args.filters
 
@@ -129,7 +134,10 @@ export const NestedDropdownWithNoteWidthCap: Story = {
         <section data-testid='single-filter-example'>
           <h3>Single visible filter: 30rem maximum</h3>
           <p>The note and nested dropdown share the wider single-filter limit.</p>
-          <div style={{ border: '1px dashed #b1b8c0', padding: '1rem' }}>
+          <div
+            className='cdc-callout cdc-callout--dashboard-filters'
+            style={{ border: '1px dashed #b1b8c0', padding: '1rem' }}
+          >
             <DashboardFilters {...args} filters={[conditionFilter]} show={[0]} />
           </div>
         </section>
@@ -137,7 +145,10 @@ export const NestedDropdownWithNoteWidthCap: Story = {
         <section data-testid='multiple-filter-example'>
           <h3>Multiple visible filters: 18rem maximum</h3>
           <p>The same nested dropdown becomes narrower when it shares the row with another filter.</p>
-          <div style={{ border: '1px dashed #b1b8c0', padding: '1rem' }}>
+          <div
+            className='cdc-callout cdc-callout--dashboard-filters'
+            style={{ border: '1px dashed #b1b8c0', padding: '1rem' }}
+          >
             <DashboardFilters {...args} filters={[topicFilter, conditionFilter]} show={[0, 1]} />
           </div>
         </section>
@@ -160,6 +171,7 @@ export const NestedDropdownWithNoteWidthCap: Story = {
     const multipleDropdown = multipleField.querySelector('.nested-dropdown') as HTMLElement
     const singleInputContainer = singleField.querySelector('.nested-dropdown-input-container') as HTMLElement
     const multipleInputContainer = multipleField.querySelector('.nested-dropdown-input-container') as HTMLElement
+    const singleInput = singleField.querySelector('.nested-dropdown input') as HTMLInputElement
 
     expect(singleForm).toHaveClass('filters-section__wrapper--single')
     expect(multipleForm).toHaveClass('filters-section__wrapper--multiple')
@@ -169,13 +181,21 @@ export const NestedDropdownWithNoteWidthCap: Story = {
     })
     expect(getComputedStyle(singleField).maxWidth).toBe(getComputedStyle(singleNote).maxWidth)
     expect(getComputedStyle(multipleField).maxWidth).toBe(getComputedStyle(multipleNote).maxWidth)
-    expect(singleField.getBoundingClientRect().width).toBeGreaterThan(multipleField.getBoundingClientRect().width)
+    expect(singleField.getBoundingClientRect().width).toBeLessThanOrEqual(singleForm.getBoundingClientRect().width)
+    expect(multipleField.getBoundingClientRect().width).toBeLessThanOrEqual(multipleForm.getBoundingClientRect().width)
     expect(singleDropdown.getBoundingClientRect().width).toBeLessThanOrEqual(
       singleField.getBoundingClientRect().width + 1
     )
     expect(multipleDropdown.getBoundingClientRect().width).toBeLessThanOrEqual(
       multipleField.getBoundingClientRect().width + 1
     )
+
+    await userEvent.click(singleInput)
+
+    const menu = within(singleField).getByRole('tree')
+    const menuRect = menu.getBoundingClientRect()
+    expect(menuRect.right).toBeLessThanOrEqual(window.innerWidth)
+    expect(menuRect.width).toBeLessThanOrEqual(window.innerWidth)
   }
 }
 

--- a/packages/dashboard/src/components/DashboardFilters/_stories/DashboardFilters.stories.tsx
+++ b/packages/dashboard/src/components/DashboardFilters/_stories/DashboardFilters.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, waitFor } from 'storybook/test'
+import { expect, waitFor, within } from 'storybook/test'
 import DashboardFilters from '../DashboardFilters'
 import '../../../scss/main.scss'
 
@@ -121,17 +121,61 @@ export const NestedDropdownWithNoteWidthCap: Story = {
     apiFilterDropdowns: {},
     handleOnChange: () => {}
   },
-  play: async ({ canvasElement }) => {
-    const form = canvasElement.querySelector('.dashboard-filters__form') as HTMLElement
-    const field = canvasElement.querySelector('.dashboard-filters__field:has(.nested-dropdown)') as HTMLElement
-    const note = field.querySelector('.filters-section__note-text') as HTMLElement
-    const nestedDropdown = field.querySelector('.nested-dropdown') as HTMLElement
-    const inputContainer = field.querySelector('.nested-dropdown-input-container') as HTMLElement
+  render: args => {
+    const [conditionFilter, topicFilter] = args.filters
 
-    expect(form).toHaveClass('filters-section__wrapper--multiple')
-    await waitFor(() => expect(inputContainer).toHaveAttribute('data-sizing-text', longConditionLabel))
-    expect(getComputedStyle(field).maxWidth).toBe(getComputedStyle(note).maxWidth)
-    expect(nestedDropdown.getBoundingClientRect().width).toBeLessThanOrEqual(field.getBoundingClientRect().width + 1)
+    return (
+      <div style={{ display: 'grid', gap: '2rem' }}>
+        <section data-testid='single-filter-example'>
+          <h3>Single visible filter: 30rem maximum</h3>
+          <p>The note and nested dropdown share the wider single-filter limit.</p>
+          <div style={{ border: '1px dashed #b1b8c0', padding: '1rem' }}>
+            <DashboardFilters {...args} filters={[conditionFilter]} show={[0]} />
+          </div>
+        </section>
+
+        <section data-testid='multiple-filter-example'>
+          <h3>Multiple visible filters: 18rem maximum</h3>
+          <p>The same nested dropdown becomes narrower when it shares the row with another filter.</p>
+          <div style={{ border: '1px dashed #b1b8c0', padding: '1rem' }}>
+            <DashboardFilters {...args} filters={[topicFilter, conditionFilter]} show={[0, 1]} />
+          </div>
+        </section>
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const singleExample = canvas.getByTestId('single-filter-example')
+    const multipleExample = canvas.getByTestId('multiple-filter-example')
+    const singleForm = singleExample.querySelector('.dashboard-filters__form') as HTMLElement
+    const multipleForm = multipleExample.querySelector('.dashboard-filters__form') as HTMLElement
+    const singleField = singleExample.querySelector('.dashboard-filters__field:has(.nested-dropdown)') as HTMLElement
+    const multipleField = multipleExample.querySelector(
+      '.dashboard-filters__field:has(.nested-dropdown)'
+    ) as HTMLElement
+    const singleNote = singleField.querySelector('.filters-section__note-text') as HTMLElement
+    const multipleNote = multipleField.querySelector('.filters-section__note-text') as HTMLElement
+    const singleDropdown = singleField.querySelector('.nested-dropdown') as HTMLElement
+    const multipleDropdown = multipleField.querySelector('.nested-dropdown') as HTMLElement
+    const singleInputContainer = singleField.querySelector('.nested-dropdown-input-container') as HTMLElement
+    const multipleInputContainer = multipleField.querySelector('.nested-dropdown-input-container') as HTMLElement
+
+    expect(singleForm).toHaveClass('filters-section__wrapper--single')
+    expect(multipleForm).toHaveClass('filters-section__wrapper--multiple')
+    await waitFor(() => {
+      expect(singleInputContainer).toHaveAttribute('data-sizing-text', longConditionLabel)
+      expect(multipleInputContainer).toHaveAttribute('data-sizing-text', longConditionLabel)
+    })
+    expect(getComputedStyle(singleField).maxWidth).toBe(getComputedStyle(singleNote).maxWidth)
+    expect(getComputedStyle(multipleField).maxWidth).toBe(getComputedStyle(multipleNote).maxWidth)
+    expect(singleField.getBoundingClientRect().width).toBeGreaterThan(multipleField.getBoundingClientRect().width)
+    expect(singleDropdown.getBoundingClientRect().width).toBeLessThanOrEqual(
+      singleField.getBoundingClientRect().width + 1
+    )
+    expect(multipleDropdown.getBoundingClientRect().width).toBeLessThanOrEqual(
+      multipleField.getBoundingClientRect().width + 1
+    )
   }
 }
 

--- a/packages/dashboard/src/components/DashboardFilters/dashboardfilter.styles.css
+++ b/packages/dashboard/src/components/DashboardFilters/dashboardfilter.styles.css
@@ -7,8 +7,9 @@
 
 .dashboard-filters__field {
   &:has(.nested-dropdown) {
-    flex: 0 0 auto;
+    flex: 0 1 auto;
     max-width: 100%;
+    min-width: 0;
   }
 
   &:has(.nested-dropdown):has(.filters-section__note-text) {
@@ -16,6 +17,10 @@
   }
 
   margin: 0;
+}
+
+.cdc-callout--dashboard-filters {
+  --filter-menu-viewport-gutter: 3.5rem;
 }
 
 .cove-dashboard-filters-container {

--- a/packages/dashboard/src/components/DashboardFilters/dashboardfilter.styles.css
+++ b/packages/dashboard/src/components/DashboardFilters/dashboardfilter.styles.css
@@ -6,6 +6,15 @@
 }
 
 .dashboard-filters__field {
+  &:has(.nested-dropdown) {
+    flex: 0 0 auto;
+    max-width: 100%;
+  }
+
+  &:has(.nested-dropdown):has(.filters-section__note-text) {
+    max-width: var(--filters-section-noted-control-max-width);
+  }
+
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
Updates nested dropdown controls to size themselves using the widest rendered option label while remaining responsive within their available container.

This replaces the previous DEV-10377 implementation with a smaller, behavior-focused approach.

## Changes

- Measures rendered option widths instead of comparing character counts, supporting proportional fonts correctly.
- Keeps the control width stable when selections or available options become shorter.
- Allows long search text to expand the control temporarily without permanently changing its baseline width.
- Resets stable sizing when the dropdown’s sizing context changes.
- Wraps nested filters onto a new flex row instead of squeezing them into cramped widths.
- Caps nested dashboard filters to the configured note width.
- Adds unit and Storybook regression coverage for the sizing and wrapping behavior.