### PR TITLE
Fix: Standalone data table download format

### DIFF
--- a/packages/core/components/DataTable/DataTableStandAlone.test.tsx
+++ b/packages/core/components/DataTable/DataTableStandAlone.test.tsx
@@ -4,11 +4,13 @@ import { describe, expect, it, vi } from 'vitest'
 
 import DataTableStandAlone from './DataTableStandAlone'
 
+const renderRows = (rows = []) => JSON.stringify(rows)
+
 vi.mock('./DataTable', () => ({
   default: ({ dataConfig, rawData, runtimeData, onExpandedChange }) => (
     <>
-      <div data-testid='raw-data'>{rawData.map(row => row.name).join(',')}</div>
-      <div data-testid='runtime-data'>{runtimeData.map(row => row.name).join(',')}</div>
+      <div data-testid='raw-data'>{renderRows(rawData)}</div>
+      <div data-testid='runtime-data'>{renderRows(runtimeData)}</div>
       <div data-testid='dataset-url'>{dataConfig?.dataUrl || ''}</div>
       <button type='button' onClick={() => onExpandedChange?.(false)}>
         Collapse table
@@ -42,6 +44,10 @@ vi.mock('../EditorWrapper/EditorWrapper', () => ({
 }))
 
 describe('DataTableStandAlone', () => {
+  const expectRows = (testId: string, rows: Record<string, any>[]) => {
+    expect(screen.getByTestId(testId)).toHaveTextContent(JSON.stringify(rows))
+  }
+
   it('updates rendered rows when dashboard-filtered config data changes', async () => {
     const filters = []
     const config = {
@@ -54,7 +60,7 @@ describe('DataTableStandAlone', () => {
 
     const { rerender } = render(<DataTableStandAlone visualizationKey='tableA' config={config} />)
 
-    expect(screen.getByTestId('runtime-data')).toHaveTextContent('Alice')
+    expectRows('runtime-data', [{ name: 'Alice' }])
 
     rerender(
       <DataTableStandAlone
@@ -67,7 +73,7 @@ describe('DataTableStandAlone', () => {
       />
     )
 
-    await waitFor(() => expect(screen.getByTestId('runtime-data')).toHaveTextContent('Bob'))
+    await waitFor(() => expectRows('runtime-data', [{ name: 'Bob' }]))
     expect(screen.getByTestId('runtime-data')).not.toHaveTextContent('Alice')
   })
 
@@ -157,13 +163,15 @@ describe('DataTableStandAlone', () => {
     expect(screen.getByTestId('dataset-url')).toHaveTextContent('/wcms/vizdata/people.json')
   })
 
-  it('uses full dashboard dataset rows as rawData while rendering dashboard-filtered rows', () => {
+  it('uses plain dashboard dataset rows as rawData while rendering dashboard-filtered rows', () => {
+    const runtimeRows = [{ name: 'Alice' }]
+    const datasetRows = [{ name: 'Alice' }, { name: 'Bob' }]
     const config = {
       type: 'table',
       visualizationType: 'table',
       dataKey: 'people',
       filters: [],
-      data: [{ name: 'Alice' }],
+      data: runtimeRows,
       table: { expanded: true, label: 'People' }
     } as any
 
@@ -173,16 +181,151 @@ describe('DataTableStandAlone', () => {
         config={config}
         datasets={{
           people: {
-            data: [{ name: 'Alice' }, { name: 'Bob' }],
+            data: datasetRows,
             dataUrl: '/wcms/vizdata/people.json'
           }
         }}
       />
     )
 
-    expect(screen.getByTestId('runtime-data')).toHaveTextContent('Alice')
+    expectRows('runtime-data', runtimeRows)
     expect(screen.getByTestId('runtime-data')).not.toHaveTextContent('Bob')
-    expect(screen.getByTestId('raw-data')).toHaveTextContent('Alice,Bob')
+    expectRows('raw-data', datasetRows)
+  })
+
+  it('keeps formattedData dataset-backed for rawData when originalFormattedData is absent', () => {
+    const datasetRows = [{ name: 'Alice' }, { name: 'Bob' }]
+    const formattedRows = [{ name: 'Alice' }]
+    const config = {
+      type: 'table',
+      visualizationType: 'table',
+      dataKey: 'people',
+      filters: [],
+      data: [{ name: 'Alice' }],
+      formattedData: formattedRows,
+      table: { expanded: true, label: 'People' }
+    } as any
+
+    render(
+      <DataTableStandAlone
+        visualizationKey='tableA'
+        config={config}
+        datasets={{
+          people: {
+            data: datasetRows,
+            dataUrl: '/wcms/vizdata/people.json'
+          }
+        }}
+      />
+    )
+
+    expectRows('runtime-data', formattedRows)
+    expectRows('raw-data', datasetRows)
+  })
+
+  it('uses original formattedData as rawData when dashboard filters narrow the displayed transformed rows', () => {
+    const sourceRows = [
+      { dataDescription: 'Visits', ageGroup: '0-4 years', value: 10 },
+      { dataDescription: 'Admissions', ageGroup: '0-4 years', value: 3 },
+      { dataDescription: 'Visits', ageGroup: '5-17 years', value: 20 },
+      { dataDescription: 'Admissions', ageGroup: '5-17 years', value: 7 }
+    ]
+    const pivotedRows = [
+      { ageGroup: '0-4 years', Visits: 10, Admissions: 3 },
+      { ageGroup: '5-17 years', Visits: 20, Admissions: 7 }
+    ]
+    const filteredPivotedRows = [{ ageGroup: '0-4 years', Visits: 10, Admissions: 3 }]
+    const config = {
+      type: 'table',
+      visualizationType: 'table',
+      dataKey: 'nssp',
+      filters: [],
+      data: filteredPivotedRows,
+      formattedData: filteredPivotedRows,
+      originalFormattedData: pivotedRows,
+      table: { expanded: true, label: 'NSSP', downloadVisibleDataOnly: false }
+    } as any
+
+    render(
+      <DataTableStandAlone
+        visualizationKey='tableA'
+        config={config}
+        datasets={{
+          nssp: {
+            data: sourceRows,
+            dataUrl: '/wcms/vizdata/nssp.json'
+          }
+        }}
+      />
+    )
+
+    expectRows('runtime-data', filteredPivotedRows)
+    expectRows('raw-data', pivotedRows)
+  })
+
+  it('uses nested dataset tableData unless originalFormattedData is available', () => {
+    const nestedRows = [{ name: 'Nested Alice' }, { name: 'Nested Bob' }]
+    const config = {
+      type: 'table',
+      visualizationType: 'table',
+      dataKey: 'people',
+      filters: [],
+      data: [{ tableData: nestedRows }],
+      table: { expanded: true, label: 'People' }
+    } as any
+
+    const { rerender } = render(
+      <DataTableStandAlone
+        visualizationKey='tableA'
+        config={config}
+        datasets={{
+          people: {
+            data: [{ tableData: nestedRows, chartValue: 42 }],
+            dataUrl: '/wcms/vizdata/people.json'
+          }
+        }}
+      />
+    )
+
+    expectRows('raw-data', nestedRows)
+
+    const transformedRows = [{ group: 'Total', count: 2 }]
+    rerender(
+      <DataTableStandAlone
+        visualizationKey='tableA'
+        config={{ ...config, formattedData: transformedRows, originalFormattedData: transformedRows }}
+        datasets={{
+          people: {
+            data: [{ tableData: nestedRows, chartValue: 42 }],
+            dataUrl: '/wcms/vizdata/people.json'
+          }
+        }}
+      />
+    )
+
+    expectRows('raw-data', transformedRows)
+  })
+
+  it('keeps runtimeData as filtered display data when rawData comes from originalFormattedData', () => {
+    const formattedRows = [
+      { name: 'Visible Alice', group: 'included' },
+      { name: 'Hidden Bob', group: 'excluded' }
+    ]
+    const filteredRows = [{ name: 'Visible Alice', group: 'included' }]
+    const config = {
+      type: 'table',
+      visualizationType: 'table',
+      filters: [{ columnName: 'group', active: 'included', values: ['included', 'excluded'] }],
+      data: [{ name: 'Long Alice' }, { name: 'Long Bob' }],
+      formattedData: filteredRows,
+      originalFormattedData: formattedRows,
+      table: { expanded: true, label: 'People' }
+    } as any
+
+    render(<DataTableStandAlone visualizationKey='tableA' config={config} />)
+
+    expectRows('runtime-data', filteredRows)
+    expectRows('raw-data', formattedRows)
   })
 
   it('hides footnotes when the table collapses', () => {

--- a/packages/core/components/DataTable/DataTableStandAlone.tsx
+++ b/packages/core/components/DataTable/DataTableStandAlone.tsx
@@ -26,6 +26,14 @@ const getTableSourceData = (config: TableConfig) => {
   return config.data
 }
 
+const getStandaloneDownloadRawData = (config: TableConfig, dataConfig?: Datasets[string]) => {
+  if (Array.isArray(config.originalFormattedData) && config.originalFormattedData.length > 0) {
+    return config.originalFormattedData
+  }
+
+  return dataConfig?.data?.[0]?.tableData || dataConfig?.data || config.data
+}
+
 const DataTableStandAlone: React.FC<StandAloneProps> = ({
   visualizationKey,
   config,
@@ -55,7 +63,7 @@ const DataTableStandAlone: React.FC<StandAloneProps> = ({
   }
 
   const dataConfig = config.dataKey ? datasets?.[config.dataKey] : undefined
-  const rawData = dataConfig?.data?.[0]?.tableData || dataConfig?.data || config.data
+  const rawData = getStandaloneDownloadRawData(config, dataConfig)
   const isDashboardTable = Boolean(config.dataKey && datasets)
 
   if (isEditor)

--- a/packages/dashboard/src/helpers/getVizConfig.ts
+++ b/packages/dashboard/src/helpers/getVizConfig.ts
@@ -5,8 +5,20 @@ import DataTransform from '@cdc/core/helpers/DataTransform'
 import { getApplicableFilters } from './getFilteredData'
 import { filterData } from './filterData'
 import { AnyVisualization } from '@cdc/core/types/Visualization'
+import { getFormattedData } from './getFormattedData'
 
 const transform = new DataTransform()
+
+const getOriginalFormattedTableData = (visualizationConfig: AnyVisualization, data: Object) => {
+  const dataKey = visualizationConfig.dataKey
+  const sourceData = dataKey ? data?.[dataKey] : undefined
+
+  if (visualizationConfig.type !== 'table' || !visualizationConfig.dataDescription || !Array.isArray(sourceData)) {
+    return
+  }
+
+  return getFormattedData(sourceData, visualizationConfig.dataDescription)
+}
 
 const getFootnotesVizConfig = (
   visualizationConfig: AnyVisualization,
@@ -93,7 +105,9 @@ export const getVizConfig = (
   const dataKey = visualizationConfig.dataKey || 'backwards-compatibility'
   const hasFilteredDataOverride = Array.isArray(filteredDataOverride)
 
-  if (visualizationConfig.formattedData) visualizationConfig.originalFormattedData = visualizationConfig.formattedData
+  const originalFormattedData =
+    getOriginalFormattedTableData(visualizationConfig, data) || visualizationConfig.formattedData
+  if (originalFormattedData) visualizationConfig.originalFormattedData = originalFormattedData
   if (visualizationConfig.type === 'chart' && visualizationConfig.yAxis?.filterDomainBehavior === 'stable') {
     let fullEligibleDomainData
     if (hasFilteredDataOverride) {

--- a/packages/dashboard/src/helpers/tests/getVizConfig.test.ts
+++ b/packages/dashboard/src/helpers/tests/getVizConfig.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { coveUpdateWorker } from '@cdc/core/helpers/coveUpdateWorker'
 import { getVizConfig } from '../getVizConfig'
 
 describe('getVizConfig', () => {
@@ -113,6 +114,112 @@ describe('getVizConfig', () => {
     expect(visualizationConfig.formattedData).toBe(casesRows)
     expect(visualizationConfig.originalFormattedData).toBe(fullRows)
     expect(visualizationConfig.yAxisDomainData).toBe(casesRows)
+  })
+
+  it('preserves full transformed rows for table raw downloads when displayed rows are filtered', () => {
+    const sourceRows = [
+      { month_end: '2024-01-31', demographics_values: '12-17 years', rate_per_100000_visits: 10 },
+      { month_end: '2024-01-31', demographics_values: '18-34 years', rate_per_100000_visits: 20 },
+      { month_end: '2024-02-29', demographics_values: '12-17 years', rate_per_100000_visits: 30 },
+      { month_end: '2024-02-29', demographics_values: '18-34 years', rate_per_100000_visits: 40 }
+    ]
+    const transformedRows = [
+      { month_end: '2024-01-31', '12-17 years': 10, '18-34 years': 20 },
+      { month_end: '2024-02-29', '12-17 years': 30, '18-34 years': 40 }
+    ]
+    const filteredRows = [transformedRows[0]]
+    const dataDescription = {
+      horizontal: false,
+      series: true,
+      singleRow: false,
+      seriesKey: 'demographics_values',
+      xKey: 'month_end',
+      valueKeysTallSupport: ['rate_per_100000_visits']
+    }
+    const config = {
+      dashboard: { sharedFilters: [] },
+      datasets: {
+        nsspData: {
+          data: sourceRows,
+          dataMetadata: {}
+        }
+      },
+      rows: [{ columns: [{ widget: 'tableA' }] }],
+      visualizations: {
+        tableA: {
+          type: 'table',
+          dataKey: 'nsspData',
+          dataDescription
+        }
+      }
+    } as any
+
+    const visualizationConfig = getVizConfig('tableA', 0, config, { nsspData: sourceRows }, { tableA: filteredRows })
+
+    expect(visualizationConfig.data).toBe(filteredRows)
+    expect(visualizationConfig.originalFormattedData).toEqual(transformedRows)
+  })
+
+  it('preserves full transformed rows for migrated dashboard table raw downloads', () => {
+    const sourceRows = [
+      { month_end: '2024-01-31', demographics_values: '12-17 years', rate_per_100000_visits: 10 },
+      { month_end: '2024-01-31', demographics_values: '18-34 years', rate_per_100000_visits: 20 },
+      { month_end: '2024-02-29', demographics_values: '12-17 years', rate_per_100000_visits: 30 },
+      { month_end: '2024-02-29', demographics_values: '18-34 years', rate_per_100000_visits: 40 }
+    ]
+    const transformedRows = [
+      { month_end: '2024-01-31', '12-17 years': 10, '18-34 years': 20 },
+      { month_end: '2024-02-29', '12-17 years': 30, '18-34 years': 40 }
+    ]
+    const filteredRows = [transformedRows[0]]
+    const dataDescription = {
+      horizontal: false,
+      series: true,
+      singleRow: false,
+      seriesKey: 'demographics_values',
+      xKey: 'month_end',
+      valueKeysTallSupport: ['rate_per_100000_visits']
+    }
+    const migratedConfig = coveUpdateWorker({
+      type: 'dashboard',
+      version: '4.26.5',
+      dashboard: { sharedFilters: [] },
+      table: { show: true, download: true },
+      datasets: {
+        nsspData: {
+          data: sourceRows,
+          dataDescription,
+          dataMetadata: {}
+        }
+      },
+      rows: [{ columns: [{ width: 12, widget: 'chartA' }] }],
+      visualizations: {
+        chartA: {
+          type: 'chart',
+          dataKey: 'nsspData'
+        }
+      }
+    } as any) as any
+    const generatedEntry = Object.entries(migratedConfig.visualizations).find(
+      ([, visualization]: [string, any]) => visualization.migrations?.generatedFromDashboardTable
+    ) as [string, any]
+    const [generatedTableKey, generatedTable] = generatedEntry
+    const generatedTableRowIndex = migratedConfig.rows.findIndex(row =>
+      row.columns?.some(column => column.widget === generatedTableKey)
+    )
+
+    const visualizationConfig = getVizConfig(
+      generatedTableKey,
+      generatedTableRowIndex,
+      migratedConfig,
+      { nsspData: sourceRows },
+      { [generatedTableKey]: filteredRows }
+    )
+
+    expect(generatedTable.dataDescription).toEqual(dataDescription)
+    expect(generatedTable.migrations.generatedFromDashboardTable).toBe(true)
+    expect(visualizationConfig.data).toBe(filteredRows)
+    expect(visualizationConfig.originalFormattedData).toEqual(transformedRows)
   })
 
   it('uses selected dataset metadata when unrelated dashboard datasets are present', () => {


### PR DESCRIPTION
## Summary

Fixes an issue with standalone data tables where they sometimes downloaded unpivoted data that didn't match the 

## Testing Steps

Load [nssp-table-csv-source-minimal.json](https://github.com/user-attachments/files/30992799/nssp-table-csv-source-minimal.json), check that the downloaded data format matches the displayed table. On `dev` it will not.

