### PR TITLE
enhancment: auto optin to new equal interval legend for maps

### DIFF
--- a/packages/core/components/Legend/Legend.Gradient.tsx
+++ b/packages/core/components/Legend/Legend.Gradient.tsx
@@ -10,6 +10,7 @@ const MARGIN = 1
 const BORDER_SIZE = 1
 const BORDER_COLOR = '#d3d3d3'
 const MOBILE_BREAKPOINT = 576
+const ZERO_LABEL = '0'
 
 type CombinedConfig = MapConfig | ChartConfig
 
@@ -42,7 +43,16 @@ const LegendGradient = ({
   const { legendSeparators, separatorSize, legendSeparatorsToSubtract, getTickSeparatorsAdjustment } =
     useLegendSeparators(separators, legendWidth, isLinearBlocks)
 
-  const numTicks = colors?.length
+  const numTicks = colors.length
+  const shouldRenderSeparateZeroBlock =
+    type === 'map' &&
+    (legend as { separateZero?: boolean })?.separateZero === true &&
+    String(labels?.[0] ?? '').trim() === ZERO_LABEL &&
+    colors.length > 1
+  const zeroBlockWidth = shouldRenderSeparateZeroBlock ? Math.max(0, legendWidth / numTicks) : 0
+  const smoothGradientX = MARGIN + zeroBlockWidth
+  const smoothGradientWidth = Math.max(0, legendWidth - zeroBlockWidth)
+  const smoothGradientColors = shouldRenderSeparateZeroBlock ? colors.slice(1) : colors
 
   const longestLabel = (labels || []).reduce((a: string, b) => (a.length > String(b).length ? a : b), '')
   const boxHeight = 20
@@ -56,8 +66,8 @@ const LegendGradient = ({
   const newHeight = height + Number(textWidth) * Math.sin(angleInRadians)
 
   // configure gradient colors
-  const stops = colors.map((color, index) => {
-    const offset = (index / (colors.length - 1)) * 100
+  const stops = smoothGradientColors.map((color, index) => {
+    const offset = smoothGradientColors.length > 1 ? (index / (smoothGradientColors.length - 1)) * 100 : 0
     return <stop key={index} offset={`${offset}%`} style={{ stopColor: color, stopOpacity: 1 }} />
   })
 
@@ -114,13 +124,37 @@ const LegendGradient = ({
         </linearGradient>
 
         {subStyle === 'smooth' && (
-          <rect
-            x={MARGIN}
-            y={MARGIN}
-            width={legendWidth}
-            height={boxHeight}
-            fill={`url(#gradient-smooth-${uniqueID})`}
-          />
+          <>
+            {shouldRenderSeparateZeroBlock && (
+              <>
+                <rect
+                  className='legend-gradient__zero-block'
+                  x={MARGIN}
+                  y={MARGIN}
+                  width={zeroBlockWidth}
+                  height={boxHeight}
+                  fill={colors[0]}
+                />
+                <line
+                  className='legend-gradient__zero-block-separator'
+                  x1={smoothGradientX}
+                  x2={smoothGradientX}
+                  y1={MARGIN}
+                  y2={boxHeight + MARGIN}
+                  stroke='white'
+                  strokeWidth={BORDER_SIZE}
+                />
+              </>
+            )}
+            <rect
+              className={shouldRenderSeparateZeroBlock ? 'legend-gradient__smooth-ramp' : undefined}
+              x={smoothGradientX}
+              y={MARGIN}
+              width={smoothGradientWidth}
+              height={boxHeight}
+              fill={`url(#gradient-smooth-${uniqueID})`}
+            />
+          </>
         )}
 
         {subStyle === 'linear blocks' && (
@@ -128,9 +162,12 @@ const LegendGradient = ({
             {colors.map((color, index) => {
               const segmentWidth = Math.max(0, (legendWidth - legendSeparatorsToSubtract) / numTicks)
               const xPosition = index * segmentWidth + MARGIN + getTickSeparatorsAdjustment(index)
+              const blockClassName =
+                shouldRenderSeparateZeroBlock && index === 0 ? 'legend-gradient__zero-block' : undefined
               return (
                 <Group key={`color-block-${index}`}>
                   <rect
+                    className={blockClassName}
                     x={xPosition}
                     y={MARGIN}
                     width={segmentWidth}

--- a/packages/core/helpers/tests/backfillDefaults.test.ts
+++ b/packages/core/helpers/tests/backfillDefaults.test.ts
@@ -250,4 +250,11 @@ describe('map legacy defaults protection', () => {
     expect(config.legend.numberOfItems).toBe(3)
     expect(config.legend.hideBorder).toBe(false)
   })
+
+  it('old config missing general.equalNumberOptIn gets the current equal-number value', () => {
+    const config = { general: { type: 'data' } } as any
+    backfillDefaults(config, mapDefaults, LEGACY_MAP_DEFAULTS)
+    expect(mapDefaults.general.equalNumberOptIn).toBe(true)
+    expect(config.general.equalNumberOptIn).toBe(true)
+  })
 })

--- a/packages/core/helpers/vegaConfigImport.ts
+++ b/packages/core/helpers/vegaConfigImport.ts
@@ -99,7 +99,11 @@ const generateNewConfig = (props: any) => {
     }
     case 'Maps': {
       newConfig = { ...props, newViz: true, datasets: {}, type: 'map' }
-      newConfig['general'] = { geoType: props.subType, type: props?.generalType }
+      newConfig['general'] = {
+        geoType: props.subType,
+        type: props?.generalType,
+        equalNumberOptIn: true
+      }
       break
     }
   }

--- a/packages/dashboard/src/helpers/addVisualization.ts
+++ b/packages/dashboard/src/helpers/addVisualization.ts
@@ -34,6 +34,7 @@ export const addVisualization = (type, subType, idOptions?: CreateCoveIdOptions)
     case 'map':
       newVisualizationConfig.general = {}
       newVisualizationConfig.general.geoType = subType
+      newVisualizationConfig.general.equalNumberOptIn = true
       newVisualizationConfig.visual = {
         border: false,
         borderColorTheme: false,

--- a/packages/dashboard/src/helpers/tests/addVisualization.test.ts
+++ b/packages/dashboard/src/helpers/tests/addVisualization.test.ts
@@ -34,7 +34,8 @@ describe('addVisualization', () => {
       uid: 'map-8fzzzbjm',
       type: 'map',
       general: {
-        geoType: 'single-state'
+        geoType: 'single-state',
+        equalNumberOptIn: true
       },
       visual: {
         border: false,

--- a/packages/editor/src/components/ChooseTab.test.tsx
+++ b/packages/editor/src/components/ChooseTab.test.tsx
@@ -137,6 +137,45 @@ describe('ChooseTab', () => {
     )
   })
 
+  it('creates a map starter config with the new equal-number legend path enabled', () => {
+    const dispatch = vi.fn()
+
+    render(
+      <ConfigContext.Provider
+        value={
+          {
+            config: {},
+            tempConfig: null,
+            errors: [],
+            currentViewport: 'lg',
+            globalActive: 0,
+            setTempConfig: vi.fn()
+          } as any
+        }
+      >
+        <EditorDispatchContext.Provider value={dispatch}>
+          <ChooseTab />
+        </EditorDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'United States (State- or County-Level)' }))
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'EDITOR_SET_CONFIG',
+        payload: expect.objectContaining({
+          type: 'map',
+          newViz: true,
+          general: expect.objectContaining({
+            geoType: 'us',
+            equalNumberOptIn: true
+          })
+        })
+      })
+    )
+  })
+
   it('creates a TP5 Gauge starter config when the Gauge Chart button is selected', () => {
     const dispatch = vi.fn()
 

--- a/packages/editor/src/components/ChooseTab.tsx
+++ b/packages/editor/src/components/ChooseTab.tsx
@@ -187,7 +187,8 @@ const ChooseTab: React.FC = (): JSX.Element => {
         }
         newConfig['general'] = {
           geoType: visualizationType,
-          type: props?.generalType
+          type: props?.generalType,
+          equalNumberOptIn: true
         }
         break
       }

--- a/packages/map/CONFIG.md
+++ b/packages/map/CONFIG.md
@@ -71,7 +71,7 @@ The following authorable data-loading fields are shared and documented in core: 
 | `general.headerColor` | `string` | No | `theme-blue` | Map-owned header theme token. | Accepts shared [`ComponentThemes`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#componentthemes) values. |
 | `general.displayStateLabels` | `boolean` | No | `true` | Shows state labels directly on the map. | `true`, `false` |
 | `general.displayAsHex` | `boolean` | No | `false` | Switches the US map to a hex-style treatment. | Works with `hexMap`. |
-| `general.equalNumberOptIn` | `boolean` | No | `false` | Enables the newer equal-number legend path. | Used when `legend.separateZero` and equal-number classification interact. |
+| `general.equalNumberOptIn` | `boolean` | No | `true` | Legacy compatibility field. Equal-number legends always use the newer quantile path. | The editor no longer exposes this as a checkbox. Saved configs may still contain the field, but `false` no longer restores the old equal-number behavior. |
 | `general.allowMapZoom` | `boolean` | No | `true` | Enables zooming on supported map types. | Disabled in some editor flows and unsupported map modes. |
 | `general.showClearSelectionButton` | `boolean` | No | `true` | Shows a Clear Selection control for dashboard maps that set a shared filter. | Only meaningful when the map is used inside a dashboard as a `setBy` control and a selection is currently active. Current runtime support is implemented for the U.S. map. |
 | `general.hideGeoColumnInTooltip` | `boolean` | No | `false` | Hides the geography field name in tooltips. | `true`, `false` |
@@ -122,7 +122,7 @@ When `legend` is omitted entirely, the package initial state supplies the defaul
 
 | Behavior | Details |
 | --- | --- |
-| `legend.separateZero` | When `true`, numeric legends split zero into its own class unless `general.equalNumberOptIn` changes the scaling path. |
+| `legend.separateZero` | When `true`, numeric legends split zero into its own class. Applies to computed and manual numeric legends, including the equal-number zero baseline; gradient legends render the zero class as a standalone block. |
 | `legend.breakpoints` | Manual numeric legend boundaries. Values outside the authored interior breakpoints still render because the runtime extends the first and last classes to the data minimum and maximum. |
 | Category legend ordering | Category legends use automatic ordering when `legend.categoryValuesOrder` is missing or empty. Automatic ordering places numeric values and simple numeric ranges first, ordered by their numeric bounds, including decimals, comma-formatted numbers, ranges such as `1 - 14` or `1,000 - 1,999`, `to` ranges such as `1 to 4`, and open-ended bins such as `<10`, `>10`, or `30+`. Non-numeric categories appear after numeric categories in first-seen data order. A non-empty `legend.categoryValuesOrder` is treated as an explicit custom order. |
 | `legend.additionalCategories` | Adds extra category labels to the legend before category ordering runs. |

--- a/packages/map/src/_stories/CdcMap.Editor.FiltersSectionTests.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Editor.FiltersSectionTests.stories.tsx
@@ -157,7 +157,7 @@ export const FiltersSectionTests: Story = {
     )
 
     // ==========================================================================
-    // TEST: Select Alabama as the default filter value
+    // TEST: Select Ohio as the default filter value
     // ==========================================================================
     const updatedFilterBlock = getFilterBlock()
     const defaultValueSelect = Array.from(updatedFilterBlock?.querySelectorAll('select') || []).find(select => {
@@ -167,19 +167,19 @@ export const FiltersSectionTests: Story = {
     }) as HTMLSelectElement
 
     await performAndAssert(
-      'Filter Default Value → Select Alabama',
+      'Filter Default Value → Select Ohio',
       () => {
-        // Check the legend text labels - when filtered to one state, shows single value
+        // Check the legend text labels - when filtered to one state, shows that state's value
         const legendContainer = canvasElement.querySelector('.legend-container')
         const textElements = Array.from(legendContainer?.querySelectorAll('text tspan') || [])
         const labels = textElements.map(el => el.textContent?.trim()).filter(t => t && t !== '')
         const labelText = labels.join(',')
 
-        // Verify filter dropdown is rendered
-        const vizContainer = canvasElement.querySelector('.cove-visualization')
-        const filterSelect = Array.from(vizContainer?.querySelectorAll('select') || []).find(select => {
+        // Verify the runtime filter dropdown is rendered in the visualization output
+        const runtimeFiltersSection = canvasElement.querySelector('.cove-visualization__filters-section')
+        const filterSelect = Array.from(runtimeFiltersSection?.querySelectorAll('select') || []).find(select => {
           const options = Array.from(select.options).map(opt => opt.value)
-          return options.includes('Alabama')
+          return options.includes('Ohio')
         })
 
         return {
@@ -190,12 +190,17 @@ export const FiltersSectionTests: Story = {
         }
       },
       async () => {
-        await userEvent.selectOptions(defaultValueSelect, 'Alabama')
+        await userEvent.selectOptions(defaultValueSelect, 'Ohio')
       },
       (before, after) => {
-        // After filtering to Alabama: should have filter dropdown, Alabama selected, and exactly 1 legend label
-        // The legend shows a single value when only one state's data is displayed
-        return after.hasFilterSelect && after.selectedValue === 'Alabama' && after.labelCount === 1
+        // After filtering to Ohio: should have runtime dropdown, Ohio selected, and Ohio's unique value in the legend
+        return (
+          after.hasFilterSelect &&
+          after.selectedValue === 'Ohio' &&
+          after.labelText !== before.labelText &&
+          after.labelText.includes('88') &&
+          !after.labelText.includes('130')
+        )
       }
     )
 

--- a/packages/map/src/_stories/CdcMap.Editor.LegendSectionTests.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Editor.LegendSectionTests.stories.tsx
@@ -33,24 +33,195 @@ const CATEGORY_SORT_ARGS = {
   }
 }
 
+const EQUAL_INTERVAL_SEPARATE_ZERO_ARGS = {
+  isEditor: true,
+  config: {
+    ...usaStateGradientConfig,
+    general: {
+      ...usaStateGradientConfig.general,
+      equalNumberOptIn: true
+    },
+    legend: {
+      ...usaStateGradientConfig.legend,
+      type: 'equalinterval',
+      style: 'boxes',
+      position: 'side',
+      separateZero: false
+    }
+  }
+}
+
+const GRADIENT_SEPARATE_ZERO_ARGS = {
+  isEditor: true,
+  config: {
+    ...usaStateGradientConfig,
+    general: {
+      ...usaStateGradientConfig.general,
+      equalNumberOptIn: true
+    },
+    legend: {
+      ...usaStateGradientConfig.legend,
+      type: 'equalnumber',
+      style: 'gradient',
+      subStyle: 'smooth',
+      position: 'top',
+      separateZero: false
+    }
+  }
+}
+
+const GRADIENT_LINEAR_BLOCKS_SEPARATE_ZERO_ARGS = {
+  isEditor: true,
+  config: {
+    ...GRADIENT_SEPARATE_ZERO_ARGS.config,
+    general: {
+      ...GRADIENT_SEPARATE_ZERO_ARGS.config.general,
+      equalNumberOptIn: true
+    },
+    legend: {
+      ...GRADIENT_SEPARATE_ZERO_ARGS.config.legend,
+      type: 'equalnumber',
+      style: 'gradient',
+      subStyle: 'linear blocks'
+    }
+  }
+}
+
+const MANUAL_SEPARATE_ZERO_ARGS = {
+  isEditor: true,
+  config: {
+    ...usaStateGradientConfig,
+    general: {
+      ...usaStateGradientConfig.general,
+      equalNumberOptIn: true
+    },
+    legend: {
+      ...usaStateGradientConfig.legend,
+      type: 'manual',
+      style: 'boxes',
+      position: 'side',
+      breakpoints: [45, 60],
+      separateZero: false
+    }
+  }
+}
+
+const openLegendAccordionForTest = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement)
+
+  await waitForEditor(canvas)
+  await waitForPresence('.map-container', canvasElement)
+  await openAccordion(canvas, 'Legend')
+
+  return getLegendAccordionItem(canvasElement)
+}
+
+const getLegendAccordionItem = (canvasElement: HTMLElement) => {
+  const legendAccordionItem = Array.from(
+    canvasElement.querySelectorAll('.form-container > .accordion > .accordion__item')
+  ).find(item => item.querySelector('.accordion__heading .accordion__button')?.textContent?.trim() === 'Legend') as
+    | HTMLElement
+    | undefined
+
+  expect(legendAccordionItem).toBeTruthy()
+  return legendAccordionItem as HTMLElement
+}
+
+const getInputByLabel = (container: HTMLElement, labelText: string) => {
+  return Array.from(container.querySelectorAll('input[type="checkbox"]') || []).find(input => {
+    const label = input.closest('label')
+    const labelSpan = label?.querySelector('.edit-label')
+    return labelSpan?.textContent?.includes(labelText)
+  }) as HTMLInputElement
+}
+
+const getSeparateZeroCheckbox = (legendAccordionItem: HTMLElement) => {
+  const separateZeroCheckbox = getInputByLabel(legendAccordionItem, 'Separate Zero')
+
+  expect(separateZeroCheckbox).toBeTruthy()
+  return separateZeroCheckbox
+}
+
+const getLegendContainer = (canvasElement: HTMLElement) => canvasElement.querySelector('.legend-container')
+
+const getLegendItemLabels = (canvasElement: HTMLElement) => {
+  const legendContainer = getLegendContainer(canvasElement)
+  const legendItems = Array.from(legendContainer?.querySelectorAll('.legend-container__li') || [])
+
+  return {
+    legendItems,
+    itemLabels: legendItems.map(item => item.textContent?.trim() || '')
+  }
+}
+
+const getGradientLabels = (canvasElement: HTMLElement) =>
+  Array.from(getLegendContainer(canvasElement)?.querySelectorAll('text tspan') || []).map(
+    item => item.textContent?.trim() || ''
+  )
+
+const hasZeroListItem = (itemLabels: string[]) => itemLabels.some(label => label.includes('0') && !label.match(/[1-9]/))
+
+const getListSeparateZeroState = (canvasElement: HTMLElement) => {
+  const { legendItems, itemLabels } = getLegendItemLabels(canvasElement)
+
+  return {
+    itemLabels,
+    hasZeroItem: hasZeroListItem(itemLabels),
+    hasLegendItems: legendItems.length > 0
+  }
+}
+
+const getGradientSeparateZeroState = (canvasElement: HTMLElement) => {
+  const legendContainer = getLegendContainer(canvasElement)
+  const zeroBlock = legendContainer?.querySelector('.legend-gradient__zero-block')
+  const smoothRamp = legendContainer?.querySelector('.legend-gradient__smooth-ramp')
+  const labels = getGradientLabels(canvasElement)
+
+  return {
+    hasGradient: Boolean(legendContainer?.querySelector('linearGradient')),
+    hasZeroBlock: Boolean(zeroBlock),
+    hasSmoothRamp: Boolean(smoothRamp),
+    hasZeroLabel: labels.some(label => label === '0'),
+    hasZeroRangeLabel: labels.some(label => /^0\s*-/.test(label)),
+    hasLegendListItems: Boolean(legendContainer?.querySelector('.legend-container__li-btn')),
+    smoothRampWidth: Number(smoothRamp?.getAttribute('width') ?? 0),
+    zeroBlockWidth: Number(zeroBlock?.getAttribute('width') ?? 0),
+    svgHTML: legendContainer?.querySelector('svg')?.outerHTML || ''
+  }
+}
+
+const makeSeparateZeroStory = <T,>(
+  args,
+  testName: string,
+  getState: (canvasElement: HTMLElement) => T,
+  assertChange: (before: T, after: T) => boolean
+): Story => ({
+  args: {
+    ...args
+  },
+  play: async ({ canvasElement }) => {
+    const legendAccordionItem = await openLegendAccordionForTest(canvasElement)
+    const separateZeroCheckbox = getSeparateZeroCheckbox(legendAccordionItem)
+
+    await performAndAssert(
+      testName,
+      () => getState(canvasElement),
+      async () => {
+        await userEvent.click(separateZeroCheckbox)
+      },
+      assertChange
+    )
+  }
+})
+
 export const LegendSectionTests: Story = {
   args: {
     ...DEFAULT_ARGS
   },
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
-
-    await waitForEditor(canvas)
-    await waitForPresence('.map-container', canvasElement)
-
-    await openAccordion(canvas, 'Legend')
-    const legendAccordionItem = Array.from(
-      canvasElement.querySelectorAll('.form-container > .accordion > .accordion__item')
-    ).find(item => item.querySelector('.accordion__heading .accordion__button')?.textContent?.trim() === 'Legend') as
-      | HTMLElement
-      | undefined
-    expect(legendAccordionItem).toBeTruthy()
-    const legendControls = within(legendAccordionItem as HTMLElement)
+    const legendAccordionItem = await openLegendAccordionForTest(canvasElement)
+    const legendControls = within(legendAccordionItem)
+    expect(legendControls.queryByLabelText('Use new quantile legend')).not.toBeInTheDocument()
 
     // ==========================================================================
     // TEST: Legend Type
@@ -404,23 +575,19 @@ export const LegendSectionTests: Story = {
     // ==========================================================================
     // TEST: Separate Zero
     // ==========================================================================
-    const separateZeroCheckbox = Array.from(legendAccordionItem?.querySelectorAll('input[type="checkbox"]') || []).find(
-      input => {
-        const label = input.closest('label')
-        const labelSpan = label?.querySelector('.edit-label')
-        return labelSpan?.textContent?.includes('Separate Zero')
-      }
-    ) as HTMLInputElement
+    const separateZeroCheckbox = getSeparateZeroCheckbox(legendAccordionItem)
 
     const getSeparateZero = () => {
-      const legendContainer = canvasElement.querySelector('.legend-container')
-      const legendItems = Array.from(legendContainer?.querySelectorAll('.legend-container__li') || [])
-      const itemLabels = legendItems.map(item => item.textContent?.trim() || '')
-      const hasZeroItem = itemLabels.some(label => label.includes('0') && !label.match(/[1-9]/))
+      const { legendItems, itemLabels } = getLegendItemLabels(canvasElement)
+      const hasZeroItem = hasZeroListItem(itemLabels)
+      const hasCurrentSeparateZeroRange = itemLabels.some(label => /^1\b.*-/.test(label))
+      const hasCurrentOptInBoundary = itemLabels.some(label => /\d+\.1\b.*-/.test(label))
       return {
         itemCount: legendItems.length,
         itemLabels,
-        hasZeroItem
+        hasZeroItem,
+        hasCurrentSeparateZeroRange,
+        hasCurrentOptInBoundary
       }
     }
 
@@ -431,8 +598,13 @@ export const LegendSectionTests: Story = {
         await userEvent.click(separateZeroCheckbox)
       },
       (before, after) => {
-        // Should separate zero into its own legend item (e.g., "0" instead of "0 - 40")
-        return after.hasZeroItem && after.itemLabels.join(',') !== before.itemLabels.join(',')
+        // Should separate zero with the current legend path: "0", then a range starting at "1".
+        return (
+          after.hasZeroItem &&
+          after.hasCurrentSeparateZeroRange &&
+          after.hasCurrentOptInBoundary &&
+          after.itemLabels.join(',') !== before.itemLabels.join(',')
+        )
       }
     )
 
@@ -633,3 +805,54 @@ export const CategorySortTests: Story = {
     )
   }
 }
+
+export const EqualIntervalSeparateZeroTests = makeSeparateZeroStory(
+  EQUAL_INTERVAL_SEPARATE_ZERO_ARGS,
+  'Equal Interval Separate Zero → Check',
+  getListSeparateZeroState,
+  (before, after) => after.hasZeroItem && after.itemLabels.join(',') !== before.itemLabels.join(',')
+)
+
+export const ManualSeparateZeroTests = makeSeparateZeroStory(
+  MANUAL_SEPARATE_ZERO_ARGS,
+  'Manual Separate Zero → Check',
+  getListSeparateZeroState,
+  (before, after) =>
+    before.hasLegendItems &&
+    !before.hasZeroItem &&
+    after.hasZeroItem &&
+    after.itemLabels.join(',') !== before.itemLabels.join(',')
+)
+
+export const GradientSeparateZeroTests = makeSeparateZeroStory(
+  GRADIENT_SEPARATE_ZERO_ARGS,
+  'Gradient Separate Zero → Zero block',
+  getGradientSeparateZeroState,
+  (before, after) =>
+    before.hasGradient &&
+    !before.hasZeroBlock &&
+    after.hasGradient &&
+    after.hasZeroBlock &&
+    after.hasSmoothRamp &&
+    after.hasZeroLabel &&
+    !after.hasLegendListItems &&
+    after.zeroBlockWidth > 0 &&
+    after.smoothRampWidth > 0 &&
+    after.svgHTML !== before.svgHTML
+)
+
+export const GradientLinearBlocksSeparateZeroTests = makeSeparateZeroStory(
+  GRADIENT_LINEAR_BLOCKS_SEPARATE_ZERO_ARGS,
+  'Gradient Linear Blocks Separate Zero → Zero block',
+  getGradientSeparateZeroState,
+  (before, after) =>
+    before.hasGradient &&
+    !before.hasZeroBlock &&
+    after.hasGradient &&
+    after.hasZeroBlock &&
+    after.hasZeroLabel &&
+    !after.hasZeroRangeLabel &&
+    !after.hasLegendListItems &&
+    after.zeroBlockWidth > 0 &&
+    after.svgHTML !== before.svgHTML
+)

--- a/packages/map/src/_stories/CdcMap.EqualNumberOptIn.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.EqualNumberOptIn.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
+import CdcMap from '../CdcMap'
+import EqualNumberMap from './_mock/equal-number.json'
+import { editConfigKeys } from '@cdc/core/helpers/configHelpers'
+import { assertVisualizationRendered, performAndAssert, waitForPresence } from '@cdc/core/helpers/testing'
+
+const meta: Meta<typeof CdcMap> = {
+  title: 'Components/Templates/Map/Equal Number Current Behavior',
+  component: CdcMap,
+  parameters: {
+    layout: 'fullscreen'
+  }
+}
+
+type Story = StoryObj<typeof CdcMap>
+
+export default meta
+
+const comparisonData = [
+  { STATE: 'AL', Rate: 10, Location: 'Alabama', URL: 'https://www.cdc.gov/' },
+  { STATE: 'AK', Rate: 20, Location: 'Alaska', URL: 'https://www.cdc.gov/' },
+  { STATE: 'AZ', Rate: 20, Location: 'Arizona', URL: 'https://www.cdc.gov/' },
+  { STATE: 'AR', Rate: 30, Location: 'Arkansas', URL: 'https://www.cdc.gov/' },
+  { STATE: 'CA', Rate: 30, Location: 'California', URL: 'https://www.cdc.gov/' },
+  { STATE: 'CO', Rate: 40, Location: 'Colorado', URL: 'https://www.cdc.gov/' }
+]
+
+const baseUpdates = [
+  { path: ['general', 'showTitle'], value: true },
+  { path: ['general', 'showSidebar'], value: true },
+  { path: ['legend', 'type'], value: 'equalnumber' },
+  { path: ['legend', 'numberOfItems'], value: 3 },
+  { path: ['legend', 'position'], value: 'side' },
+  { path: ['legend', 'style'], value: 'circles' },
+  { path: ['legend', 'singleColumn'], value: true },
+  { path: ['legend', 'hideBorder'], value: false },
+  { path: ['columns', 'primary', 'roundToPlace'], value: 0 },
+  { path: ['columns', 'primary', 'suffix'], value: '' },
+  { path: ['data'], value: comparisonData }
+]
+
+const makeMapConfig = (equalNumberOptIn: boolean, title: string) =>
+  editConfigKeys(EqualNumberMap, [
+    ...baseUpdates,
+    { path: ['general', 'title'], value: title },
+    { path: ['general', 'equalNumberOptIn'], value: equalNumberOptIn }
+  ])
+
+const falseFlagConfig = () => makeMapConfig(false, 'Equal-number legend with false compatibility flag')
+const trueFlagConfig = () => makeMapConfig(true, 'Equal-number legend with true compatibility flag')
+const currentLegendLabels = ['0 - 20', '20.1 - 30', '30.1 - 40']
+
+const getLegendLabels = (canvasElement: HTMLElement) =>
+  Array.from(canvasElement.querySelectorAll('.legend-container__li-btn'))
+    .map(item => item.textContent?.replace(/\s+/g, ' ').trim() || '')
+    .filter(Boolean)
+
+const expectLegendLabels = async (canvasElement: HTMLElement, expectedLabels: string[]) => {
+  await assertVisualizationRendered(canvasElement)
+  await waitForPresence('aside[aria-label="Legend"]', canvasElement)
+  await waitForPresence('.legend-container__li-btn', canvasElement)
+  await performAndAssert(
+    'Legend labels settle',
+    () => getLegendLabels(canvasElement),
+    () => undefined,
+    (_before, after) => JSON.stringify(after) === JSON.stringify(expectedLabels),
+    after => expect(after).toEqual(expectedLabels)
+  )
+}
+
+export const FalseFlagEqualNumberLegend: Story = {
+  args: {
+    config: falseFlagConfig(),
+    isEditor: false
+  },
+  play: async ({ canvasElement }) => {
+    await expectLegendLabels(canvasElement, currentLegendLabels)
+  }
+}
+
+export const TrueFlagEqualNumberLegend: Story = {
+  args: {
+    config: trueFlagConfig(),
+    isEditor: false
+  },
+  play: async ({ canvasElement }) => {
+    await expectLegendLabels(canvasElement, currentLegendLabels)
+  }
+}
+
+export const CompatibilityFlagComparison: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+        gap: '1.5rem',
+        padding: '1rem'
+      }}
+    >
+      <section aria-label='False flag equal-number map'>
+        <CdcMap config={falseFlagConfig()} isEditor={false} />
+      </section>
+      <section aria-label='True flag equal-number map'>
+        <CdcMap config={trueFlagConfig()} isEditor={false} />
+      </section>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+    await waitForPresence('[aria-label="False flag equal-number map"] .legend-container__li-btn', canvasElement)
+    await waitForPresence('[aria-label="True flag equal-number map"] .legend-container__li-btn', canvasElement)
+
+    await performAndAssert(
+      'Equal-number labels match regardless of compatibility flag',
+      () => {
+        const falseFlagRoot = canvasElement.querySelector('[aria-label="False flag equal-number map"]') as HTMLElement
+        const trueFlagRoot = canvasElement.querySelector('[aria-label="True flag equal-number map"]') as HTMLElement
+
+        return {
+          falseFlagLabels: getLegendLabels(falseFlagRoot),
+          trueFlagLabels: getLegendLabels(trueFlagRoot)
+        }
+      },
+      () => undefined,
+      (_before, after) =>
+        JSON.stringify(after.falseFlagLabels) === JSON.stringify(currentLegendLabels) &&
+        JSON.stringify(after.trueFlagLabels) === JSON.stringify(currentLegendLabels),
+      after => {
+        expect(after.falseFlagLabels).toEqual(currentLegendLabels)
+        expect(after.trueFlagLabels).toEqual(currentLegendLabels)
+        expect(after.falseFlagLabels).toEqual(after.trueFlagLabels)
+      }
+    )
+  }
+}

--- a/packages/map/src/_stories/CdcMap.EqualNumberOptIn.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.EqualNumberOptIn.stories.tsx
@@ -49,7 +49,7 @@ const makeMapConfig = (equalNumberOptIn: boolean, title: string) =>
 
 const falseFlagConfig = () => makeMapConfig(false, 'Equal-number legend with false compatibility flag')
 const trueFlagConfig = () => makeMapConfig(true, 'Equal-number legend with true compatibility flag')
-const currentLegendLabels = ['0 - 20', '20.1 - 30', '30.1 - 40']
+const currentLegendLabels = ['10 - 20', '20.1 - 30', '30.1 - 40']
 
 const getLegendLabels = (canvasElement: HTMLElement) =>
   Array.from(canvasElement.querySelectorAll('.legend-container__li-btn'))

--- a/packages/map/src/_stories/CdcMap.Patterns.smoke.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Patterns.smoke.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
 import CdcMap from '../CdcMap'
 import defaultPatterns from './_mock/default-patterns.json'
 import countyPatterns from './_mock/county-patterns.json'
 import { editConfigKeys } from '@cdc/core/helpers/configHelpers'
-import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import { assertVisualizationRendered, waitForPresence } from '@cdc/core/helpers/testing'
 import { sanitizeToSvgId } from '@cdc/core/helpers/cove/string'
 
 const meta: Meta<typeof CdcMap> = {
@@ -43,24 +44,33 @@ export const County_Patterns: Story = {
   },
   play: async ({ canvasElement }) => {
     await assertVisualizationRendered(canvasElement)
+    await waitForPresence('aside[aria-label="Legend"] .legend-container__li-btn--pattern', canvasElement)
 
-    const patternDefs = Array.from(canvasElement.querySelectorAll('pattern'))
-    const patternPaths = Array.from(canvasElement.querySelectorAll('path, circle')).filter(node => {
-      const fill = node.getAttribute('fill')
-      return fill?.startsWith('url(#')
+    const legend = canvasElement.querySelector('aside[aria-label="Legend"]') as HTMLElement
+    const patternButtons = Array.from(legend.querySelectorAll('.legend-container__li-btn--pattern'))
+    expect(patternButtons).toHaveLength(countyPatterns.map.patterns.length)
+
+    const patternChecks = countyPatterns.map.patterns.map((patternData, patternIndex) => {
+      const sanitizedDataKey = sanitizeToSvgId(patternData.dataKey)
+      const expectedIdFragment = `${sanitizedDataKey}--${patternIndex}`
+      const patternButton = patternButtons[patternIndex]
+      const patternDef = patternButton?.querySelector('pattern')
+      const patternFill = patternButton?.querySelector('[fill^="url(#"]')
+
+      return {
+        expectedIdFragment,
+        hasSanitizedPatternId: Boolean(patternDef?.id.endsWith(expectedIdFragment)),
+        hasMatchingUrlRef: patternFill?.getAttribute('fill') === `url(#${patternDef?.id})`
+      }
     })
 
-    const sanitizedCoverageType = sanitizeToSvgId('Coverage Type')
-    const sanitizedPatternDef = patternDefs.find(def => def.id.includes(sanitizedCoverageType))
-    const hasSanitizedPatternId = Boolean(sanitizedPatternDef)
-    const hasMatchingUrlRef = Boolean(
-      sanitizedPatternDef &&
-        patternPaths.some(node => node.getAttribute('fill')?.includes(`#${sanitizedPatternDef.id}`))
+    expect(patternChecks).toEqual(
+      countyPatterns.map.patterns.map((patternData, patternIndex) => ({
+        expectedIdFragment: `${sanitizeToSvgId(patternData.dataKey)}--${patternIndex}`,
+        hasSanitizedPatternId: true,
+        hasMatchingUrlRef: true
+      }))
     )
-
-    if (!hasSanitizedPatternId || !hasMatchingUrlRef) {
-      throw new Error('Pattern IDs/refs were not sanitized or linked correctly in legend rendering.')
-    }
   }
 }
 

--- a/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
+++ b/packages/map/src/components/EditorPanel/components/EditorPanel.tsx
@@ -2690,9 +2690,6 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
 
                             const _newConfig = cloneConfig(config)
                             _newConfig.legend.type = event.target.value
-                            if (event.target.value === 'manual') {
-                              _newConfig.legend.separateZero = false
-                            }
                             _newConfig.runtime.editorErrorMessage = messages
                             setConfig(_newConfig)
                           }}
@@ -2933,7 +2930,7 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                           }}
                         />
                       }
-                      {['equalnumber', 'equalinterval'].includes(legend.type) && (
+                      {['equalnumber', 'equalinterval', 'manual'].includes(legend.type) && (
                         <CheckBox
                           value={legend.separateZero || false}
                           section='legend'
@@ -2941,6 +2938,21 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                           fieldName='separateZero'
                           label='Separate Zero'
                           updateField={updateField}
+                          onChange={event => {
+                            const checked = event.target.checked
+
+                            setConfig({
+                              ...config,
+                              general: {
+                                ...config.general,
+                                equalNumberOptIn: checked ? true : config.general.equalNumberOptIn
+                              },
+                              legend: {
+                                ...config.legend,
+                                separateZero: checked
+                              }
+                            })
+                          }}
                           tooltip={
                             <Tooltip style={{ textTransform: 'none' }}>
                               <Tooltip.Target>
@@ -2951,33 +2963,6 @@ const EditorPanel: React.FC<MapEditorPanelProps> = ({ datasets }) => {
                               </Tooltip.Target>
                               <Tooltip.Content>
                                 <p>For numeric data, you can separate the zero value as its own data class.</p>
-                              </Tooltip.Content>
-                            </Tooltip>
-                          }
-                        />
-                      )}
-
-                      {/* Temp Checkbox */}
-                      {config.legend.type === 'equalnumber' && (
-                        <CheckBox
-                          value={config.general.equalNumberOptIn}
-                          section='general'
-                          subsection={null}
-                          fieldName='equalNumberOptIn'
-                          label='Use new quantile legend'
-                          updateField={updateField}
-                          tooltip={
-                            <Tooltip style={{ textTransform: 'none' }}>
-                              <Tooltip.Target>
-                                <Icon
-                                  display='question'
-                                  style={{ marginLeft: '0.5rem', display: 'inline-block', whiteSpace: 'nowrap' }}
-                                />
-                              </Tooltip.Target>
-                              <Tooltip.Content>
-                                <p>
-                                  This prevents numbers from being used in more than one category (ie. 0-1, 1-2, 2-3){' '}
-                                </p>
                               </Tooltip.Content>
                             </Tooltip>
                           }

--- a/packages/map/src/data/initial-state.js
+++ b/packages/map/src/data/initial-state.js
@@ -38,6 +38,7 @@ const createInitialState = () => {
       fullBorder: false,
       type: 'data',
       convertFipsCodes: true,
+      equalNumberOptIn: true,
       palette: paletteDefaults,
       allowMapZoom: true,
       hideGeoColumnInTooltip: false,

--- a/packages/map/src/data/legacy-defaults.ts
+++ b/packages/map/src/data/legacy-defaults.ts
@@ -4,5 +4,6 @@
 //
 // See backfillDefaults() in @cdc/core for the shared fill logic.
 export const LEGACY_MAP_DEFAULTS: Record<string, Record<string, unknown>> = {
+  general: { equalNumberOptIn: true },
   legend: { style: 'circles', position: 'side', numberOfItems: 3, hideBorder: false }
 }

--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -8,6 +8,7 @@ import { setBinNumbers } from './setBinNumbers'
 import { sortSpecialClassesLast } from './sortSpecialClassesLast'
 import { hashObj } from '@cdc/core/helpers/hashObj'
 import { filterVizData } from '@cdc/core/helpers/filterVizData'
+import numberFromString from '@cdc/core/helpers/numberFromString'
 import { normalizeBreakpoints } from './breakpointHelpers'
 import { sortAutomaticCategoryValues, sortByConfiguredCategoryOrder } from './categorySortHelpers'
 
@@ -39,6 +40,58 @@ export type GeneratedLegend = {
   items: LegendItem[] | []
 }
 
+const CURRENCY_SYMBOLS = ['$', '\u20ac', '\u00a3', '\u00a5']
+const NUMERIC_STRING_PATTERN = /^[+-]?(?:(?:\d{1,3}(?:,\d{3})+)|(?:\d+))(?:\.\d+)?$/
+
+const stripAffix = (input: string, affix: unknown, side: 'start' | 'end') => {
+  if (typeof affix !== 'string' || affix.trim() === '') return input
+
+  const trimmedAffix = affix.trim()
+  const trimmedInput = input.trim()
+
+  if (side === 'start' && trimmedInput.startsWith(trimmedAffix)) {
+    return trimmedInput.slice(trimmedAffix.length)
+  }
+
+  if (side === 'end' && trimmedInput.endsWith(trimmedAffix)) {
+    return trimmedInput.slice(0, -trimmedAffix.length)
+  }
+
+  return input
+}
+
+const parseLegendNumber = (value: unknown, primaryColumn: MapConfig['columns']['primary']): number | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  if (typeof value !== 'string') return null
+
+  const parsedValue = numberFromString(value)
+  if (typeof parsedValue === 'number' && Number.isFinite(parsedValue)) return parsedValue
+
+  let normalized = value.trim()
+  if (!normalized) return null
+
+  normalized = stripAffix(normalized, primaryColumn?.prefix, 'start').trim()
+  normalized = stripAffix(normalized, primaryColumn?.suffix, 'end').trim()
+
+  if (CURRENCY_SYMBOLS.includes(normalized[0])) {
+    normalized = normalized.slice(1).trim()
+  }
+
+  if (normalized.endsWith('%')) {
+    normalized = normalized.slice(0, -1).trim()
+  }
+
+  if (!NUMERIC_STRING_PATTERN.test(normalized)) {
+    return null
+  }
+
+  const parsedNumber = Number(normalized.replace(/,/g, ''))
+  return Number.isFinite(parsedNumber) ? parsedNumber : null
+}
+
 export const generateRuntimeLegend = (
   configObj: MapConfig,
   runtimeData: DataRow[],
@@ -63,6 +116,10 @@ export const generateRuntimeLegend = (
     const { legend, columns, general } = configObj
     const primaryColName = columns.primary.name
     const geoColName = columns.geo.name
+    const getPrimaryNumber = (row: DataRow) => {
+      return parseLegendNumber(row?.[primaryColName], columns.primary)
+    }
+    const isPrimaryZero = (row: DataRow) => getPrimaryNumber(row) === 0
     const isBubble = general.type === 'bubble'
     const categoricalCol = columns.categorical ? columns.categorical.name : undefined
     const getCategoryValue = (row: DataRow) =>
@@ -88,8 +145,8 @@ export const generateRuntimeLegend = (
     // Unified will base the legend off ALL the data maps received. Otherwise, it will use
     let dataSet = legend.unified ? data : Object.values(runtimeData ?? {})
 
-    let domainNums = Array.from(new Set(dataSet?.map(item => item[primaryColName])))
-      .filter(d => typeof d === 'number' && !isNaN(d))
+    let domainNums = Array.from(new Set(dataSet?.map(item => getPrimaryNumber(item))))
+      .filter((d): d is number => typeof d === 'number' && !isNaN(d))
       .sort((a, b) => a - b)
 
     let specialClasses = 0
@@ -253,206 +310,139 @@ export const generateRuntimeLegend = (
 
     let uniqueValues = {}
     dataSet.forEach(datum => {
-      uniqueValues[datum[primaryColName]] = true
+      const primaryNumber = getPrimaryNumber(datum)
+      if (primaryNumber !== null) {
+        uniqueValues[primaryNumber] = true
+      }
     })
 
     let legendNumber = Math.min(legend.numberOfItems, Object.keys(uniqueValues).length)
+    const numericLegendTypes = ['equalnumber', 'equalinterval', 'manual']
+    const canSeparateZero = true === legend.separateZero && numericLegendTypes.includes(legend.type)
+    let hasSeparatedZero = false
 
     // Separate zero
-    if (true === legend.separateZero && !general.equalNumberOptIn) {
-      let addLegendItem = false
+    if (canSeparateZero) {
+      const zeroRows = dataSet.filter(row => isPrimaryZero(row))
+      const shouldSeparateZeroBaseline = legend.type === 'equalnumber' && domainNums.length > 0 && domainNums[0] > 0
 
-      for (let i = 0; i < dataSet.length; i++) {
-        if (dataSet[i][primaryColName] === 0) {
-          addLegendItem = true
+      if (zeroRows.length > 0 || shouldSeparateZeroBaseline) {
+        const zeroLegendIndex = result.items.length
+        const nonZeroRows = dataSet.filter(row => !isPrimaryZero(row))
+        hasSeparatedZero = true
+        dataSet = nonZeroRows
 
-          let row = dataSet.splice(i, 1)[0]
-
-          newLegendMemo.set(hashObj(row), result.items.length)
-          i--
+        if (legend.type !== 'manual') {
+          legendNumber = nonZeroRows.length > 0 ? Math.max(legendNumber - 1, 1) : 0
         }
-      }
 
-      if (addLegendItem) {
-        legendNumber -= 1 // This zero takes up one legend item
-
-        // Add new legend item
         result.items.push({
           min: 0,
           max: 0
         })
 
-        let lastIdx = result.items.length - 1
+        zeroRows.forEach(row => {
+          newLegendMemo.set(hashObj(row), zeroLegendIndex)
+        })
 
         // Add color to new legend item
-        result.items[lastIdx].color = applyColorToLegend(lastIdx, configObj, result.items)
+        result.items[zeroLegendIndex].color = applyColorToLegend(zeroLegendIndex, configObj, result.items)
       }
     }
 
     // Sort data for use in equalnumber or equalinterval
     if (general.type !== 'us-geocode') {
       dataSet = dataSet
-        .filter(row => typeof row[primaryColName] === 'number')
+        .filter(row => getPrimaryNumber(row) !== null)
         .sort((a, b) => {
-          let aNum = a[primaryColName]
-          let bNum = b[primaryColName]
+          let aNum = getPrimaryNumber(a)
+          let bNum = getPrimaryNumber(b)
 
-          return aNum - bNum
+          return (aNum ?? 0) - (bNum ?? 0)
         })
     }
 
     // Equal Number
     if (legend.type === 'equalnumber') {
-      // start work on changing legend functionality
-      // FALSE === ignore old version for now.
-      if (!general.equalNumberOptIn) {
-        let numberOfRows = dataSet.length
-        let changingNumber = legendNumber
-        let remainder
-        let chunkAmt
+      const paletteName = configObj.general?.palette?.name || configObj.color
+      const version = getColorPaletteVersion(configObj)
+      let colors = colorPalettes?.[`v${version}`]?.[paletteName]
+      // Fallback to a default palette if none is selected or found
+      if (!colors) {
+        const defaultPalette = version === 1 ? 'sequential_blue_green' : 'sequential_blue'
+        colors = colorPalettes?.[`v${version}`]?.[defaultPalette]
+      }
 
-        // Loop through the array until it has been split into equal subarrays
-        while (numberOfRows > 0) {
-          remainder = numberOfRows % changingNumber
-          chunkAmt = Math.floor(numberOfRows / changingNumber)
+      if (!colors) {
+        console.warn('No color palette found, using fallback colors')
+        colors = ['#d3d3d3', '#a0a0a0', '#707070', '#404040'] // Gray fallback
+      }
 
-          if (remainder > 0) {
-            chunkAmt += 1
-          }
+      const scaleDataSet = dataSet
+      const legendItemCount = hasSeparatedZero ? legendNumber : legend.numberOfItems
 
-          let removedRows = dataSet.splice(0, chunkAmt)
+      // Check if we should use v2 distribution logic for better contrast
+      const isSequentialOrDivergent =
+        paletteName && (paletteName.includes('sequential') || paletteName.includes('divergent'))
+      const useV2Distribution = version === 2 && isSequentialOrDivergent && colors.length === 9 && legendItemCount <= 9
 
-          let min = removedRows[0][primaryColName],
-            max = removedRows[removedRows.length - 1][primaryColName]
-
-          // eslint-disable-next-line
-          removedRows.forEach(row => {
-            newLegendMemo.set(hashObj(row), result.items.length)
-          })
-
-          result.items.push({
-            min,
-            max
-          })
-
-          result.items[result.items.length - 1].color = applyColorToLegend(
-            result.items.length - 1,
-            configObj,
-            result.items
-          )
-
-          changingNumber -= 1
-          numberOfRows -= chunkAmt
-        }
+      let colorRange
+      if (useV2Distribution && v2ColorDistribution[legendItemCount]) {
+        // Use strategic color distribution for v2 sequential/divergent palettes
+        const distributionIndices = v2ColorDistribution[legendItemCount]
+        colorRange = distributionIndices.map(index => colors[index])
       } else {
-        const paletteName = configObj.general?.palette?.name || configObj.color
-        const version = getColorPaletteVersion(configObj)
-        let colors = colorPalettes?.[`v${version}`]?.[paletteName]
-        // Fallback to a default palette if none is selected or found
-        if (!colors) {
-          const defaultPalette = version === 1 ? 'sequential_blue_green' : 'sequential_blue'
-          colors = colorPalettes?.[`v${version}`]?.[defaultPalette]
+        // Use existing logic for v1 palettes and other cases
+        colorRange = colors.slice(0, legendItemCount)
+      }
+
+      const getDomain = () => {
+        if (columns?.primary?.roundToPlace !== undefined) {
+          return uniq(
+            scaleDataSet.map(item => Number(getPrimaryNumber(item)).toFixed(Number(columns?.primary?.roundToPlace)))
+          )
         }
+        return uniq(scaleDataSet.map(item => Math.round(Number(getPrimaryNumber(item)))))
+      }
 
-        if (!colors) {
-          console.warn('No color palette found, using fallback colors')
-          colors = ['#d3d3d3', '#a0a0a0', '#707070', '#404040'] // Gray fallback
+      const getBreaks = scale => {
+        if (columns?.primary?.roundToPlace !== undefined) {
+          return scale.quantiles().map(b => Number(b)?.toFixed(Number(columns?.primary?.roundToPlace)))
         }
+        return scale.quantiles().map(item => Number(Math.round(item)))
+      }
 
-        // Check if we should use v2 distribution logic for better contrast
-        const isSequentialOrDivergent =
-          paletteName && (paletteName.includes('sequential') || paletteName.includes('divergent'))
-        const useV2Distribution =
-          version === 2 && isSequentialOrDivergent && colors.length === 9 && legend.numberOfItems <= 9
-
-        let colorRange
-        if (useV2Distribution && v2ColorDistribution[legend.numberOfItems]) {
-          // Use strategic color distribution for v2 sequential/divergent palettes
-          const distributionIndices = v2ColorDistribution[legend.numberOfItems]
-          colorRange = distributionIndices.map(index => colors[index])
-        } else {
-          // Use existing logic for v1 palettes and other cases
-          colorRange = colors.slice(0, legend.numberOfItems)
-        }
-
-        const getDomain = () => {
-          // backwards compatibility
-          if (columns?.primary?.roundToPlace !== undefined && general?.equalNumberOptIn) {
-            return uniq(
-              dataSet.map(item => Number(item[primaryColName]).toFixed(Number(columns?.primary?.roundToPlace)))
-            )
-          }
-          return uniq(dataSet.map(item => Math.round(Number(item[primaryColName]))))
-        }
-
-        const getBreaks = scale => {
-          // backwards compatibility
-          if (columns?.primary?.roundToPlace !== undefined && general?.equalNumberOptIn) {
-            return scale.quantiles().map(b => Number(b)?.toFixed(Number(columns?.primary?.roundToPlace)))
-          }
-          return scale.quantiles().map(item => Number(Math.round(item)))
-        }
-
+      if (scaleDataSet.length !== 0 && legendItemCount > 0) {
         let scale = d3
           .scaleQuantile()
           .domain(getDomain()) // min/max values
           .range(colorRange) // set range to our colors array
 
-        const breaks = getBreaks(scale)
-        let cachedBreaks = null
-        if (!cachedBreaks) {
-          cachedBreaks = breaks
+        const breaks = getBreaks(scale).map(Number).filter(Number.isFinite)
+        const cachedBreaks = [...breaks]
+        const lowerBound = hasSeparatedZero ? 0 : Number(domainNums[0])
+
+        if (Number.isFinite(lowerBound) && cachedBreaks[0] !== lowerBound) {
+          cachedBreaks.unshift(lowerBound)
         }
 
-        // if separating zero force it into breaks
-        if (cachedBreaks[0] !== 0) {
-          cachedBreaks.unshift(0)
-        }
+        const max = Number(domainNums[domainNums.length - 1])
+        const decimalPlace = Number(configObj?.columns?.primary?.roundToPlace) || 1
+        const nextBoundaryIncrement = Math.pow(10, -decimalPlace)
+        const zeroBoundaryIncrement =
+          Number(configObj?.columns?.primary?.roundToPlace) > 0
+            ? Math.pow(10, -Number(configObj?.columns?.primary?.roundToPlace))
+            : 1
+        const upperBounds = [...cachedBreaks.slice(1), max]
 
-        // eslint-disable-next-line array-callback-return
-        cachedBreaks.map((item, index) => {
-          const setMin = index => {
-            let min = cachedBreaks[index]
-
-            // if first break is a seperated zero, min is zero
-            if (index === 0 && legend.separateZero) {
-              min = 0
-            }
-
-            // if we're on the second break, and separating out zero, increment min to 1.
-            if (index === 1 && legend.separateZero) {
-              min = 1
-            }
-
-            // For non-first ranges, add small increment to prevent overlap
-            if (index > 0 && !legend.separateZero) {
-              const decimalPlace = Number(configObj?.columns?.primary?.roundToPlace) || 1
-              min = Number(cachedBreaks[index]) + Math.pow(10, -decimalPlace)
-            }
-
-            return min
-          }
-
-          const getDecimalPlace = n => {
-            return Math.pow(10, -n)
-          }
-
-          const setMax = index => {
-            let max = Number(breaks[index + 1])
-
-            if (index === 0 && legend.separateZero) {
-              max = 0
-            }
-
-            if (index + 1 === breaks.length) {
-              max = Number(domainNums[domainNums.length - 1])
-            }
-
-            return max
-          }
-
-          let min = setMin(index)
-          let max = setMax(index)
+        upperBounds.forEach((upperBound, index) => {
+          let min =
+            hasSeparatedZero && index === 0
+              ? zeroBoundaryIncrement
+              : index === 0
+              ? cachedBreaks[index]
+              : Number(cachedBreaks[index]) + nextBoundaryIncrement
+          let max = Number(upperBound)
 
           result.items.push({
             min,
@@ -464,8 +454,8 @@ export const generateRuntimeLegend = (
             result.items
           )
 
-          dataSet.forEach(row => {
-            let number = row[primaryColName]
+          scaleDataSet.forEach(row => {
+            let number = getPrimaryNumber(row)
             let updated = result.items.length - 1
 
             if (result.items?.[updated]?.min === undefined || result.items?.[updated]?.max === undefined) return
@@ -478,52 +468,52 @@ export const generateRuntimeLegend = (
             }
           })
         })
+      }
 
-        // Final pass: handle any unassigned rows
-        dataSet.forEach(row => {
-          if (!newLegendMemo.has(hashObj(row))) {
-            let number = row[primaryColName]
-            let assigned = false
+      // Final pass: handle any unassigned rows
+      scaleDataSet.forEach(row => {
+        if (!newLegendMemo.has(hashObj(row))) {
+          let number = getPrimaryNumber(row)
+          let assigned = false
 
-            // Find the correct range for this value - check both boundaries
-            for (let itemIndex = 0; itemIndex < result.items.length; itemIndex++) {
-              const item = result.items[itemIndex]
+          // Find the correct range for this value - check both boundaries
+          for (let itemIndex = 0; itemIndex < result.items.length; itemIndex++) {
+            const item = result.items[itemIndex]
 
-              if (item.min === undefined || item.max === undefined) continue
+            if (item.min === undefined || item.max === undefined) continue
 
-              // Check if value falls within range (inclusive of both min and max)
-              if (number >= item.min && number <= item.max) {
-                newLegendMemo.set(hashObj(row), itemIndex)
-                assigned = true
-                break
-              }
-            }
-
-            // Fallback: if still not assigned, assign to closest range
-            if (!assigned) {
-              console.warn('Value not assigned to any range:', number, 'assigning to closest range')
-              let closestIndex = 0
-              let minDistance = Math.abs(number - (result.items[0].min + result.items[0].max) / 2)
-
-              for (let i = 1; i < result.items.length; i++) {
-                const midpoint = (result.items[i].min + result.items[i].max) / 2
-                const distance = Math.abs(number - midpoint)
-                if (distance < minDistance) {
-                  minDistance = distance
-                  closestIndex = i
-                }
-              }
-
-              newLegendMemo.set(hashObj(row), closestIndex)
+            // Check if value falls within range (inclusive of both min and max)
+            if (number >= item.min && number <= item.max) {
+              newLegendMemo.set(hashObj(row), itemIndex)
+              assigned = true
+              break
             }
           }
-        })
-      }
+
+          // Fallback: if still not assigned, assign to closest range
+          if (!assigned) {
+            console.warn('Value not assigned to any range:', number, 'assigning to closest range')
+            let closestIndex = 0
+            let minDistance = Math.abs(number - (result.items[0].min + result.items[0].max) / 2)
+
+            for (let i = 1; i < result.items.length; i++) {
+              const midpoint = (result.items[i].min + result.items[i].max) / 2
+              const distance = Math.abs(number - midpoint)
+              if (distance < minDistance) {
+                minDistance = distance
+                closestIndex = i
+              }
+            }
+
+            newLegendMemo.set(hashObj(row), closestIndex)
+          }
+        }
+      })
     }
 
     if (legend.type === 'manual' && dataSet?.length !== 0) {
-      const dataMin = dataSet[0][primaryColName]
-      const dataMax = dataSet[dataSet.length - 1][primaryColName]
+      const dataMin = getPrimaryNumber(dataSet[0])
+      const dataMax = getPrimaryNumber(dataSet[dataSet.length - 1])
       const breakpoints = normalizeBreakpoints(legend.breakpoints).filter(
         breakpoint => breakpoint > dataMin && breakpoint < dataMax
       )
@@ -535,7 +525,7 @@ export const generateRuntimeLegend = (
         const max = boundaries[i + 1]
 
         while (pointer < dataSet.length) {
-          const value = dataSet[pointer][primaryColName]
+          const value = getPrimaryNumber(dataSet[pointer])
           const withinUpperBound = i === boundaries.length - 2 ? value <= max : value <= max
 
           if (withinUpperBound) {
@@ -557,7 +547,7 @@ export const generateRuntimeLegend = (
     }
 
     // Equal Interval
-    if (legend.type === 'equalinterval' && dataSet?.length !== 0) {
+    if (legend.type === 'equalinterval' && dataSet?.length !== 0 && legendNumber > 0) {
       if (!dataSet || dataSet.length === 0) {
         setConfig({
           ...configObj,
@@ -568,9 +558,9 @@ export const generateRuntimeLegend = (
         })
         return
       }
-      dataSet = dataSet.filter(row => row[primaryColName] !== undefined)
-      let dataMin = dataSet[0][primaryColName]
-      let dataMax = dataSet[dataSet.length - 1][primaryColName]
+      dataSet = dataSet.filter(row => getPrimaryNumber(row) !== null)
+      let dataMin = getPrimaryNumber(dataSet[0])
+      let dataMax = getPrimaryNumber(dataSet[dataSet.length - 1])
 
       let pointer = 0 // Start at beginning of dataSet
 
@@ -584,7 +574,7 @@ export const generateRuntimeLegend = (
         if (i === legendNumber - 1) max = dataMax
 
         // Add rows in dataSet that belong to this new legend item since we've got the data sorted
-        while (pointer < dataSet.length && dataSet[pointer][primaryColName] <= max) {
+        while (pointer < dataSet.length && getPrimaryNumber(dataSet[pointer]) <= max) {
           newLegendMemo.set(hashObj(dataSet[pointer]), result.items.length)
           pointer += 1
         }

--- a/packages/map/src/helpers/generateRuntimeLegendHash.ts
+++ b/packages/map/src/helpers/generateRuntimeLegendHash.ts
@@ -5,7 +5,6 @@ export const generateRuntimeLegendHash = (config: MapConfig, runtimeFilters) => 
   const { name: paletteName } = config.general.palette
   return hashObj({
     unified: config.legend.unified ?? false,
-    equalNumberOptIn: config.general.equalNumberOptIn ?? false,
     specialClassesLast: config.legend.showSpecialClassesLast ?? false,
     color: paletteName,
     customColors: config.general?.palette?.customColors,

--- a/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
+++ b/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
@@ -118,6 +118,27 @@ const buildCategoryConfig = (values: Array<string | number>) => {
   return config
 }
 
+const buildEqualNumberConfig = (separateZero = false) => {
+  const config = buildConfig()
+
+  config.general.equalNumberOptIn = true
+  config.legend.type = 'equalnumber'
+  config.legend.numberOfItems = 3
+  config.legend.separateZero = separateZero
+  config.columns.primary.roundToPlace = 0
+  config.data = [
+    { state: 'Alabama', value: 0 },
+    { state: 'Alaska', value: 10 },
+    { state: 'Arizona', value: 20 },
+    { state: 'Arkansas', value: 20 },
+    { state: 'California', value: 30 },
+    { state: 'Colorado', value: 30 },
+    { state: 'Connecticut', value: 40 }
+  ]
+
+  return config
+}
+
 const getCategoryLegendValues = config => {
   const { runtimeLegend } = getRuntimeLegend(config, config.data)
 
@@ -189,6 +210,162 @@ describe('generateRuntimeLegend', () => {
     config.legend.breakpoints = [10, 30, 50, 70]
 
     expect(generateRuntimeLegendHash(config, {})).not.toBe(baselineHash)
+  })
+
+  it('does not include the equalNumberOptIn compatibility flag in the runtime legend cache hash', () => {
+    const config = buildEqualNumberConfig()
+    config.general.equalNumberOptIn = false
+    const baselineHash = generateRuntimeLegendHash(config, {})
+
+    config.general.equalNumberOptIn = true
+
+    expect(generateRuntimeLegendHash(config, {})).toBe(baselineHash)
+  })
+
+  it('uses current equal-number behavior even when equalNumberOptIn is false', () => {
+    const config = buildEqualNumberConfig(false)
+    config.general.equalNumberOptIn = false
+
+    const { runtimeLegend } = getRuntimeLegend(config, config.data)
+
+    expect(runtimeLegend.items.map(item => [item.min, item.max])).toEqual([
+      [0, 13],
+      [13.1, 27],
+      [27.1, 40]
+    ])
+  })
+
+  it('starts equal-number ranges at the data minimum when zero is absent and separate zero is off', () => {
+    const config = buildEqualNumberConfig(false)
+    config.data = config.data.map(row => ({ ...row, value: row.value === 0 ? 5 : row.value }))
+
+    const { runtimeLegend } = getRuntimeLegend(config, config.data)
+
+    expect(runtimeLegend.items.map(item => [item.min, item.max])).toEqual([
+      [5, 13],
+      [13.1, 27],
+      [27.1, 40]
+    ])
+  })
+
+  it('separates zero with current equal-number behavior even when equalNumberOptIn is false', () => {
+    const config = buildEqualNumberConfig(true)
+    config.general.equalNumberOptIn = false
+
+    const { runtimeLegend, legendMemo } = getRuntimeLegend(config, config.data)
+
+    expect(runtimeLegend.items.map(item => [item.min, item.max])).toEqual([
+      [0, 0],
+      [1, 25],
+      [25.1, 40]
+    ])
+    expect(legendMemo.current.get(hashObj(config.data[0]))).toBe(0)
+  })
+
+  it('separates the equal-number zero baseline even when no data rows are zero', () => {
+    const config = buildEqualNumberConfig(true)
+    config.data = config.data.map(row => ({ ...row, value: row.value === 0 ? 5 : row.value }))
+
+    const { runtimeLegend, legendMemo } = getRuntimeLegend(config, config.data)
+
+    expect(runtimeLegend.items.map(item => [item.min, item.max])).toEqual([
+      [0, 0],
+      [1, 20],
+      [20.1, 40]
+    ])
+    expect(legendMemo.current.get(hashObj(config.data[0]))).not.toBe(0)
+  })
+
+  it.each([
+    {
+      legendType: 'equalnumber',
+      breakpoints: undefined,
+      expectedRanges: [
+        [0, 0],
+        [1, 25],
+        [25.1, 40]
+      ]
+    },
+    {
+      legendType: 'equalinterval',
+      breakpoints: undefined,
+      expectedRanges: [
+        [0, 0],
+        [10, 25],
+        [25, 40]
+      ]
+    },
+    {
+      legendType: 'manual',
+      breakpoints: [25],
+      expectedRanges: [
+        [0, 0],
+        [10, 25],
+        [25, 40]
+      ]
+    }
+  ])(
+    'recognizes formatted numeric zero when separating zero for $legendType legends',
+    ({ legendType, breakpoints, expectedRanges }) => {
+      const config = buildEqualNumberConfig(true)
+      config.legend.type = legendType
+      config.legend.breakpoints = breakpoints
+      config.data = config.data.map(row => ({ ...row, value: ` ${row.value}% ` }))
+
+      const { runtimeLegend, legendMemo } = getRuntimeLegend(config, config.data)
+
+      expect(runtimeLegend.items.map(item => [item.min, item.max])).toEqual(expectedRanges)
+      expect(legendMemo.current.get(hashObj(config.data[0]))).toBe(0)
+    }
+  )
+
+  it('recognizes configured numeric suffixes when separating zero for equal-number legends', () => {
+    const config = buildEqualNumberConfig(true)
+    const values = [0, 1000, 2000, 2000, 3000, 3000, 4000]
+    config.columns.primary.prefix = '~'
+    config.columns.primary.suffix = ' cases'
+    config.data = config.data.map((row, index) => ({
+      ...row,
+      value: `~${values[index].toLocaleString('en-US')} cases`
+    }))
+
+    const { runtimeLegend, legendMemo } = getRuntimeLegend(config, config.data)
+
+    expect(runtimeLegend.items.map(item => [item.min, item.max])).toEqual([
+      [0, 0],
+      [1, 2500],
+      [2500.1, 4000]
+    ])
+    expect(legendMemo.current.get(hashObj(config.data[0]))).toBe(0)
+  })
+
+  it('separates zero for equal-interval legends when the equal-number opt-in flag is true', () => {
+    const config = buildEqualNumberConfig(true)
+    config.legend.type = 'equalinterval'
+
+    const { runtimeLegend, legendMemo } = getRuntimeLegend(config, config.data)
+
+    expect(runtimeLegend.items.map(item => [item.min, item.max])).toEqual([
+      [0, 0],
+      [10, 25],
+      [25, 40]
+    ])
+    expect(legendMemo.current.get(hashObj(config.data[0]))).toBe(0)
+  })
+
+  it('separates zero for manual breakpoint legends', () => {
+    const config = buildEqualNumberConfig(true)
+    config.legend.type = 'manual'
+    config.legend.breakpoints = [25]
+
+    const { runtimeLegend, legendMemo } = getRuntimeLegend(config, config.data)
+
+    expect(runtimeLegend.items.map(item => [item.min, item.max])).toEqual([
+      [0, 0],
+      [10, 25],
+      [25, 40]
+    ])
+    expect(legendMemo.current.get(hashObj(config.data[0]))).toBe(0)
   })
 
   it('automatically orders numeric and range category values', () => {


### PR DESCRIPTION
This pull request introduces improvements to the handling and rendering of "separate zero" legend blocks in map visualizations, ensures consistent initialization of the `equalNumberOptIn` field for maps, and updates documentation and tests to reflect these changes. The main areas of change are legend rendering, configuration defaults, and comprehensive test coverage for these behaviors.

**Legend rendering and behavior improvements:**

* [`Legend.Gradient.tsx`](diffhunk://#diff-f5e53bd4fafc67be4363ab1b7d2e94cf4418c7407060d74494c7fe887d15f136L45-R55): Refactored gradient legend rendering to visually separate a zero block when `legend.separateZero` is enabled. This includes calculating and rendering a distinct zero block and its separator for both smooth and linear gradient substyles. The logic now always uses the updated equal-number path for legends. [[1]](diffhunk://#diff-f5e53bd4fafc67be4363ab1b7d2e94cf4418c7407060d74494c7fe887d15f136L45-R55) [[2]](diffhunk://#diff-f5e53bd4fafc67be4363ab1b7d2e94cf4418c7407060d74494c7fe887d15f136R127-R170) [[3]](diffhunk://#diff-f5e53bd4fafc67be4363ab1b7d2e94cf4418c7407060d74494c7fe887d15f136L59-R70)

**Configuration and defaults:**

* `vegaConfigImport.ts`, `addVisualization.ts`, `ChooseTab.tsx`: Ensured that new map visualizations always have `general.equalNumberOptIn` set to `true` by default, removing legacy paths and guaranteeing consistent legend behavior. [[1]](diffhunk://#diff-c73845b4a9d9ab4e48e49aa6d394fec1895221411a62cb44da47c3f86c1b1b2aL102-R106) [[2]](diffhunk://#diff-8ab90418333d5872817eec654ce970ee50be73b43beaa21fb27233a797deb13bR37) [[3]](diffhunk://#diff-9c22598f5ddc64dfad15374b50f86b3cd8af4345c34c29eefa229dc4758e52f1L190-R191)
* [`backfillDefaults.test.ts`](diffhunk://#diff-da2b890a36772ef68443a43957620ec28db337c8b011d662a2041fefaacae793R253-R259): Added a test to verify that legacy map configs missing `equalNumberOptIn` are backfilled with the correct value.

**Documentation updates:**

* [`CONFIG.md`](diffhunk://#diff-01826e729e2622db4ab1d0c6a2b699bdefbed257779c2fe1ec347cceed9a0de0L74-R74): Updated documentation to clarify that `equalNumberOptIn` is always `true` for maps, is no longer user-exposed, and that `legend.separateZero` always splits zero into its own class for numeric legends. [[1]](diffhunk://#diff-01826e729e2622db4ab1d0c6a2b699bdefbed257779c2fe1ec347cceed9a0de0L74-R74) [[2]](diffhunk://#diff-01826e729e2622db4ab1d0c6a2b699bdefbed257779c2fe1ec347cceed9a0de0L125-R125)

**Test and Storybook coverage:**

* [`LegendSectionTests.stories.tsx`](diffhunk://#diff-d7354fb0cc98580699a71a471e99669f565db7ce342300d6789b50fcfba63c39L36-R224): Refactored and expanded Storybook stories and test utilities to systematically verify the behavior of the "separate zero" option across all legend types (equal interval, manual, gradient smooth, and gradient linear blocks). Added helper functions and assertions to validate correct rendering and state transitions. [[1]](diffhunk://#diff-d7354fb0cc98580699a71a471e99669f565db7ce342300d6789b50fcfba63c39L36-R224) [[2]](diffhunk://#diff-d7354fb0cc98580699a71a471e99669f565db7ce342300d6789b50fcfba63c39L407-R590) [[3]](diffhunk://#diff-d7354fb0cc98580699a71a471e99669f565db7ce342300d6789b50fcfba63c39R808-R858)
* `ChooseTab.test.tsx`, `addVisualization.test.ts`: Added and updated tests to confirm that new map configs are initialized with the correct legend path and options. [[1]](diffhunk://#diff-09ab1efbe92b73efcaebbfd3ddb9a620d1f7af6cbf24de7d3ff9811a3208e436R140-R178) [[2]](diffhunk://#diff-2cb928b6fead3318833eb20ed1aaa25e3c83ab18ad3bdf328c4956d0dda15de2L37-R38)

These changes ensure that the legend rendering logic is robust, configuration is consistent for all map visualizations, and that the expected behavior is well-documented and thoroughly tested.