### PR TITLE
Fix/bubble map tooltips

### DIFF
--- a/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
+++ b/packages/map/src/components/UsaMap/components/UsaMap.State.tsx
@@ -61,6 +61,7 @@ import { hashObj } from '@cdc/core/helpers/hashObj'
 import { getMatchingPatternForRow } from '../../../helpers/getMatchingPatternForRow'
 import { getConfiguredBubbleLayers } from '../../../helpers/bubbleLayers'
 import { getBubbleRenderData, type BubbleRenderRow } from '../../../helpers/bubbleRenderData'
+import { getBaseGeoTooltipAttributes } from '../../../helpers/baseGeoTooltip'
 const { features: unitedStatesHex } = topoFeature(hexTopoJSON, hexTopoJSON.objects.states)
 
 const DC_GEO_KEY = 'US-DC'
@@ -413,6 +414,7 @@ const UsaMap = () => {
       // If a legend applies, return it with appropriate information.
       if (legendColors && legendColors[0] !== '#000000') {
         const tooltip = applyTooltipsToGeo(geoDisplayName, geoData)
+        const tooltipAttrs = getBaseGeoTooltipAttributes(tooltip, tooltipId, hasBubbleLayers)
         const geoOpacity =
           setSharedFilterValue && isFilterValueSupported && setSharedFilterValue !== geoData[columns.geo.name] ? 0.5 : 1
         const bubbleLabelColor = bubbleLabelColorByState.get(geoKey)
@@ -528,8 +530,7 @@ const UsaMap = () => {
               style={styles}
               onClick={() => geoClickHandler(geoDisplayName, geoData)}
               id={geoName}
-              data-tooltip-id={`tooltip__${tooltipId}`}
-              data-tooltip-html={tooltip}
+              {...tooltipAttrs}
               tabIndex={-1}
               onMouseEnter={e => {
                 // Track hover analytics event if this is a new location

--- a/packages/map/src/components/WorldMap/WorldMap.tsx
+++ b/packages/map/src/components/WorldMap/WorldMap.tsx
@@ -26,6 +26,7 @@ import { generateRuntimeFilters } from '../../helpers/generateRuntimeFilters'
 import { applyLegendToRow } from '../../helpers/applyLegendToRow'
 import { normalizeTopoJsonProperties } from '../../helpers/normalizeTopoJsonProperties'
 import { getConfiguredBubbleLayers } from '../../helpers/bubbleLayers'
+import { getBaseGeoTooltipAttributes } from '../../helpers/baseGeoTooltip'
 import { type MapPosition } from '../../types/MapConfig'
 
 import './worldMap.styles.css'
@@ -315,6 +316,7 @@ const WorldMap = () => {
 
       // If a legend applies, return it with appropriate information.
       const toolTip = applyTooltipsToGeo(geoDisplayName, geoData)
+      const tooltipAttrs = getBaseGeoTooltipAttributes(toolTip, tooltipId, hasBubbleLayers)
       if (legendColors && legendColors[0] !== '#000000') {
         styles = {
           ...styles,
@@ -361,8 +363,7 @@ const WorldMap = () => {
                 specifics: `location: ${locationName?.toLowerCase()}`
               })
             }}
-            data-tooltip-id={`tooltip__${tooltipId}`}
-            data-tooltip-html={toolTip}
+            {...tooltipAttrs}
             data-country-code={geo.properties.iso}
             tabIndex={-1}
           />
@@ -394,8 +395,7 @@ const WorldMap = () => {
               specifics: `location: ${locationName?.toLowerCase()}`
             })
           }}
-          data-tooltip-id={`tooltip__${tooltipId}`}
-          data-tooltip-html={toolTip}
+          {...tooltipAttrs}
           data-country-code={geo.properties.iso}
         />
       )

--- a/packages/map/src/helpers/baseGeoTooltip.ts
+++ b/packages/map/src/helpers/baseGeoTooltip.ts
@@ -1,0 +1,33 @@
+const TOOLTIP_BODY_PATTERN = /<li\b[^>]*class=(["'])[^"']*\btooltip-body\b[^"']*\1/i
+const TOOLTIP_BODY_CONTENT_PATTERN = /<li\b[^>]*class=(["'])[^"']*\btooltip-body\b[^"']*\1[^>]*>(.*?)<\/li>/gis
+
+const hasTooltipBodyContent = (tooltipHtml: string): boolean => {
+  const bodyMatches = [...tooltipHtml.matchAll(TOOLTIP_BODY_CONTENT_PATTERN)]
+  if (!bodyMatches.length) return false
+
+  return bodyMatches.some(match => {
+    const textContent = match[2].replace(/<[^>]*>/g, '').replace(/&nbsp;/gi, ' ').trim()
+    return textContent.length > 0
+  })
+}
+
+export const shouldRenderBaseGeoTooltip = (tooltipHtml: unknown, hasBubbleLayers: boolean): boolean => {
+  if (!tooltipHtml) return false
+  if (!hasBubbleLayers) return true
+  if (typeof tooltipHtml !== 'string') return true
+
+  return TOOLTIP_BODY_PATTERN.test(tooltipHtml) && hasTooltipBodyContent(tooltipHtml)
+}
+
+export const getBaseGeoTooltipAttributes = (
+  tooltipHtml: unknown,
+  tooltipId: string,
+  hasBubbleLayers: boolean
+): { 'data-tooltip-id'?: string; 'data-tooltip-html'?: string } => {
+  if (!shouldRenderBaseGeoTooltip(tooltipHtml, hasBubbleLayers)) return {}
+
+  return {
+    'data-tooltip-id': `tooltip__${tooltipId}`,
+    'data-tooltip-html': String(tooltipHtml)
+  }
+}

--- a/packages/map/src/helpers/tests/baseGeoTooltip.test.ts
+++ b/packages/map/src/helpers/tests/baseGeoTooltip.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { createTooltipBuilder } from '../../hooks/useTooltip'
+import { getBaseGeoTooltipAttributes, shouldRenderBaseGeoTooltip } from '../baseGeoTooltip'
+
+const headingOnlyTooltip = '<p class="tooltip-heading" style="text-transform: none;">State: Alabama</p><ul></ul>'
+const emptyBodyTooltip =
+  '<p class="tooltip-heading" style="text-transform: none;">State: Alabama</p><ul><li class="tooltip-body"></li></ul>'
+const tooltipWithBody =
+  '<p class="tooltip-heading" style="text-transform: none;">State: Alabama</p><ul><li class="tooltip-body">10</li></ul>'
+
+describe('baseGeoTooltip', () => {
+  it('suppresses heading-only base geography tooltips on bubble layer maps', () => {
+    expect(shouldRenderBaseGeoTooltip(headingOnlyTooltip, true)).toBe(false)
+    expect(getBaseGeoTooltipAttributes(headingOnlyTooltip, 'map-tooltip', true)).toEqual({})
+  })
+
+  it('suppresses base geography tooltips with only empty body rows on bubble layer maps', () => {
+    expect(shouldRenderBaseGeoTooltip(emptyBodyTooltip, true)).toBe(false)
+    expect(getBaseGeoTooltipAttributes(emptyBodyTooltip, 'map-tooltip', true)).toEqual({})
+  })
+
+  it('keeps base geography tooltips that include configured data fields on bubble layer maps', () => {
+    expect(shouldRenderBaseGeoTooltip(tooltipWithBody, true)).toBe(true)
+    expect(getBaseGeoTooltipAttributes(tooltipWithBody, 'map-tooltip', true)).toEqual({
+      'data-tooltip-id': 'tooltip__map-tooltip',
+      'data-tooltip-html': tooltipWithBody
+    })
+  })
+
+  it('keeps heading-only base geography tooltips on non-bubble maps', () => {
+    expect(shouldRenderBaseGeoTooltip(headingOnlyTooltip, false)).toBe(true)
+  })
+
+  it('suppresses migrated legacy bubble base geographies with empty top-level tooltip columns', () => {
+    const config = {
+      general: {
+        geoType: 'us',
+        type: 'data',
+        hideGeoColumnInTooltip: false,
+        hidePrimaryColumnInTooltip: false,
+        geoLabelOverride: ''
+      },
+      columns: {
+        geo: { name: '', label: 'Location', tooltip: false, displayColumn: '' },
+        primary: { name: '', label: '', tooltip: true },
+        navigate: { name: '' }
+      },
+      legend: {
+        specialClasses: []
+      },
+      tooltips: {
+        noDataLabel: 'No Data'
+      }
+    }
+
+    const tooltipHtml = createTooltipBuilder(config as any).buildTooltip({ STATE: 'AL', Rate: 10 }, 'Alabama')
+
+    expect(tooltipHtml).toContain('State: Alabama')
+    expect(tooltipHtml).toContain('<li class="tooltip-body"></li>')
+    expect(getBaseGeoTooltipAttributes(tooltipHtml, 'map-tooltip', true)).toEqual({})
+  })
+})


### PR DESCRIPTION
This pull request introduces improvements to how tooltips are rendered for map geographies, especially when bubble layers are present. The main enhancement is that base geography tooltips are now conditionally suppressed if they contain only headings or empty body content, which helps prevent redundant or empty tooltips from appearing on bubble maps. The logic for this is encapsulated in a new helper, and comprehensive tests have been added to ensure correct behavior.

**Tooltip rendering improvements:**

* Added a new helper module `baseGeoTooltip.ts` with logic to determine whether a base geography tooltip should be rendered, based on its content and the presence of bubble layers. Tooltips with only headings or empty bodies are now suppressed on bubble maps. (`packages/map/src/helpers/baseGeoTooltip.ts`)
* Updated `UsaMap.State.tsx` and `WorldMap.tsx` to use the new helper for generating tooltip attributes, replacing direct setting of `data-tooltip-id` and `data-tooltip-html` with a conditional spread of attributes. (`packages/map/src/components/UsaMap/components/UsaMap.State.tsx`, `packages/map/src/components/WorldMap/WorldMap.tsx`) [[1]](diffhunk://#diff-21a7a45120c78985b8e2aa8e40b4f2da0fd11f98a997355882301cf56a6f147dR64) [[2]](diffhunk://#diff-21a7a45120c78985b8e2aa8e40b4f2da0fd11f98a997355882301cf56a6f147dR417) [[3]](diffhunk://#diff-21a7a45120c78985b8e2aa8e40b4f2da0fd11f98a997355882301cf56a6f147dL531-R533) [[4]](diffhunk://#diff-6e4dd1f196ec1546714413a9e4dadfc6e471120ea918234f5b5300dce6dd9ce3R29) [[5]](diffhunk://#diff-6e4dd1f196ec1546714413a9e4dadfc6e471120ea918234f5b5300dce6dd9ce3R319) [[6]](diffhunk://#diff-6e4dd1f196ec1546714413a9e4dadfc6e471120ea918234f5b5300dce6dd9ce3L364-R366) [[7]](diffhunk://#diff-6e4dd1f196ec1546714413a9e4dadfc6e471120ea918234f5b5300dce6dd9ce3L397-R398)

**Testing and validation:**

* Added a comprehensive test suite for the new tooltip logic, covering various scenarios including tooltips with only headings, empty bodies, actual content, and legacy configurations. (`packages/map/src/helpers/tests/baseGeoTooltip.test.ts`)