### PR TITLE
waffle chart > add comma functionality

### DIFF
--- a/packages/waffle-chart/CONFIG.md
+++ b/packages/waffle-chart/CONFIG.md
@@ -13,7 +13,7 @@ The config is documented in the order the package reads it:
 | Section | Covers |
 | --- | --- |
 | Identity and data source | Package identity, data loading, and locale handling |
-| Metric calculation | Numerator, denominator, filters, and conditional row selection |
+| Metric calculation | Numerator, denominator, filters, conditional row selection, and display formatting |
 | Copy and markup | Text content and dynamic markup variables |
 | Layout and appearance | Chart shape, spacing, typography, theme, and TP5 shell variants |
 | Trend indicators | Categorical or numeric trend arrows and labels |
@@ -32,7 +32,7 @@ The copy-pasteable minimum config lives in [README.md](./README.md). Its source 
 | `data` | `object[]` | Conditionally | `''` in package defaults; effective data is loaded rows or an authored array | Inline dataset used to calculate the chart value. | A rendered chart needs either `data` or `dataUrl`. Fetched data replaces inline `data` when `dataUrl` is provided. |
 | `dataUrl` | `string` | Conditionally | None | Remote dataset URL fetched at load time. | Supports the same loader formats as [`ConfigureData`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#configuredata) / [`DataSet`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#dataset), including JSON and CSV fetch targets. |
 | `dataMetadata` | `any` | No | None | Metadata returned with `dataUrl` loads and exposed to markup variables. | Usually populated automatically by the loader. |
-| `locale` | `string` | No | `en-US` for markup-variable formatting | Locale used for number formatting and dynamic text. | The editor currently offers `en-US` and `es-MX`; shared markup-variable formatting falls back to `en-US` when omitted. |
+| `locale` | `string` | No | `en-US` | Locale used for number formatting and dynamic text. | The editor currently offers `en-US` and `es-MX`; metric and shared markup-variable formatting fall back to `en-US` when omitted. |
 
 ## Metric Calculation
 
@@ -53,6 +53,8 @@ The copy-pasteable minimum config lives in [README.md](./README.md). Its source 
 | `prefix` | `string` | No | `''` | Text shown before the value. | Commonly used for symbols such as `$`. |
 | `suffix` | `string` | No | `'%'` | Text shown after the value. | Set to `''` when no suffix is wanted. |
 | `roundToPlace` | `number \| string` | No | `'0'` | Decimal precision for rendered numbers. | Numeric values must be `0` or greater. A saved/editor value of `''` is supported and means the renderer does not force fixed decimal precision. |
+| `dataFormat` | `object` | No | `{ commas: false }` | Display formatting options for the rendered metric value. | See `dataFormat.*` below. |
+| `dataFormat.commas` | `boolean` | No | `false` | Adds locale-aware grouping to displayed percentage, numerator, and denominator values. | `true`, `false`. This affects text display only; waffle fills, gauge width, and trend calculations use the raw numeric values. |
 | `valueDescription` | `string` | No | `''` | Short descriptor inserted between the value and denominator. | Example: `out of`. |
 
 ## Copy and Markup

--- a/packages/waffle-chart/src/CdcWaffleChart.tsx
+++ b/packages/waffle-chart/src/CdcWaffleChart.tsx
@@ -66,6 +66,36 @@ const getDynamicWaffleGrid = (unitCount: number) => {
   }
 }
 
+const formatWaffleMetricValue = (value: number | string | null, locale: string | undefined, useCommas: boolean) => {
+  if (value === '' || value === null || value === undefined || !useCommas) {
+    return value
+  }
+
+  const numericValue = Number(value)
+  if (!Number.isFinite(numericValue)) {
+    return value
+  }
+
+  const valueString = String(value)
+  if (/e/i.test(valueString)) {
+    return value
+  }
+
+  const decimalPlaces = Math.min(valueString.includes('.') ? valueString.split('.')[1].length : 0, 20)
+
+  const formatOptions = {
+    useGrouping: true,
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces
+  }
+
+  try {
+    return numericValue.toLocaleString(locale || 'en-US', formatOptions)
+  } catch {
+    return numericValue.toLocaleString('en-US', formatOptions)
+  }
+}
+
 type CdcWaffleChartProps = {
   configUrl?: string
   config?: Config
@@ -605,13 +635,18 @@ const WaffleChart = ({ config, isEditor, link = '', showConfigConfirm, updateCon
   }, [setHeightRatio])
 
   const { contentClasses } = useDataVizClasses(config)
+  const useCommas = config.dataFormat?.commas ?? false
 
   const primaryValue = (
     <>
       {prefix ? prefix : ' '}
-      {config.showPercent ? dataPercentage : waffleNumerator}
+      {config.showPercent
+        ? formatWaffleMetricValue(dataPercentage, config.locale, useCommas)
+        : formatWaffleMetricValue(waffleNumerator, config.locale, useCommas)}
       {suffix ? suffix + ' ' : ' '} {processedValueDescription}{' '}
-      {config.showDenominator && waffleDenominator ? waffleDenominator : ' '}
+      {config.showDenominator && waffleDenominator
+        ? formatWaffleMetricValue(waffleDenominator, config.locale, useCommas)
+        : ' '}
     </>
   )
   const hasPrimaryValue = (config.showPercent ? dataPercentage : waffleNumerator) !== ''

--- a/packages/waffle-chart/src/components/EditorPanel.jsx
+++ b/packages/waffle-chart/src/components/EditorPanel.jsx
@@ -338,6 +338,13 @@ const EditorPanel = memo(props => {
             </div>
           </li>
         </ul>
+        <CheckBox
+          value={config.dataFormat?.commas ?? false}
+          section='dataFormat'
+          fieldName='commas'
+          label='Add commas'
+          updateField={updateField}
+        />
         <>
           <hr className='cove-accordion__divider' />
           <div className='cove-accordion__panel-section reverse-labels'>

--- a/packages/waffle-chart/src/data/initial-state.js
+++ b/packages/waffle-chart/src/data/initial-state.js
@@ -10,6 +10,7 @@ export default {
   subtext: '',
   orientation: 'horizontal',
   data: '',
+  locale: 'en-US',
   filters: [],
   fontSize: '',
   overallFontSize: 'medium',
@@ -25,6 +26,9 @@ export default {
   dataDenomFunction: '',
   suffix: '%',
   roundToPlace: '0',
+  dataFormat: {
+    commas: false
+  },
   shape: 'circle',
   nodeWidth: '10',
   nodeSpacer: '2',

--- a/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
+++ b/packages/waffle-chart/src/test/CdcWaffleChart.test.jsx
@@ -63,6 +63,7 @@ describe('Waffle Chart', () => {
     filters: [],
     content: 'Test content',
     subtext: 'Test subtext',
+    locale: 'en-US',
     dataColumn: 'value',
     dataFunction: 'Sum',
     customDenom: false,
@@ -74,6 +75,9 @@ describe('Waffle Chart', () => {
     valueDescription: 'out of',
     suffix: '%',
     roundToPlace: 0,
+    dataFormat: {
+      commas: false
+    },
     nodeWidth: 10,
     nodeSpacer: 2,
     theme: 'theme-blue',
@@ -155,9 +159,11 @@ describe('Waffle Chart', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Data' }))
 
     const dataColumnSelect = screen.getByLabelText('Data Column')
+    const commasCheckbox = screen.getByLabelText('Add commas')
     const options = Array.from(dataColumnSelect.options).map(option => option.value)
 
     expect(options).toEqual(expect.arrayContaining(['denominator', 'numerator', 'region']))
+    expect(commasCheckbox).not.toBeChecked()
   })
 
   it('renders the legacy count example through the direct config prop path', async () => {
@@ -171,6 +177,95 @@ describe('Waffle Chart', () => {
 
     expect(getPrimaryValueText(container)).toBeTruthy()
     expect(getPrimaryValueText(container)).not.toContain('out of')
+  })
+
+  it('formats displayed numerator and denominator values with commas when enabled', async () => {
+    const { container } = render(
+      <CdcWaffleChart
+        config={createBaseConfig({
+          data: [{ value: 1234, total: 2000 }],
+          customDenom: true,
+          dataDenomColumn: 'total',
+          showPercent: false,
+          showDenominator: true,
+          valueDescription: 'out of',
+          suffix: '',
+          dataFormat: {
+            commas: true
+          }
+        })}
+      />
+    )
+
+    await waitFor(() => {
+      expect(getPrimaryValueText(container)).toContain('1,234 out of 2,000')
+    })
+  })
+
+  it('leaves displayed numerator and denominator values ungrouped when commas are disabled', async () => {
+    const { container } = render(
+      <CdcWaffleChart
+        config={createBaseConfig({
+          data: [{ value: 1234, total: 2000 }],
+          customDenom: true,
+          dataDenomColumn: 'total',
+          showPercent: false,
+          showDenominator: true,
+          valueDescription: 'out of',
+          suffix: '',
+          dataFormat: {
+            commas: false
+          }
+        })}
+      />
+    )
+
+    await waitFor(() => {
+      expect(getPrimaryValueText(container)).toContain('1234 out of 2000')
+    })
+  })
+
+  it('defaults omitted dataFormat to ungrouped displayed values', async () => {
+    const config = createBaseConfig({
+      data: [{ value: 1234, total: 2000 }],
+      customDenom: true,
+      dataDenomColumn: 'total',
+      showPercent: false,
+      showDenominator: true,
+      valueDescription: 'out of',
+      suffix: ''
+    })
+    delete config.dataFormat
+
+    const { container } = render(<CdcWaffleChart config={config} />)
+
+    await waitFor(() => {
+      expect(getPrimaryValueText(container)).toContain('1234 out of 2000')
+    })
+  })
+
+  it('falls back to en-US formatting when the configured locale is invalid', async () => {
+    const { container } = render(
+      <CdcWaffleChart
+        config={createBaseConfig({
+          data: [{ value: 1234, total: 2000 }],
+          customDenom: true,
+          dataDenomColumn: 'total',
+          showPercent: false,
+          showDenominator: true,
+          valueDescription: 'out of',
+          suffix: '',
+          locale: 'en_US',
+          dataFormat: {
+            commas: true
+          }
+        })}
+      />
+    )
+
+    await waitFor(() => {
+      expect(getPrimaryValueText(container)).toContain('1,234 out of 2,000')
+    })
   })
 
   it('runs migrations for legacy configs loaded through configUrl', async () => {

--- a/packages/waffle-chart/src/types/Config.ts
+++ b/packages/waffle-chart/src/types/Config.ts
@@ -16,6 +16,9 @@ export type Config = {
   dataDenom: string
   dataDenomColumn: string
   dataDenomFunction: string
+  dataFormat?: {
+    commas?: boolean
+  }
   dataFunction: string
   dataUrl?: string
   dataMetadata?: any


### PR DESCRIPTION
This pull request adds support for configurable display formatting of metric values in the Waffle Chart, specifically enabling locale-aware grouping (commas) for displayed numbers. It introduces a new `dataFormat.commas` option, updates the UI to allow toggling this setting, ensures consistent handling of locale and formatting, and extends tests and documentation accordingly.

**Display Formatting Improvements**
* Added a new `dataFormat.commas` boolean option to the config, allowing users to toggle locale-aware grouping (e.g., thousands separators) for displayed percentage, numerator, and denominator values. [[1]](diffhunk://#diff-9997f73b750983c55256f892886173c58a6cb74ef4bf09e3206ac96d024a95c8R56-R57) [[2]](diffhunk://#diff-420006440b5c0e3403b54689d6b293d642f3bb231ab8774259575cf94a4827d9R19-R21) [[3]](diffhunk://#diff-0449efbbb95e4b983811f37274ab509c215fc5761e14fb59151c6ab7c6aa311aR29-R31)
* Implemented the `formatWaffleMetricValue` helper to handle number formatting based on the `locale` and `dataFormat.commas` settings, including fallback to `'en-US'` for invalid locales. [[1]](diffhunk://#diff-a1a74b5be16019dde72550b579fce1a80f68c3cbd14b65001d986b53ab90c784R69-R98) [[2]](diffhunk://#diff-a1a74b5be16019dde72550b579fce1a80f68c3cbd14b65001d986b53ab90c784R638-R649)
* Updated the editor panel UI to include an "Add commas" checkbox for toggling the new formatting option.

**Configuration and Defaults**
* Set `locale: 'en-US'` and `dataFormat: { commas: false }` as defaults in the initial state and test configs, and clarified fallback behavior in the documentation. [[1]](diffhunk://#diff-0449efbbb95e4b983811f37274ab509c215fc5761e14fb59151c6ab7c6aa311aR13) [[2]](diffhunk://#diff-fa98e7bdaff2b8638223a6f86c441c602d7236911a4f9364bbf7c4fe76e773a7R66) [[3]](diffhunk://#diff-fa98e7bdaff2b8638223a6f86c441c602d7236911a4f9364bbf7c4fe76e773a7R78-R80) [[4]](diffhunk://#diff-9997f73b750983c55256f892886173c58a6cb74ef4bf09e3206ac96d024a95c8L35-R35)
* Updated documentation to describe the new display formatting options and clarify how locale and formatting are applied. [[1]](diffhunk://#diff-9997f73b750983c55256f892886173c58a6cb74ef4bf09e3206ac96d024a95c8L16-R16) [[2]](diffhunk://#diff-9997f73b750983c55256f892886173c58a6cb74ef4bf09e3206ac96d024a95c8R56-R57)

**Testing**
* Added tests to verify correct rendering of grouped and ungrouped values, default behaviors, and locale fallbacks for the new formatting option. [[1]](diffhunk://#diff-fa98e7bdaff2b8638223a6f86c441c602d7236911a4f9364bbf7c4fe76e773a7R162-R166) [[2]](diffhunk://#diff-fa98e7bdaff2b8638223a6f86c441c602d7236911a4f9364bbf7c4fe76e773a7R182-R270)