### PR TITLE
enhancement: update data table file names for all visualizations

### DIFF
--- a/packages/chart/src/_stories/Chart.DataTableDownloadFilename.stories.tsx
+++ b/packages/chart/src/_stories/Chart.DataTableDownloadFilename.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
+import { editConfigKeys } from '@cdc/core/helpers/configHelpers'
+import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import Chart from '../CdcChart'
+import simplifiedLine from './_mock/simplified_line.json'
+
+const meta: Meta<typeof Chart> = {
+  title: 'Components/Templates/Data Table Download Filename',
+  component: Chart
+}
+
+type Story = StoryObj<typeof Chart>
+
+const captureImageDownloadName = async (downloadButton: HTMLElement) => {
+  const downloads: string[] = []
+  const originalClick = HTMLAnchorElement.prototype.click
+
+  HTMLAnchorElement.prototype.click = function () {
+    if (this.download) downloads.push(this.download)
+  }
+
+  try {
+    await userEvent.click(downloadButton)
+    await waitFor(() => expect(downloads.length).toBeGreaterThan(0), { timeout: 10000 })
+    return downloads[0]
+  } finally {
+    HTMLAnchorElement.prototype.click = originalClick
+    document.body.querySelectorAll('a[download]').forEach(anchor => anchor.remove())
+  }
+}
+
+export const ChartImageDownloadUsesTableFilenameFallback: Story = {
+  args: {
+    config: editConfigKeys(simplifiedLine, [
+      { path: ['title'], value: '' },
+      { path: ['dataFileSourceType'], value: 'file' },
+      { path: ['dataUrl'], value: '' },
+      { path: ['dataFileName'], value: '' },
+      { path: ['table', 'show'], value: true },
+      { path: ['table', 'expanded'], value: true },
+      { path: ['table', 'download'], value: true },
+      { path: ['table', 'showDownloadImgButton'], value: true },
+      { path: ['table', 'downloadFileName'], value: 'Chart Table Report.csv' },
+      { path: ['table', 'showDownloadLinkBelow'], value: false }
+    ]),
+    isEditor: false
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    const canvas = within(canvasElement)
+    const downloadButton = await canvas.findByRole('button', { name: 'Download Chart as Image' })
+    const downloadName = await captureImageDownloadName(downloadButton)
+
+    expect(downloadName).toMatch(/^chart-table-report-\d{4}-\d{2}-\d{2}\.png$/)
+  }
+}
+
+export default meta

--- a/packages/core/components/DataTable/DataTable.test.tsx
+++ b/packages/core/components/DataTable/DataTable.test.tsx
@@ -6,7 +6,8 @@ import DataTable from './DataTable'
 
 const downloadState = vi.hoisted(() => ({
   latest: [] as Record<string, unknown>[],
-  fileName: ''
+  fileName: '',
+  mediaDownloads: [] as Array<{ title: string; imageFilenameFallback?: string }>
 }))
 
 vi.mock('@cdc/core/components/ErrorBoundary', () => ({
@@ -17,8 +18,14 @@ vi.mock('@cdc/core/components/MediaControls', () => ({
   default: {
     Section: ({ children }) => <div>{children}</div>,
     Link: () => null,
-    DownloadLink: ({ title }) => (
-      <button type='button' aria-label={title}>
+    DownloadLink: ({ title, imageFilenameFallback }) => (
+      <button
+        type='button'
+        aria-label={title}
+        onClick={() => {
+          downloadState.mediaDownloads.push({ title, imageFilenameFallback })
+        }}
+      >
         {title}
       </button>
     )
@@ -920,6 +927,107 @@ describe('DataTable search', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Download data' }))
 
     expect(downloadState.fileName).toBe('abc.csv')
+  })
+
+  it('passes an explicit csv filename base to table media download links', () => {
+    downloadState.mediaDownloads = []
+    const runtimeData = [{ category: 'Black', rate: 29 }]
+    const config = {
+      type: 'chart',
+      visualizationType: 'Bar',
+      general: {},
+      columns: {
+        category: { name: 'category', label: 'Category', dataTable: true },
+        rate: { name: 'rate', label: 'Rate', dataTable: true }
+      },
+      xAxis: { dataKey: 'category', type: 'categorical' },
+      yAxis: {},
+      table: {
+        label: 'Data Table',
+        expanded: true,
+        collapsible: false,
+        showDownloadLinkBelow: false,
+        download: false,
+        downloadFileName: 'Weekly Report.csv',
+        showVertical: true,
+        indexLabel: '',
+        cellMinWidth: 0
+      },
+      runtime: { series: [{ dataKey: 'rate' }] },
+      preliminaryData: []
+    } as any
+
+    render(
+      <DataTable
+        config={config}
+        columns={config.columns}
+        rawData={runtimeData}
+        runtimeData={runtimeData as any}
+        expandDataTable={true}
+        tableTitle='Data Table'
+        viewport='lg'
+        tabbingId='download-chart-media-table'
+        showDownloadImgButton={true}
+        showDownloadPdfButton={true}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download Chart as Image' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Download Chart as PDF' }))
+
+    expect(downloadState.mediaDownloads).toEqual([
+      { title: 'Download Chart as Image', imageFilenameFallback: 'Weekly Report' },
+      { title: 'Download Chart as PDF', imageFilenameFallback: 'Weekly Report' }
+    ])
+  })
+
+  it('passes a dataset-derived csv filename base to table media download links', () => {
+    downloadState.mediaDownloads = []
+    const runtimeData = [{ category: 'Black', rate: 29 }]
+    const config = {
+      type: 'chart',
+      visualizationType: 'Bar',
+      general: {},
+      columns: {
+        category: { name: 'category', label: 'Category', dataTable: true },
+        rate: { name: 'rate', label: 'Rate', dataTable: true }
+      },
+      xAxis: { dataKey: 'category', type: 'categorical' },
+      yAxis: {},
+      table: {
+        label: 'Data Table',
+        expanded: true,
+        collapsible: false,
+        showDownloadLinkBelow: false,
+        download: false,
+        showVertical: true,
+        indexLabel: '',
+        cellMinWidth: 0
+      },
+      runtime: { series: [{ dataKey: 'rate' }] },
+      preliminaryData: []
+    } as any
+
+    render(
+      <DataTable
+        config={config}
+        columns={config.columns}
+        dataConfig={{ dataUrl: '/wcms/vizdata/abc.json' }}
+        rawData={runtimeData}
+        runtimeData={runtimeData as any}
+        expandDataTable={true}
+        tableTitle='Data Table'
+        viewport='lg'
+        tabbingId='download-chart-media-table'
+        showDownloadImgButton={true}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download Chart as Image' }))
+
+    expect(downloadState.mediaDownloads).toEqual([
+      { title: 'Download Chart as Image', imageFilenameFallback: 'abc' }
+    ])
   })
 
   it('filters standalone table rows by visible values only', () => {

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -137,6 +137,8 @@ const TableMediaControls = ({
   const hasDownloadLink = config.table.download
   const hasImageDownloads = Boolean(showDownloadImgButton || showDownloadPdfButton)
   const visualizationLabel = getMediaDownloadVisualizationLabel(config.type)
+  const csvDownloadFileName = resolveCsvDownloadFileName({ config, dataConfig, vizTitle })
+  const mediaFilenameFallback = csvDownloadFileName.replace(/\.csv$/i, '')
 
   return (
     <MediaControls.Section
@@ -151,6 +153,7 @@ const TableMediaControls = ({
           elementToCapture={imageRef}
           interactionLabel={interactionLabel}
           includeContextInDownload={includeContextInDownload}
+          imageFilenameFallback={mediaFilenameFallback}
         />
       )}
       {showDownloadPdfButton && (
@@ -161,13 +164,14 @@ const TableMediaControls = ({
           elementToCapture={imageRef}
           interactionLabel={interactionLabel}
           includeContextInDownload={includeContextInDownload}
+          imageFilenameFallback={mediaFilenameFallback}
         />
       )}
       <MediaControls.Link config={config} dashboardDataConfig={dataConfig} interactionLabel={interactionLabel} />
       {hasDownloadLink && (
         <DownloadButton
           getRawData={getDownloadData}
-          fileName={resolveCsvDownloadFileName({ config, dataConfig, vizTitle })}
+          fileName={csvDownloadFileName}
           interactionLabel={interactionLabel}
           config={config}
         />

--- a/packages/core/components/MediaControls.test.tsx
+++ b/packages/core/components/MediaControls.test.tsx
@@ -41,7 +41,7 @@ const clickImageButtonAndWaitForDownload = async (buttonName: string) => {
 
   await waitFor(() => expect(clickSpy).toHaveBeenCalled())
 
-  return document.body.querySelector('a')?.getAttribute('download')
+  return document.body.querySelector('a[download]')?.getAttribute('download')
 }
 
 describe('MediaControls.Link', () => {
@@ -339,5 +339,21 @@ describe('MediaControls.DownloadLink', () => {
     expect(link).not.toHaveClass('download-link-with-icon')
     expect(getDownloadIcon(link, 'image')).not.toBeInTheDocument()
     expect(screen.getByText('Download Chart (PDF)')).toBeInTheDocument()
+  })
+
+  it('forwards image filename fallbacks to media generation', async () => {
+    render(
+      <MediaControls.DownloadLink
+        state={{ type: 'chart', table: {} }}
+        type='image'
+        title='Download Chart as Image'
+        elementToCapture='dashboard-download'
+        imageFilenameFallback='table-report'
+      />
+    )
+
+    await expect(clickImageButtonAndWaitForDownload('Download Chart as Image')).resolves.toBe(
+      'table-report-2026-07-24.png'
+    )
   })
 })

--- a/packages/core/components/MediaControls.tsx
+++ b/packages/core/components/MediaControls.tsx
@@ -258,7 +258,8 @@ const DownloadLink = ({
   title,
   elementToCapture,
   interactionLabel = '',
-  includeContextInDownload = false
+  includeContextInDownload = false,
+  imageFilenameFallback
 }) => {
   const vizType = state?.type === 'map' ? 'Map' : 'Chart'
   const format = type === 'pdf' ? 'PDF' : 'PNG'
@@ -269,7 +270,9 @@ const DownloadLink = ({
   return (
     <a
       role='button'
-      onClick={() => generateMedia(state, type, elementToCapture, interactionLabel, includeContextInDownload)}
+      onClick={() =>
+        generateMedia(state, type, elementToCapture, interactionLabel, includeContextInDownload, imageFilenameFallback)
+      }
       aria-label={title}
       title={title}
       className={`no-border${showDownloadIcon ? ' download-link-with-icon' : ''}`}

--- a/packages/data-table/src/_stories/DataTable.DownloadFilename.stories.tsx
+++ b/packages/data-table/src/_stories/DataTable.DownloadFilename.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
+import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import CdcDataTable from '../CdcDataTable'
+
+const meta: Meta<typeof CdcDataTable> = {
+  title: 'Components/Templates/Data Table Download Filename',
+  component: CdcDataTable
+}
+
+type Story = StoryObj<typeof CdcDataTable>
+
+const dataTableConfig = {
+  version: '4.26.4',
+  type: 'table',
+  visualizationType: 'Table',
+  locale: 'en-US',
+  data: [
+    { year: '2020', value: 77.3 },
+    { year: '2021', value: 76.4 }
+  ],
+  table: {
+    label: 'Data Table',
+    expanded: true,
+    limitHeight: false,
+    height: '',
+    caption: '',
+    showDownloadUrl: false,
+    showDataTableLink: true,
+    showDownloadLinkBelow: false,
+    search: false,
+    indexLabel: '',
+    download: true,
+    downloadFileName: 'Standalone Table Report.csv',
+    showVertical: true,
+    show: true,
+    defaultSort: {}
+  },
+  columns: {
+    year: { name: 'year', label: 'Year', dataTable: true },
+    value: { name: 'value', label: 'Value', dataTable: true }
+  },
+  dataFormat: {}
+}
+
+const captureCsvDownloadName = async (downloadButton: HTMLElement) => {
+  const downloads: string[] = []
+  const originalClick = HTMLAnchorElement.prototype.click
+
+  HTMLAnchorElement.prototype.click = function () {
+    if (this.download) downloads.push(this.download)
+  }
+
+  try {
+    await userEvent.click(downloadButton)
+    await waitFor(() => expect(downloads.length).toBeGreaterThan(0))
+    return downloads[0]
+  } finally {
+    HTMLAnchorElement.prototype.click = originalClick
+  }
+}
+
+export const StandaloneCsvDownloadUsesConfiguredFilename: Story = {
+  args: {
+    config: dataTableConfig,
+    isEditor: false
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    const canvas = within(canvasElement)
+    const downloadButton = await canvas.findByRole('button', {
+      name: 'Download this data in a CSV file format.'
+    })
+    const downloadName = await captureCsvDownloadName(downloadButton)
+
+    expect(downloadName).toBe('Standalone Table Report.csv')
+  }
+}
+
+export default meta

--- a/packages/map/src/_stories/CdcMap.DataTableDownloadFilename.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.DataTableDownloadFilename.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
+import { editConfigKeys } from '@cdc/core/helpers/configHelpers'
+import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import CdcMapComponent from '../CdcMapComponent'
+import cityStateConfig from './_mock/example-city-state.json'
+
+const meta: Meta<typeof CdcMapComponent> = {
+  title: 'Components/Templates/Data Table Download Filename',
+  component: CdcMapComponent
+}
+
+type Story = StoryObj<typeof CdcMapComponent>
+
+const captureImageDownloadName = async (downloadButton: HTMLElement) => {
+  const downloads: string[] = []
+  const originalClick = HTMLAnchorElement.prototype.click
+
+  HTMLAnchorElement.prototype.click = function () {
+    if (this.download) downloads.push(this.download)
+  }
+
+  try {
+    await userEvent.click(downloadButton)
+    await waitFor(() => expect(downloads.length).toBeGreaterThan(0), { timeout: 10000 })
+    return downloads[0]
+  } finally {
+    HTMLAnchorElement.prototype.click = originalClick
+    document.body.querySelectorAll('a[download]').forEach(anchor => anchor.remove())
+  }
+}
+
+export const MapImageDownloadUsesTableFilenameFallback: Story = {
+  args: {
+    config: editConfigKeys(cityStateConfig, [
+      { path: ['general', 'title'], value: '' },
+      { path: ['general', 'showTitle'], value: false },
+      { path: ['general', 'showDownloadImgButton'], value: true },
+      { path: ['table', 'download'], value: true },
+      { path: ['table', 'downloadFileName'], value: 'Map Table Report.csv' },
+      { path: ['table', 'showDownloadLinkBelow'], value: false }
+    ])
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    const canvas = within(canvasElement)
+    const downloadButton = await canvas.findByRole('button', { name: 'Download Map as Image' })
+    const downloadName = await captureImageDownloadName(downloadButton)
+
+    expect(downloadName).toMatch(/^map-table-report-\d{4}-\d{2}-\d{2}\.png$/)
+  }
+}
+
+export default meta


### PR DESCRIPTION
This pull request introduces improved handling and testing of download filenames for data tables and chart/map images across the codebase. The changes ensure that image and PDF downloads from tables use a consistent and meaningful filename, often derived from the configured CSV download filename, and that this behavior is well-tested and documented in Storybook stories.

**Enhancements to Download Filename Handling:**

- Media downloads (images, PDFs) for tables now use a fallback filename based on the table's configured CSV download filename, improving consistency and clarity for users. This includes forwarding the filename base to media generation logic and ensuring it is used in the generated filenames. [[1]](diffhunk://#diff-262afb6d83a5eb0ced6cc67142011a2e834d638550235ec01d1b1e590f05fabfR140-R141) [[2]](diffhunk://#diff-262afb6d83a5eb0ced6cc67142011a2e834d638550235ec01d1b1e590f05fabfR156) [[3]](diffhunk://#diff-262afb6d83a5eb0ced6cc67142011a2e834d638550235ec01d1b1e590f05fabfR167-R174) [[4]](diffhunk://#diff-63080c4caf695d5321af1ae63641b6432e7f6567cdb36750b97314aa1e8e64e4L261-R262) [[5]](diffhunk://#diff-63080c4caf695d5321af1ae63641b6432e7f6567cdb36750b97314aa1e8e64e4L272-R275)

**Testing Improvements:**

- Added and expanded tests in `DataTable.test.tsx` to verify that the correct filename base is passed to media download links, both when a filename is explicitly configured and when it is derived from the dataset. [[1]](diffhunk://#diff-08d749e0f466fe58186dbeacf8a80b8fb65bfdbba756176d88db888b50eee5bfL9-R10) [[2]](diffhunk://#diff-08d749e0f466fe58186dbeacf8a80b8fb65bfdbba756176d88db888b50eee5bfL20-R28) [[3]](diffhunk://#diff-08d749e0f466fe58186dbeacf8a80b8fb65bfdbba756176d88db888b50eee5bfR932-R1032)
- Updated `MediaControls.test.tsx` to test that image filename fallbacks are correctly forwarded and used in actual downloads. [[1]](diffhunk://#diff-a51a1652b12601d4d7da565bedfdae213c6491df9cb1a6e48fd41eb0918203c5L44-R44) [[2]](diffhunk://#diff-a51a1652b12601d4d7da565bedfdae213c6491df9cb1a6e48fd41eb0918203c5R343-R358)

**Documentation and Storybook Coverage:**

- Added new Storybook stories for charts, maps, and standalone data tables to demonstrate and verify the download filename behavior in real UI scenarios. These stories check that the correct filenames are used for CSV and image downloads. [[1]](diffhunk://#diff-3ad2ef1f427c08dc3f92d735a73c98a6064394ed3ac928de7e1a1cba0f0be245R1-R60) [[2]](diffhunk://#diff-5dddd76cfaf4b6d3aba7d8649cda447cfabc7fab02eb76f75ca7296cb5ffc5efR1-R55) [[3]](diffhunk://#diff-753ec7f231a4267c559d965900b9be196b32ad67061db5074893a05902b2b3feR1-R81)

These changes collectively improve the user experience by making download filenames predictable and meaningful, and ensure that this functionality is robustly tested and well-documented.