### PR TITLE
Fix: dashboard save

### DIFF
--- a/packages/dashboard/src/CdcDashboardComponent.tsx
+++ b/packages/dashboard/src/CdcDashboardComponent.tsx
@@ -481,10 +481,6 @@ export default function CdcDashboard({
     }
 
     dispatch({ type: 'SET_CONFIG', payload: updatedConfig })
-    // Pass up to <CdcEditor /> if it exists when config state changes
-    if (isEditor) {
-      editorContext.setTempConfig(updatedConfig)
-    }
   }
 
   const resizeObserverRef = useRef<ResizeObserver | null>(null)

--- a/packages/dashboard/src/test/CdcDashboardComponent.test.tsx
+++ b/packages/dashboard/src/test/CdcDashboardComponent.test.tsx
@@ -6,6 +6,7 @@ import CdcDashboardComponent from '../CdcDashboardComponent'
 import type { InitialState } from '../types/InitialState'
 import Header from '../components/Header'
 import { DashboardContext, DashboardDispatchContext } from '../DashboardContext'
+import EditorContext from '@cdc/core/contexts/EditorContext'
 import { prepareScreenshotContainer } from '@cdc/core/helpers/prepareScreenshot'
 import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
 
@@ -23,6 +24,17 @@ vi.mock('@cdc/core/components/ui/Icon', () => ({
 
 vi.mock('@cdc/core/components/AdvancedEditor', () => ({
   default: () => <div data-testid='advanced-editor' />
+}))
+
+vi.mock('../components/DashboardEditors', () => ({
+  default: ({ visualizationConfig, _updateConfig }) => (
+    <button
+      data-testid='mock-dashboard-child-editor'
+      onClick={() => _updateConfig({ ...visualizationConfig, title: 'Updated child title' })}
+    >
+      Update child
+    </button>
+  )
 }))
 
 // Mounting the dashboard triggers an async data reload. Mock it to resolve
@@ -277,6 +289,82 @@ describe('CdcDashboardComponent', () => {
     expectElementBefore(tabsHeader!, editorLayout!)
     expectElementBefore(tabsHeader!, settingsHeader!)
     expectElementBefore(settingsHeader!, editorLayout!)
+  })
+
+  it('forwards child edits only after merging them into the complete dashboard config', async () => {
+    const setTempConfig = vi.fn()
+    const initialState = makeDashboardPreviewState({
+      visualizations: {
+        child: {
+          ...makeMarkupVisualization('Child content'),
+          uid: 'child',
+          editing: true,
+          dataKey: 'datasetA'
+        }
+      },
+      rows: [{ columns: [{ width: 12, widget: 'child' }] }],
+      activeDashboard: 0,
+      multiDashboards: [
+        {
+          label: 'Dashboard 1',
+          dashboard: {
+            title: 'Dashboard Title',
+            titleStyle: 'small',
+            theme: 'theme-blue',
+            downloads: { downloadImageButton: true },
+            sharedFilters: []
+          },
+          visualizations: {
+            child: {
+              ...makeMarkupVisualization('Child content'),
+              uid: 'child',
+              editing: true,
+              dataKey: 'datasetA'
+            }
+          },
+          rows: [{ columns: [{ width: 12, widget: 'child' }] }]
+        }
+      ]
+    })
+    initialState.tabSelected = 'Dashboard Settings'
+
+    render(
+      <EditorContext.Provider value={{ setTempConfig } as any}>
+        <CdcDashboardComponent initialState={initialState} interactionLabel='dashboard-test' isEditor={true} />
+      </EditorContext.Provider>
+    )
+
+    await waitFor(() => expect(setTempConfig).toHaveBeenCalled())
+    setTempConfig.mockClear()
+
+    fireEvent.click(screen.getByTestId('mock-dashboard-child-editor'))
+
+    await waitFor(() => {
+      expect(setTempConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'dashboard',
+          dashboard: expect.objectContaining({ title: 'Dashboard Title' }),
+          datasets: expect.objectContaining({ datasetA: expect.any(Object) }),
+          rows: expect.any(Array),
+          visualizations: expect.objectContaining({
+            child: expect.objectContaining({ title: 'Updated child title' })
+          }),
+          multiDashboards: expect.any(Array)
+        })
+      )
+    })
+
+    for (const [forwardedConfig] of setTempConfig.mock.calls) {
+      expect(forwardedConfig).toEqual(
+        expect.objectContaining({
+          type: 'dashboard',
+          dashboard: expect.any(Object),
+          datasets: expect.any(Object),
+          rows: expect.any(Array),
+          visualizations: expect.any(Object)
+        })
+      )
+    }
   })
 
   it('uses the compact preview header in editor preview mode without settings controls', () => {

--- a/packages/editor/src/components/ChooseTab.test.tsx
+++ b/packages/editor/src/components/ChooseTab.test.tsx
@@ -5,6 +5,10 @@ import ConfigContext, { EditorDispatchContext } from '@cdc/core/contexts/EditorC
 import ChooseTab from './ChooseTab'
 
 describe('ChooseTab', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('dispatches EDITOR_SAVE once when tempConfig is present', async () => {
     const dispatch = vi.fn()
     const tempConfig = { type: 'chart', data: [{ x: 'A', y: 1 }] }
@@ -41,7 +45,7 @@ describe('ChooseTab', () => {
       <ConfigContext.Provider
         value={
           {
-            config: { type: 'chart' },
+            config: {},
             tempConfig: null,
             errors: [],
             currentViewport: 'lg',
@@ -92,6 +96,171 @@ describe('ChooseTab', () => {
     expect(payload.xAxis.dataKey).toBeUndefined()
     expect(payload.yAxis.label).toBeUndefined()
     expect(payload.series).toBeUndefined()
+  })
+
+  it('keeps the existing config unchanged when the selected visualization is already active', () => {
+    const dispatch = vi.fn()
+    const config = {
+      type: 'dashboard',
+      activeVizButtonID: 15,
+      dashboard: { title: 'Existing dashboard' },
+      rows: [{ columns: [] }],
+      visualizations: { existing: { type: 'chart' } },
+      datasets: { existingDataset: { data: [{ value: 1 }] } }
+    }
+
+    render(
+      <ConfigContext.Provider
+        value={
+          {
+            config,
+            tempConfig: null,
+            errors: [],
+            currentViewport: 'lg',
+            globalActive: 0,
+            setTempConfig: vi.fn()
+          } as any
+        }
+      >
+        <EditorDispatchContext.Provider value={dispatch}>
+          <ChooseTab />
+        </EditorDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dashboard' }))
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenCalledWith({ type: 'EDITOR_SET_GLOBALACTIVE', payload: 1 })
+  })
+
+  it('keeps the existing config when changing visualizations is canceled', () => {
+    const dispatch = vi.fn()
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(
+      <ConfigContext.Provider
+        value={
+          {
+            config: {
+              type: 'dashboard',
+              activeVizButtonID: 15,
+              dashboard: { title: 'Existing dashboard' },
+              rows: [{ columns: [] }],
+              visualizations: {}
+            },
+            tempConfig: null,
+            errors: [],
+            currentViewport: 'lg',
+            globalActive: 0,
+            setTempConfig: vi.fn()
+          } as any
+        }
+      >
+        <EditorDispatchContext.Provider value={dispatch}>
+          <ChooseTab />
+        </EditorDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Data Bite' }))
+
+    expect(confirm).toHaveBeenCalledWith(
+      'Changing visualization type will clear configuration settings. Do you want to continue?'
+    )
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('replaces the existing config when changing visualizations is confirmed', () => {
+    const dispatch = vi.fn()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(
+      <ConfigContext.Provider
+        value={
+          {
+            config: {
+              type: 'dashboard',
+              activeVizButtonID: 15,
+              dashboard: { title: 'Existing dashboard' },
+              rows: [{ columns: [] }],
+              visualizations: { existing: { type: 'chart' } },
+              datasets: { existingDataset: { data: [{ value: 1 }] } }
+            },
+            tempConfig: null,
+            errors: [],
+            currentViewport: 'lg',
+            globalActive: 0,
+            setTempConfig: vi.fn()
+          } as any
+        }
+      >
+        <EditorDispatchContext.Provider value={dispatch}>
+          <ChooseTab />
+        </EditorDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Data Bite' }))
+
+    const setConfigAction = dispatch.mock.calls.find(([action]) => action.type === 'EDITOR_SET_CONFIG')![0]
+    expect(setConfigAction.payload).toEqual(
+      expect.objectContaining({
+        type: 'data-bite',
+        visualizationType: null,
+        biteStyle: 'tp5',
+        activeVizButtonID: 16,
+        datasets: {}
+      })
+    )
+    expect(setConfigAction.payload).not.toHaveProperty('dashboard')
+    expect(setConfigAction.payload).not.toHaveProperty('rows')
+    expect(setConfigAction.payload).not.toHaveProperty('visualizations')
+    expect(dispatch).toHaveBeenLastCalledWith({ type: 'EDITOR_SET_GLOBALACTIVE', payload: 1 })
+  })
+
+  it('requires confirmation and starts fresh when selecting a different subtype', () => {
+    const dispatch = vi.fn()
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(
+      <ConfigContext.Provider
+        value={
+          {
+            config: {
+              type: 'chart',
+              visualizationType: 'Bar',
+              activeVizButtonID: 1,
+              title: 'Existing chart',
+              datasets: { existingDataset: { data: [{ value: 1 }] } }
+            },
+            tempConfig: null,
+            errors: [],
+            currentViewport: 'lg',
+            globalActive: 0,
+            setTempConfig: vi.fn()
+          } as any
+        }
+      >
+        <EditorDispatchContext.Provider value={dispatch}>
+          <ChooseTab />
+        </EditorDispatchContext.Provider>
+      </ConfigContext.Provider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Line' }))
+
+    expect(confirm).toHaveBeenCalledOnce()
+    const setConfigAction = dispatch.mock.calls.find(([action]) => action.type === 'EDITOR_SET_CONFIG')![0]
+    expect(setConfigAction.payload).toEqual(
+      expect.objectContaining({
+        type: 'chart',
+        visualizationType: 'Line',
+        activeVizButtonID: 4,
+        datasets: {}
+      })
+    )
+    expect(setConfigAction.payload).not.toHaveProperty('title')
   })
 
   it('creates a dashboard starter config with legacy root table output disabled', () => {

--- a/packages/editor/src/components/ChooseTab.tsx
+++ b/packages/editor/src/components/ChooseTab.tsx
@@ -209,8 +209,20 @@ const ChooseTab: React.FC = (): JSX.Element => {
   }
 
   const configureTabs = props => {
+    if (config.activeVizButtonID === props.id) {
+      dispatch({ type: 'EDITOR_SET_GLOBALACTIVE', payload: 1 })
+      return
+    }
+
+    if (
+      config.type &&
+      !window.confirm('Changing visualization type will clear configuration settings. Do you want to continue?')
+    ) {
+      return
+    }
+
     const newConfig = generateNewConfig(props)
-    dispatch({ type: 'EDITOR_SET_CONFIG', payload: { ...config, ...newConfig, activeVizButtonID: props.id } })
+    dispatch({ type: 'EDITOR_SET_CONFIG', payload: { ...newConfig, activeVizButtonID: props.id } })
     dispatch({ type: 'EDITOR_SET_GLOBALACTIVE', payload: 1 })
   }
 


### PR DESCRIPTION
## Summary

Removes an extra event that was occasionally saving malformed configs in WCMS, and clears out configs when the user navigates back to the first tab and creates a different type of visualization.

## Testing Steps

This is best tested during regression testing on WCMS.