### PR TITLE
fix: bubble layer data table

### DIFF
--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -144,7 +144,7 @@ Shared filter and table structures are documented in [`@cdc/core`](https://githu
 | `table.showNonGeoData` | Includes non-geographic rows in map-related table output. |
 | `table.showFullGeoNameInCSV` | Adds full geography names to CSV downloads when the formatter can resolve them. |
 | `table.wrapColumns` | Allows map table cell content to wrap instead of staying on one line. |
-| Bubble-only maps | When migrated bubble-only maps leave `columns.geo.name` and `columns.primary.name` blank, table rendering falls back to the first configured `bubble.layers[]` geography and primary columns. Mixed choropleth-plus-bubble maps keep using the top-level map columns. |
+| Bubble layers | Data table rendering includes fields referenced by configured bubble layers. When a data-column bubble layer leaves `bubble.layers[].columns.geo.name` blank, runtime falls back to `columns.geo.name` for layer positioning and table output. Bubble-only maps can also fall back from blank or data-absent top-level `columns.geo.name` and `columns.primary.name` to the first configured bubble layer. |
 
 ## Map Features
 
@@ -156,7 +156,7 @@ Bubble layer settings live under `bubble.layers`. Bubble layers are supported on
 | --- | --- | --- | --- | --- | --- |
 | `bubble.layers` | `array` | No | One empty layer in editor defaults | Ordered bubble overlay layers. | Remove a layer to hide it. Only layers with a primary or size column and the configured location source columns render. |
 | `bubble.layers[].locationSource` | `string` | No | `data-column` | Chooses how the layer positions bubbles. | `data-column`, `latitude-longitude`. The editor labels these as "Use data column" and "Use lat/long". |
-| `bubble.layers[].columns.geo.name` | `string` | Conditionally | `''` | Geography lookup or label column for bubbles. | Required when `locationSource` is `data-column`. When `locationSource` is `latitude-longitude`, this column labels tooltips and table output but does not position bubbles. |
+| `bubble.layers[].columns.geo.name` | `string` | Conditionally | `''` | Geography lookup or label column for bubbles. | Required when `locationSource` is `data-column` unless `columns.geo.name` is configured, in which case runtime falls back to the map geography column. When `locationSource` is `latitude-longitude`, this column labels tooltips and table output but does not position bubbles. |
 | `bubble.layers[].columns.geo.label` | `string` | No | Inherits `columns.geo.label` | Tooltip label for the bubble geography/label column. | Used when `bubble.layers[].columns.geo.tooltip` is `true`. |
 | `bubble.layers[].columns.geo.tooltip` | `boolean` | No | Inherits `columns.geo.tooltip` | Includes the bubble geography/label column in bubble tooltips. | `true`, `false` |
 | `bubble.layers[].columns.latitude.name` | `string` | Conditionally | `''` | Latitude column used to position bubbles directly from row coordinates. | Required with `bubble.layers[].columns.longitude.name` when `locationSource` is `latitude-longitude`. Ignored for bubble positioning when `locationSource` is `data-column`. |

--- a/packages/map/src/CdcMapComponent.tsx
+++ b/packages/map/src/CdcMapComponent.tsx
@@ -61,9 +61,7 @@ import {
 import { prepareSmallMultiplesDataTable } from './helpers/smallMultiplesHelpers'
 import {
   getConfiguredBubbleLayers,
-  getPrimaryBubbleLayer,
-  hasBubbleLayerCoordinateColumns,
-  isBubbleLayerUsingCoordinates,
+  getMapRuntimeGeoColumnName,
   mapConfigForBubbleLayer
 } from './helpers/bubbleLayers'
 
@@ -254,10 +252,8 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
   useEffect(() => {
     // UID
     const bubbleLayers = getConfiguredBubbleLayers(config)
-    const geoColName = config.columns.geo.name || getPrimaryBubbleLayer(config)?.columns.geo.name
-    const hasCoordinateBubbleLayers = bubbleLayers.some(
-      layer => isBubbleLayerUsingCoordinates(layer) && hasBubbleLayerCoordinateColumns(layer)
-    )
+    const geoColName = getMapRuntimeGeoColumnName(config)
+    const hasConfiguredBubbleLayerData = bubbleLayers.length > 0
     if (config.data && geoColName && geoColName !== config.data.fromColumn) {
       addUIDs(config, geoColName)
     }
@@ -300,7 +296,7 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
     })
 
     // Data
-    if (hashData !== runtimeData?.fromHash && (config.data?.fromColumn || hasCoordinateBubbleLayers)) {
+    if (hashData !== runtimeData?.fromHash && (config.data?.fromColumn || hasConfiguredBubbleLayerData)) {
       const isCategoryLegend = config?.legend?.type === 'category'
       const newRuntimeData = generateRuntimeData(
         { ...config, data: configObj.data },
@@ -709,7 +705,7 @@ const CdcMapComponent: React.FC<CdcMapComponent> = ({
                       <DataTable
                         columns={dataTableColumns}
                         config={dataTableConfig}
-                        currentViewport={currentViewport}
+                        viewport={currentViewport}
                         dataConfig={config.dataKey ? datasets?.[config.dataKey] : undefined}
                         displayGeoName={displayGeoName}
                         expandDataTable={table.expanded}

--- a/packages/map/src/helpers/bubbleLayers.ts
+++ b/packages/map/src/helpers/bubbleLayers.ts
@@ -193,11 +193,50 @@ export const hasConfiguredBubbleLayer = (layer?: BubbleLayer): boolean =>
   Boolean(layer?.columns?.primary?.name || layer?.columns?.size?.name) &&
   (isBubbleLayerUsingCoordinates(layer) ? hasBubbleLayerCoordinateColumns(layer) : hasBubbleLayerGeographyColumn(layer))
 
+export const withMapGeoColumnFallback = (config: MapConfig, layer: BubbleLayer): BubbleLayer => {
+  const normalizedLayer = normalizeBubbleLayer(layer)
+  const fallbackGeoColumn = config.columns?.geo
+
+  if (isBubbleLayerUsingCoordinates(normalizedLayer) || normalizedLayer.columns.geo.name || !fallbackGeoColumn?.name) {
+    return normalizedLayer
+  }
+
+  return {
+    ...normalizedLayer,
+    columns: {
+      ...normalizedLayer.columns,
+      geo: {
+        ...fallbackGeoColumn,
+        ...normalizedLayer.columns.geo,
+        name: fallbackGeoColumn.name
+      }
+    }
+  }
+}
+
 export const getConfiguredBubbleLayers = (config: MapConfig): BubbleLayer[] =>
-  getBubbleLayers(config.bubble).filter(hasConfiguredBubbleLayer)
+  getBubbleLayers(config.bubble)
+    .map(layer => withMapGeoColumnFallback(config, layer))
+    .filter(hasConfiguredBubbleLayer)
 
 export const getPrimaryBubbleLayer = (config: MapConfig): BubbleLayer | undefined =>
-  getConfiguredBubbleLayers(config)[0] ?? getBubbleLayers(config.bubble)[0]
+  getConfiguredBubbleLayers(config)[0] ??
+  getBubbleLayers(config.bubble).map(layer => withMapGeoColumnFallback(config, layer))[0]
+
+export const hasDataColumn = (data: unknown, columnName?: string): boolean => {
+  if (!columnName || !Array.isArray(data)) return false
+  return data.some(row => row && typeof row === 'object' && Object.prototype.hasOwnProperty.call(row, columnName))
+}
+
+export const getMapRuntimeGeoColumnName = (config: MapConfig): string => {
+  const mapGeoColumnName = config.columns?.geo?.name || ''
+  const bubbleGeoColumnName = getPrimaryBubbleLayer(config)?.columns?.geo?.name || ''
+
+  if (!mapGeoColumnName) return bubbleGeoColumnName
+  if (!bubbleGeoColumnName || bubbleGeoColumnName === mapGeoColumnName) return mapGeoColumnName
+
+  return hasDataColumn(config.data, mapGeoColumnName) ? mapGeoColumnName : bubbleGeoColumnName
+}
 
 export const getPaletteNameForReverseState = (paletteName = '', isReversed: boolean) => {
   if (isReversed && paletteName && !paletteName.endsWith(REVERSE_PALETTE_SUFFIX)) {

--- a/packages/map/src/helpers/dataTableHelpers.ts
+++ b/packages/map/src/helpers/dataTableHelpers.ts
@@ -2,13 +2,66 @@ import {
   stateFipsToTwoDigit as stateFipsToAbbreviation,
   supportedStatesFipsCodes as supportedStateFipsCodes
 } from '../data/supported-geos'
-import { getPrimaryBubbleLayer } from './bubbleLayers'
+import {
+  getBubbleSizeColumnName,
+  getConfiguredBubbleLayers,
+  getPrimaryBubbleLayer,
+  hasDataColumn
+} from './bubbleLayers'
 import { MapConfig } from '../types/MapConfig'
 
 type DataTablePreparation = {
   config: MapConfig
   columns: MapConfig['columns']
   runtimeData: any
+}
+
+type BubbleTableColumnRole = 'geo' | 'primary' | 'size'
+
+const getColumnLabel = (name: string, label?: string) => label || name
+
+const hasColumnName = (columns: Record<string, any>, name?: string): boolean => {
+  if (!name) return true
+  return Object.values(columns).some((column: any) => column?.name === name)
+}
+
+const getSyntheticBubbleColumnKey = (
+  columns: Record<string, any>,
+  layerIndex: number,
+  role: BubbleTableColumnRole
+): string => {
+  const baseKey = `bubbleLayer${layerIndex}${role.charAt(0).toUpperCase()}${role.slice(1)}`
+  if (!columns[baseKey]) return baseKey
+
+  let index = 2
+  while (columns[`${baseKey}${index}`]) index += 1
+  return `${baseKey}${index}`
+}
+
+const addSyntheticBubbleColumn = (
+  columns: Record<string, any>,
+  layerIndex: number,
+  role: BubbleTableColumnRole,
+  name?: string,
+  label?: string
+): boolean => {
+  if (!name || hasColumnName(columns, name)) return false
+
+  columns[getSyntheticBubbleColumnKey(columns, layerIndex, role)] = {
+    dataTable: true,
+    label: getColumnLabel(name, label),
+    name
+  }
+
+  return true
+}
+
+const shouldUseBubbleColumnForTable = (config: MapConfig, currentName?: string, bubbleName?: string): boolean => {
+  if (!bubbleName) return false
+  if (!currentName) return true
+  if (currentName === bubbleName) return false
+
+  return !hasDataColumn(config.data, currentName) && hasDataColumn(config.data, bubbleName)
 }
 
 /**
@@ -19,10 +72,9 @@ export const shouldShowDataTable = (config: any, table: any, general: any, loadi
 }
 
 /**
- * Migrated bubble-only maps keep their rendered geography/value columns under
- * bubble.layers[0].columns and intentionally clear the top-level map columns.
- * The shared map data table still reads config.columns, so fill only the missing
- * table-facing names from the primary bubble layer.
+ * Bubble layers can carry table-facing geography/value fields outside the
+ * top-level map columns. Fill missing or stale table-facing names from the
+ * configured bubble layers, then add any distinct layer fields to the table.
  */
 export const prepareBubbleMapDataTable = (
   config: MapConfig,
@@ -30,17 +82,18 @@ export const prepareBubbleMapDataTable = (
   runtimeData: any
 ): DataTablePreparation => {
   const bubbleLayer = getPrimaryBubbleLayer(config)
+  const bubbleLayers = getConfiguredBubbleLayers(config)
   const bubbleGeoName = bubbleLayer?.columns?.geo?.name
   const bubblePrimaryName = bubbleLayer?.columns?.primary?.name
 
-  if (!bubbleGeoName && !bubblePrimaryName) {
+  if (!bubbleGeoName && !bubblePrimaryName && !bubbleLayers.length) {
     return { config, columns, runtimeData }
   }
 
   let didUpdateColumns = false
-  const preparedColumns = { ...columns }
+  const preparedColumns = { ...columns } as MapConfig['columns'] & Record<string, any>
 
-  if (!preparedColumns.geo?.name && bubbleGeoName) {
+  if (shouldUseBubbleColumnForTable(config, preparedColumns.geo?.name, bubbleGeoName)) {
     preparedColumns.geo = {
       ...(preparedColumns.geo ?? {}),
       dataTable: preparedColumns.geo?.dataTable ?? true,
@@ -50,7 +103,7 @@ export const prepareBubbleMapDataTable = (
     didUpdateColumns = true
   }
 
-  if (!preparedColumns.primary?.name && bubblePrimaryName) {
+  if (shouldUseBubbleColumnForTable(config, preparedColumns.primary?.name, bubblePrimaryName)) {
     preparedColumns.primary = {
       ...(preparedColumns.primary ?? {}),
       dataTable: preparedColumns.primary?.dataTable ?? true,
@@ -59,6 +112,27 @@ export const prepareBubbleMapDataTable = (
     }
     didUpdateColumns = true
   }
+
+  bubbleLayers.forEach((layer, layerIndex) => {
+    const layerGeo = layer.columns?.geo
+    const layerPrimary = layer.columns?.primary
+    const sizeColumnName = getBubbleSizeColumnName(layer)
+    const layerSize = layer.columns?.size
+
+    didUpdateColumns =
+      addSyntheticBubbleColumn(preparedColumns, layerIndex, 'geo', layerGeo?.name, layerGeo?.label) || didUpdateColumns
+    didUpdateColumns =
+      addSyntheticBubbleColumn(preparedColumns, layerIndex, 'primary', layerPrimary?.name, layerPrimary?.label) ||
+      didUpdateColumns
+    didUpdateColumns =
+      addSyntheticBubbleColumn(
+        preparedColumns,
+        layerIndex,
+        'size',
+        sizeColumnName,
+        layerSize?.label || layer.legend?.size?.title
+      ) || didUpdateColumns
+  })
 
   if (!didUpdateColumns) {
     return { config, columns, runtimeData }

--- a/packages/map/src/helpers/generateRuntimeData.ts
+++ b/packages/map/src/helpers/generateRuntimeData.ts
@@ -7,6 +7,7 @@ import {
   getFiniteBubbleNumber,
   getConfiguredBubbleLayers,
   getPrimaryBubbleLayer,
+  getMapRuntimeGeoColumnName,
   hasBubbleLayerCoordinateColumns,
   isBubbleLayerUsingCoordinates,
   mapConfigForBubbleLayer
@@ -81,7 +82,7 @@ const generateRuntimeData = (
 
     const bubbleLayers = getConfiguredBubbleLayers(configObj)
     const primaryBubbleLayer = getPrimaryBubbleLayer(configObj)
-    const geoColName = configObj.columns.geo.name || primaryBubbleLayer?.columns.geo.name || ''
+    const geoColName = getMapRuntimeGeoColumnName(configObj)
     const coordinateBubbleLayers = bubbleLayers.filter(
       layer => isBubbleLayerUsingCoordinates(layer) && hasBubbleLayerCoordinateColumns(layer)
     )

--- a/packages/map/src/helpers/tests/bubbleLayers.test.ts
+++ b/packages/map/src/helpers/tests/bubbleLayers.test.ts
@@ -10,6 +10,7 @@ import {
   getBubbleSizeLegendItems,
   getBubbleLayerStaticColor,
   getConfiguredBubbleLayers,
+  getMapRuntimeGeoColumnName,
   mapConfigForBubbleLayer,
   normalizeBubbleLayer
 } from '../bubbleLayers'
@@ -197,6 +198,77 @@ describe('bubbleLayers', () => {
     }
 
     expect(getConfiguredBubbleLayers(config)).toEqual([])
+  })
+
+  it('uses the map geography column for data-column bubble layers with blank layer geography', () => {
+    const config: any = {
+      columns: {
+        geo: { name: 'STATE', label: 'Location' }
+      },
+      bubble: {
+        layers: [
+          {
+            columns: {
+              geo: { name: '' },
+              primary: { name: 'Location' },
+              size: { name: 'Rate' }
+            }
+          }
+        ]
+      }
+    }
+
+    expect(getConfiguredBubbleLayers(config)).toEqual([
+      expect.objectContaining({
+        columns: expect.objectContaining({
+          geo: { name: 'STATE', label: 'Location' },
+          primary: { name: 'Location' },
+          size: { name: 'Rate' }
+        })
+      })
+    ])
+  })
+
+  it('uses the bubble geography column for runtime rows when the map geography column is absent from the data', () => {
+    const config: any = {
+      data: [{ STATE: 'Alabama', Rate: 130 }],
+      columns: {
+        geo: { name: 'FIPS Codes', label: 'Location' }
+      },
+      bubble: {
+        layers: [
+          {
+            columns: {
+              geo: { name: 'STATE' },
+              primary: { name: 'Rate' }
+            }
+          }
+        ]
+      }
+    }
+
+    expect(getMapRuntimeGeoColumnName(config)).toBe('STATE')
+  })
+
+  it('preserves the map geography column for runtime rows when it exists in the data', () => {
+    const config: any = {
+      data: [{ 'FIPS Codes': '01', STATE: 'Alabama', Rate: 130 }],
+      columns: {
+        geo: { name: 'FIPS Codes', label: 'Location' }
+      },
+      bubble: {
+        layers: [
+          {
+            columns: {
+              geo: { name: 'STATE' },
+              primary: { name: 'Rate' }
+            }
+          }
+        ]
+      }
+    }
+
+    expect(getMapRuntimeGeoColumnName(config)).toBe('FIPS Codes')
   })
 
   it('treats a size column as sufficient to configure a bubble layer with no data column', () => {

--- a/packages/map/src/helpers/tests/dataTableHelpers.test.ts
+++ b/packages/map/src/helpers/tests/dataTableHelpers.test.ts
@@ -139,7 +139,7 @@ describe('prepareBubbleMapDataTable', () => {
     expect(config.columns.primary.name).toBe('')
   })
 
-  it('preserves top-level map columns when they are already configured', () => {
+  it('preserves top-level map columns when adding bubble layer columns', () => {
     const config = createConfig({
       columns: {
         geo: {
@@ -172,9 +172,198 @@ describe('prepareBubbleMapDataTable', () => {
 
     const prepared = prepareBubbleMapDataTable(config, config.columns, {})
 
-    expect(prepared.config).toBe(config)
-    expect(prepared.columns).toBe(config.columns)
     expect(prepared.config.columns.geo.name).toBe('country')
     expect(prepared.config.columns.primary.name).toBe('outbreakStatus')
+    expect((prepared.config.columns as any).bubbleLayer0Primary).toMatchObject({
+      name: 'diseaseType',
+      label: 'diseaseType',
+      dataTable: true
+    })
+    expect((prepared.config.columns as any).bubbleLayer0Size).toMatchObject({
+      name: 'cases',
+      label: 'cases',
+      dataTable: true
+    })
+  })
+
+  it('adds unique bubble layer primary and size columns alongside configured map columns', () => {
+    const config = createConfig({
+      columns: {
+        geo: {
+          name: 'country',
+          label: 'Country',
+          dataTable: true
+        },
+        primary: {
+          name: 'outbreakStatus',
+          label: 'Active Outbreak',
+          dataTable: true
+        }
+      },
+      bubble: {
+        layers: [
+          {
+            minBubbleSize: 4,
+            maxBubbleSize: 28,
+            extraBubbleBorder: false,
+            showBubbleZeros: false,
+            columns: {
+              geo: { name: 'country' },
+              primary: { name: 'diseaseType', label: 'Disease Type' },
+              size: { name: 'cases', label: 'Case Count' }
+            }
+          }
+        ]
+      }
+    })
+
+    const prepared = prepareBubbleMapDataTable(config, config.columns, {})
+
+    expect(prepared.config.columns.geo.name).toBe('country')
+    expect(prepared.config.columns.primary.name).toBe('outbreakStatus')
+    expect((prepared.config.columns as any).bubbleLayer0Primary).toMatchObject({
+      name: 'diseaseType',
+      label: 'Disease Type',
+      dataTable: true
+    })
+    expect((prepared.config.columns as any).bubbleLayer0Size).toMatchObject({
+      name: 'cases',
+      label: 'Case Count',
+      dataTable: true
+    })
+    expect(Object.values(prepared.config.columns).filter((column: any) => column.name === 'country')).toHaveLength(1)
+  })
+
+  it('adds bubble columns when a data-column layer inherits map geography', () => {
+    const config = createConfig({
+      columns: {
+        geo: {
+          name: 'STATE',
+          label: 'Location',
+          dataTable: true
+        },
+        primary: {
+          name: 'Rate',
+          label: 'Rate',
+          dataTable: true
+        }
+      },
+      bubble: {
+        layers: [
+          {
+            minBubbleSize: 4,
+            maxBubbleSize: 28,
+            extraBubbleBorder: false,
+            showBubbleZeros: false,
+            columns: {
+              geo: { name: '' },
+              primary: { name: 'Location' },
+              size: { name: 'Rate' }
+            }
+          }
+        ]
+      }
+    })
+
+    const prepared = prepareBubbleMapDataTable(config, config.columns, {})
+
+    expect(prepared.config.columns.geo.name).toBe('STATE')
+    expect(prepared.config.columns.primary.name).toBe('Rate')
+    expect((prepared.config.columns as any).bubbleLayer0Primary).toMatchObject({
+      name: 'Location',
+      label: 'Location',
+      dataTable: true
+    })
+    expect(Object.values(prepared.config.columns).filter((column: any) => column.name === 'Rate')).toHaveLength(1)
+  })
+
+  it('uses bubble geography when the configured map geography column is not in the data', () => {
+    const config = createConfig({
+      data: [
+        { STATE: 'Alabama', Rate: 130, Location: 'Vehicle' },
+        { STATE: 'California', Rate: 30, Location: 'Home' }
+      ],
+      columns: {
+        geo: {
+          name: 'FIPS Codes',
+          label: 'Location',
+          dataTable: true
+        },
+        primary: {
+          name: '',
+          label: 'Rate',
+          dataTable: true
+        }
+      },
+      bubble: {
+        layers: [
+          {
+            minBubbleSize: 4,
+            maxBubbleSize: 28,
+            extraBubbleBorder: false,
+            showBubbleZeros: false,
+            columns: {
+              geo: { name: 'STATE' },
+              primary: { name: 'Rate' },
+              size: { name: 'Rate' }
+            }
+          }
+        ]
+      }
+    })
+
+    const prepared = prepareBubbleMapDataTable(config, config.columns, {})
+
+    expect(prepared.config.columns.geo).toMatchObject({
+      name: 'STATE',
+      label: 'Location',
+      dataTable: true
+    })
+    expect(prepared.config.columns.primary).toMatchObject({
+      name: 'Rate',
+      label: 'Rate',
+      dataTable: true
+    })
+    expect((prepared.config.columns as any).bubbleLayer0Geo).toBeUndefined()
+    expect(Object.values(prepared.config.columns).filter((column: any) => column.name === 'Rate')).toHaveLength(1)
+  })
+
+  it('adds the size column for size-only bubble layers', () => {
+    const config = createConfig({
+      bubble: {
+        layers: [
+          {
+            minBubbleSize: 4,
+            maxBubbleSize: 28,
+            extraBubbleBorder: false,
+            showBubbleZeros: false,
+            legend: {
+              size: {
+                title: 'Case Count'
+              }
+            },
+            columns: {
+              geo: { name: 'State' },
+              primary: { name: '' },
+              size: { name: 'Cases' }
+            }
+          }
+        ]
+      }
+    })
+
+    const prepared = prepareBubbleMapDataTable(config, config.columns, {})
+
+    expect(prepared.config.columns.geo).toMatchObject({
+      name: 'State',
+      label: 'Location',
+      dataTable: true
+    })
+    expect(prepared.config.columns.primary.name).toBe('')
+    expect((prepared.config.columns as any).bubbleLayer0Size).toMatchObject({
+      name: 'Cases',
+      label: 'Case Count',
+      dataTable: true
+    })
   })
 })

--- a/packages/map/src/helpers/tests/generateRuntimeData.test.ts
+++ b/packages/map/src/helpers/tests/generateRuntimeData.test.ts
@@ -205,6 +205,51 @@ describe('generateRuntimeData', () => {
     expect(result.BRA.cases).toBe(5)
   })
 
+  it('uses bubble layer geography when the configured map geography column is not present in the data', () => {
+    const config: any = {
+      columns: {
+        geo: { name: 'FIPS Codes' },
+        primary: { name: '' },
+        latitude: { name: '' },
+        longitude: { name: '' },
+        navigate: { name: '' },
+        categorical: { name: '' }
+      },
+      general: {
+        displayAsHex: false,
+        geoType: 'us',
+        type: 'data'
+      },
+      legend: {
+        type: 'equalnumber'
+      },
+      bubble: {
+        layers: [
+          {
+            minBubbleSize: 4,
+            maxBubbleSize: 28,
+            extraBubbleBorder: false,
+            showBubbleZeros: false,
+            columns: {
+              geo: { name: 'STATE' },
+              primary: { name: 'Rate' },
+              size: { name: 'Rate' }
+            }
+          }
+        ]
+      },
+      data: [
+        { STATE: 'Alabama', Rate: '130' },
+        { STATE: 'California', Rate: '30' }
+      ]
+    }
+
+    const result = generateRuntimeData(config, [], 3, false)
+
+    expect(Object.keys(result)).toEqual(['US-AL', 'US-CA'])
+    expect(result['US-AL']).toMatchObject({ STATE: 'Alabama', Rate: 130 })
+  })
+
   it('keeps a unified bubble size scale and legend when filtered layer runtime data changes', () => {
     const config: any = {
       columns: {

--- a/packages/map/src/test/CdcMapComponent.dataTable.test.tsx
+++ b/packages/map/src/test/CdcMapComponent.dataTable.test.tsx
@@ -105,6 +105,244 @@ describe('CdcMapComponent data table wiring', () => {
     })
   })
 
+  it('passes runtime rows to DataTable for layer-only data-column bubble maps', async () => {
+    const data = [
+      { State: 'California', Cases: 12 },
+      { State: 'Texas', Cases: 20 }
+    ]
+
+    render(
+      <CdcMapComponent
+        config={
+          {
+            type: 'map',
+            data,
+            general: {
+              title: 'Layer-only Bubble Map',
+              geoType: 'us',
+              type: 'data',
+              showTitle: true
+            },
+            columns: {
+              geo: { name: '', label: 'Location', dataTable: true },
+              primary: { name: '', label: 'Cases', dataTable: true, prefix: '', suffix: '' },
+              navigate: { name: '' },
+              latitude: { name: '' },
+              longitude: { name: '' }
+            },
+            bubble: {
+              layers: [
+                {
+                  minBubbleSize: 4,
+                  maxBubbleSize: 28,
+                  extraBubbleBorder: false,
+                  showBubbleZeros: false,
+                  columns: {
+                    geo: { name: 'State' },
+                    primary: { name: 'Cases' }
+                  }
+                }
+              ]
+            },
+            legend: {
+              type: 'equalnumber',
+              numberOfItems: 3,
+              specialClasses: [],
+              unified: false
+            },
+            table: {
+              forceDisplay: true,
+              expanded: true,
+              download: true,
+              label: 'Data Table',
+              indexLabel: '',
+              showNonGeoData: false
+            },
+            filters: []
+          } as any
+        }
+        datasets={{} as any}
+        isDashboard={true}
+        interactionLabel='layer-only-bubble-table-test'
+        navigationHandler={vi.fn()}
+        setSharedFilter={vi.fn()}
+        setSharedFilterValue={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(dataTableProps.at(-1)?.runtimeData?.['US-CA']).toBeTruthy())
+
+    const latestProps = dataTableProps.at(-1)
+    expect(latestProps.columns.geo.name).toBe('State')
+    expect(latestProps.columns.primary.name).toBe('Cases')
+    expect(Object.keys(latestProps.runtimeData)).toEqual(['US-CA', 'US-TX'])
+    expect(latestProps.runtimeData['US-CA']).toMatchObject({ State: 'California', Cases: 12 })
+  })
+
+  it('uses bubble layer geography for DataTable rows when the map geography column is a stale default', async () => {
+    const data = [
+      { STATE: 'Alabama', Rate: 130, Location: 'Vehicle' },
+      { STATE: 'California', Rate: 30, Location: 'Home' }
+    ]
+
+    render(
+      <CdcMapComponent
+        config={
+          {
+            type: 'map',
+            data,
+            general: {
+              title: 'Stale Geo Bubble Map',
+              geoType: 'us',
+              type: 'data',
+              showTitle: true
+            },
+            columns: {
+              geo: { name: 'FIPS Codes', label: 'Location', dataTable: true },
+              primary: { name: '', label: 'Rate', dataTable: true, prefix: '', suffix: '' },
+              navigate: { name: '' },
+              latitude: { name: '' },
+              longitude: { name: '' }
+            },
+            bubble: {
+              layers: [
+                {
+                  minBubbleSize: 4,
+                  maxBubbleSize: 28,
+                  extraBubbleBorder: false,
+                  showBubbleZeros: false,
+                  columns: {
+                    geo: { name: 'STATE' },
+                    primary: { name: 'Rate' },
+                    size: { name: 'Rate' }
+                  }
+                }
+              ]
+            },
+            legend: {
+              type: 'equalnumber',
+              numberOfItems: 3,
+              specialClasses: [],
+              unified: false
+            },
+            table: {
+              forceDisplay: true,
+              expanded: true,
+              download: true,
+              label: 'Data Table',
+              indexLabel: '',
+              showNonGeoData: false
+            },
+            filters: []
+          } as any
+        }
+        datasets={{} as any}
+        isDashboard={true}
+        interactionLabel='stale-geo-bubble-table-test'
+        navigationHandler={vi.fn()}
+        setSharedFilter={vi.fn()}
+        setSharedFilterValue={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(dataTableProps.at(-1)?.runtimeData?.['US-AL']).toBeTruthy())
+
+    const latestProps = dataTableProps.at(-1)
+    expect(latestProps.columns.geo.name).toBe('STATE')
+    expect(latestProps.columns.primary.name).toBe('Rate')
+    expect(Object.keys(latestProps.runtimeData)).toEqual(['US-AL', 'US-CA'])
+    expect(latestProps.runtimeData['US-AL']).toMatchObject({ STATE: 'Alabama', Rate: 130, Location: 'Vehicle' })
+  })
+
+  it('passes bubble-specific columns to DataTable when layer geography inherits from map columns', async () => {
+    const data = [
+      { State: 'California', Outbreak: 'Yes', Disease: 'Influenza', Cases: 12 },
+      { State: 'Texas', Outbreak: 'No', Disease: 'Measles', Cases: 20 }
+    ]
+
+    render(
+      <CdcMapComponent
+        config={
+          {
+            type: 'map',
+            data,
+            general: {
+              title: 'Layered Bubble Map',
+              geoType: 'us',
+              type: 'data',
+              showTitle: true
+            },
+            columns: {
+              geo: { name: 'State', label: 'Location', dataTable: true },
+              primary: { name: 'Outbreak', label: 'Active Outbreak', dataTable: true, prefix: '', suffix: '' },
+              navigate: { name: '' },
+              latitude: { name: '' },
+              longitude: { name: '' }
+            },
+            bubble: {
+              layers: [
+                {
+                  minBubbleSize: 4,
+                  maxBubbleSize: 28,
+                  extraBubbleBorder: false,
+                  showBubbleZeros: false,
+                  columns: {
+                    geo: { name: '' },
+                    primary: { name: 'Disease', label: 'Disease Type' },
+                    size: { name: 'Cases', label: 'Case Count' }
+                  }
+                }
+              ]
+            },
+            legend: {
+              type: 'category',
+              numberOfItems: 3,
+              specialClasses: [],
+              unified: false
+            },
+            table: {
+              forceDisplay: true,
+              expanded: true,
+              download: true,
+              label: 'Data Table',
+              indexLabel: '',
+              showNonGeoData: false
+            },
+            filters: []
+          } as any
+        }
+        datasets={{} as any}
+        isDashboard={true}
+        interactionLabel='bubble-specific-columns-table-test'
+        navigationHandler={vi.fn()}
+        setSharedFilter={vi.fn()}
+        setSharedFilterValue={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(dataTableProps.at(-1)?.runtimeData?.['US-CA']).toBeTruthy())
+
+    const latestProps = dataTableProps.at(-1)
+    expect(latestProps.columns.geo.name).toBe('State')
+    expect(latestProps.columns.primary.name).toBe('Outbreak')
+    expect(latestProps.columns.bubbleLayer0Primary).toMatchObject({
+      name: 'Disease',
+      label: 'Disease Type',
+      dataTable: true
+    })
+    expect(latestProps.columns.bubbleLayer0Size).toMatchObject({
+      name: 'Cases',
+      label: 'Case Count',
+      dataTable: true
+    })
+    expect(latestProps.runtimeData['US-CA']).toMatchObject({
+      State: 'California',
+      Outbreak: 'Yes',
+      Disease: 'Influenza',
+      Cases: 12
+    })
+  })
+
   it('keeps map footnotes visible when the data table is collapsed by default', async () => {
     const dataset = {
       data: [

--- a/packages/map/src/test/CdcMapComponent.renderedDataTable.test.tsx
+++ b/packages/map/src/test/CdcMapComponent.renderedDataTable.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react'
+import { render, screen, within, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import CdcMapComponent from '../CdcMapComponent'
+
+Object.defineProperty((globalThis as any).HTMLCanvasElement.prototype, 'getContext', {
+  configurable: true,
+  value: () => ({
+    measureText: (text = '') => ({ width: String(text).length * 8 })
+  })
+})
+
+vi.mock('../components/MapContainer', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    default: () => React.createElement('div', { 'data-testid': 'mock-map-container' })
+  }
+})
+
+describe('CdcMapComponent rendered data table', () => {
+  it('renders rows and bubble columns for the editor-created US state bubble layer flow', async () => {
+    const data = [
+      { STATE: 'Overall', Rate: 55, Location: 'Vehicle' },
+      { STATE: 'Alabama', Rate: 130, Location: 'Vehicle' },
+      { STATE: 'California', Rate: 30, Location: 'Home' }
+    ]
+
+    render(
+      <CdcMapComponent
+        config={
+          {
+            type: 'map',
+            data,
+            general: {
+              title: 'US State Bubble Table',
+              geoType: 'us',
+              type: 'data',
+              showTitle: true,
+              showSidebar: true,
+              allowMapZoom: true,
+              displayStateLabels: false,
+              hideGeoColumnInTooltip: false,
+              hidePrimaryColumnInTooltip: false
+            },
+            columns: {
+              geo: { name: 'FIPS Codes', label: 'Location', tooltip: false, dataTable: true },
+              primary: {
+                name: '',
+                label: 'Rate',
+                dataTable: true,
+                tooltip: true,
+                prefix: '',
+                suffix: '',
+                roundToPlace: 0
+              },
+              navigate: { name: '' },
+              latitude: { name: '' },
+              longitude: { name: '' }
+            },
+            bubble: {
+              layers: [
+                {
+                  minBubbleSize: 4,
+                  maxBubbleSize: 28,
+                  extraBubbleBorder: false,
+                  showBubbleZeros: false,
+                  columns: {
+                    geo: { name: 'STATE' },
+                    primary: { name: 'Rate' },
+                    size: { name: 'Rate' }
+                  },
+                  legend: {
+                    size: { show: true }
+                  }
+                }
+              ]
+            },
+            legend: {
+              type: 'equalnumber',
+              numberOfItems: 3,
+              specialClasses: [],
+              unified: false,
+              position: 'top',
+              style: 'gradient',
+              descriptions: {}
+            },
+            table: {
+              forceDisplay: true,
+              expanded: true,
+              download: false,
+              label: 'Data Table',
+              indexLabel: '',
+              showNonGeoData: false,
+              showDownloadLinkBelow: true,
+              wrapColumns: false,
+              collapsible: false
+            },
+            filters: [],
+            runtime: { editorErrorMessage: [] },
+            map: { layers: [], patterns: [] },
+            visual: { border: false, additionalCityStyles: [] },
+            tooltips: { appearanceType: 'hover' }
+          } as any
+        }
+        datasets={{} as any}
+        isDashboard={false}
+        interactionLabel='rendered-bubble-table-test'
+        navigationHandler={vi.fn()}
+        setSharedFilter={vi.fn()}
+        setSharedFilterValue={vi.fn()}
+      />
+    )
+
+    const table = await screen.findByRole('table')
+
+    await waitFor(() => {
+      expect(within(table).queryByText('No Data')).not.toBeInTheDocument()
+      expect(within(table).getByText('Alabama')).toBeInTheDocument()
+    })
+
+    expect(within(table).getByText('California')).toBeInTheDocument()
+    expect(within(table).getAllByRole('columnheader', { name: /Location/ })).toHaveLength(1)
+    expect(within(table).getByRole('columnheader', { name: /Rate/ })).toBeInTheDocument()
+    expect(within(table).queryByText('Overall')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
This pull request improves how bubble layers interact with map data tables and geography columns, ensuring that table rendering and runtime processing correctly handle cases where bubble layers provide their own geography/value columns or need to fall back to the map’s main columns. It also enhances the logic for selecting which geography column to use at runtime, adds synthetic columns for bubble layers to the data table, and updates documentation and tests to reflect these changes.

**Bubble layer and geography column handling:**
- Added a fallback mechanism so that bubble layers with blank or missing `columns.geo.name` will use the map’s main geography column (`columns.geo.name`) for positioning and table output, ensuring smoother migration and configuration flexibility. (`withMapGeoColumnFallback`, `getConfiguredBubbleLayers`, `getPrimaryBubbleLayer`, `getMapRuntimeGeoColumnName`) [[1]](diffhunk://#diff-42f17d3bed85dbee0480fcffa8dde11a5145767ae5e8b67b2c7c80e9b98364b8R196-R239) [[2]](diffhunk://#diff-70594a91b13dfd803e46162efe13c762786d8e59d397ea3ba3530ef52d3ec339R10) [[3]](diffhunk://#diff-70594a91b13dfd803e46162efe13c762786d8e59d397ea3ba3530ef52d3ec339L84-R85) [[4]](diffhunk://#diff-13aae024794a33b190cf70b36ad788cd6f03913128f1d78437915ef383f854e7L64-R64) [[5]](diffhunk://#diff-13aae024794a33b190cf70b36ad788cd6f03913128f1d78437915ef383f854e7L257-R256) [[6]](diffhunk://#diff-13aae024794a33b190cf70b36ad788cd6f03913128f1d78437915ef383f854e7L303-R299) [[7]](diffhunk://#diff-0cf93349cdd96836632520237ac9c69ede4d318ef2188630ccab17fbbe6bc6e6R13) [[8]](diffhunk://#diff-0cf93349cdd96836632520237ac9c69ede4d318ef2188630ccab17fbbe6bc6e6R203-R273)
- Improved runtime selection of the geography column for UID generation and data processing: now uses the bubble layer’s geography column if the map’s column is missing from the data, otherwise prefers the map’s column. (`getMapRuntimeGeoColumnName`, related logic in `CdcMapComponent` and `generateRuntimeData`) [[1]](diffhunk://#diff-42f17d3bed85dbee0480fcffa8dde11a5145767ae5e8b67b2c7c80e9b98364b8R196-R239) [[2]](diffhunk://#diff-70594a91b13dfd803e46162efe13c762786d8e59d397ea3ba3530ef52d3ec339L84-R85) [[3]](diffhunk://#diff-13aae024794a33b190cf70b36ad788cd6f03913128f1d78437915ef383f854e7L257-R256)

**Data table rendering and configuration:**
- Enhanced data table preparation to fill missing or mismatched table-facing columns from bubble layers, and to add synthetic columns for each bubble layer’s geography, primary, and size fields, ensuring all relevant bubble data appears in the table. (`prepareBubbleMapDataTable`, `addSyntheticBubbleColumn`, `shouldUseBubbleColumnForTable`) [[1]](diffhunk://#diff-83cf85b1ed2aa5a3719d00c65a42eebbd87aa8c3b0c1b801cd1fdc0203a874c4L5-R10) [[2]](diffhunk://#diff-83cf85b1ed2aa5a3719d00c65a42eebbd87aa8c3b0c1b801cd1fdc0203a874c4R19-R66) [[3]](diffhunk://#diff-83cf85b1ed2aa5a3719d00c65a42eebbd87aa8c3b0c1b801cd1fdc0203a874c4L22-R96) [[4]](diffhunk://#diff-83cf85b1ed2aa5a3719d00c65a42eebbd87aa8c3b0c1b801cd1fdc0203a874c4L53-R106) [[5]](diffhunk://#diff-83cf85b1ed2aa5a3719d00c65a42eebbd87aa8c3b0c1b801cd1fdc0203a874c4R116-R136)
- Updated the `DataTable` component prop from `currentViewport` to `viewport` for consistency.

**Documentation and testing:**
- Updated documentation to clarify bubble layer fallback behavior and table rendering logic. [[1]](diffhunk://#diff-01826e729e2622db4ab1d0c6a2b699bdefbed257779c2fe1ec347cceed9a0de0L147-R147) [[2]](diffhunk://#diff-01826e729e2622db4ab1d0c6a2b699bdefbed257779c2fe1ec347cceed9a0de0L159-R159)
- Added and updated tests to verify new fallback and selection logic for geography columns and bubble layers. [[1]](diffhunk://#diff-0cf93349cdd96836632520237ac9c69ede4d318ef2188630ccab17fbbe6bc6e6R203-R273) [[2]](diffhunk://#diff-031b648a18eaeedda620083f3bdd67be62171ea6f13f5225a5a81c7d10168a18L142-R142)