### PR TITLE
Fix: Stacked bar max calculation

### DIFF
--- a/packages/chart/src/components/Brush/BrushSelector.tsx
+++ b/packages/chart/src/components/Brush/BrushSelector.tsx
@@ -9,6 +9,7 @@ import type { BrushHandleRenderProps } from '@visx/brush/lib/BrushHandle'
 import { isDateScale } from '@cdc/core/helpers/cove/date'
 import ConfigContext, { ChartDispatchContext } from '../../ConfigContext'
 import { getChartPatternId } from '../../helpers/getChartPatternId'
+import getStackedSeriesMax from '../../helpers/getStackedSeriesMax'
 import MiniChartPreview from './MiniChartPreview'
 import { classifyBrushInteraction } from './brushInteraction'
 import type { BrushInteractionTarget } from './brushInteraction'
@@ -298,24 +299,9 @@ const BrushSelector: FC<BrushSelectorProps> = ({ xMax, yMax }) => {
     let hasValidValues = false
 
     if (isStacked) {
-      for (const row of tableData) {
-        let rowSum = 0
-        let hasRowValue = false
-        for (const s of leftSeries) {
-          if (!s.dataKey) continue
-          const value = parseFloat(row[s.dataKey])
-          if (!isNaN(value) && isFinite(value)) {
-            rowSum += value
-            hasRowValue = true
-          }
-        }
-        if (hasRowValue) {
-          hasValidValues = true
-          minValue = Math.min(minValue, rowSum)
-          maxValue = Math.max(maxValue, rowSum)
-        }
-      }
-      minValue = Math.min(0, minValue)
+      maxValue = getStackedSeriesMax(tableData, leftSeries)
+      minValue = 0
+      hasValidValues = maxValue !== 0
     } else {
       for (const s of leftSeries) {
         if (!s.dataKey) continue

--- a/packages/chart/src/helpers/getMinMax.ts
+++ b/packages/chart/src/helpers/getMinMax.ts
@@ -1,6 +1,7 @@
 import { ChartConfig } from '../types/ChartConfig'
 import { getCleanTopTickMax } from './getCleanTopTickMax'
 import { getAxisMaxOverride } from './getAxisMaxOverride'
+import getStackedSeriesMax from './getStackedSeriesMax'
 
 type GetMinMaxProps = {
   /** config - standard chart config */
@@ -120,24 +121,25 @@ const getMinMax = ({
       let rightAxisSeriesItems = series.filter(s => s.axis === 'Right')
 
       const findMaxFromSeriesKeys = (data, seriesData, max, axis = 'left') => {
-        let stackedBarMax = 0
-        let axisSeriesKeys = seriesData.map(i => i.dataKey) || []
+        const stackedBarSeries =
+          config.visualizationSubType === 'stacked' && axis === 'left' ? seriesData.filter(s => s.type === 'Bar') : []
+        const stackedBarSeriesKeys = new Set(stackedBarSeries.map(s => s.dataKey))
+        let axisSeriesKeys = seriesData.map(i => i.dataKey).filter(key => !stackedBarSeriesKeys.has(key)) || []
 
         axisSeriesKeys.forEach(key => {
-          let _seriesData = seriesData.find(s => s.dataKey === key)
           let _data = data.map(d => d[key])
           let seriesMax = Math.max.apply(null, _data)
-          if (config.visualizationSubType === 'stacked' && axis === 'left' && _seriesData.type === 'Bar') {
-            stackedBarMax += seriesMax
-          }
           if (seriesMax > max) {
             max = seriesMax
           }
+        })
 
+        if (stackedBarSeries.length) {
+          const stackedBarMax = getStackedSeriesMax(data, stackedBarSeries)
           if (max < stackedBarMax) {
             max = stackedBarMax
           }
-        })
+        }
         return max
       }
       leftMax = findMaxFromSeriesKeys(dataForMinMax, leftAxisSeriesItems, leftMax, 'left')

--- a/packages/chart/src/helpers/getStackedSeriesMax.ts
+++ b/packages/chart/src/helpers/getStackedSeriesMax.ts
@@ -1,0 +1,51 @@
+import isNumber from '@cdc/core/helpers/isNumber'
+
+type SeriesKeyOrItem =
+  | string
+  | {
+      dataKey?: string
+      originalDataKey?: string
+      dynamicCategory?: boolean
+    }
+
+const cleanValue = value => {
+  if (value === null || value === '') return ''
+  return typeof value === 'string' ? value.replace(/[,$]/g, '') : value
+}
+
+const getSeriesDataKey = (seriesKeyOrItem: SeriesKeyOrItem) => {
+  if (typeof seriesKeyOrItem === 'string') return seriesKeyOrItem
+  return seriesKeyOrItem.dynamicCategory && seriesKeyOrItem.originalDataKey
+    ? seriesKeyOrItem.originalDataKey
+    : seriesKeyOrItem.dataKey
+}
+
+const getStackedSeriesMax = (data: Object[] = [], seriesKeysOrSeriesItems: SeriesKeyOrItem[] = []) => {
+  let maxValue = Number.NEGATIVE_INFINITY
+  let hasValue = false
+
+  for (const row of data) {
+    let rowSum = 0
+    let hasRowValue = false
+
+    for (const seriesKeyOrItem of seriesKeysOrSeriesItems) {
+      const seriesKey = getSeriesDataKey(seriesKeyOrItem)
+      if (!seriesKey) continue
+
+      const value = cleanValue(row[seriesKey])
+      if (isNumber(value)) {
+        rowSum += Number(value)
+        hasRowValue = true
+      }
+    }
+
+    if (hasRowValue) {
+      maxValue = Math.max(maxValue, rowSum)
+      hasValue = true
+    }
+  }
+
+  return hasValue ? maxValue : 0
+}
+
+export default getStackedSeriesMax

--- a/packages/chart/src/helpers/tests/getMinMax.test.ts
+++ b/packages/chart/src/helpers/tests/getMinMax.test.ts
@@ -155,6 +155,47 @@ describe('getMinMax automatic max strategy', () => {
     expect(result.rightMax).toBe(89)
   })
 
+  it('uses stacked row totals for combo left-axis bar series and keeps right-axis line max independent', () => {
+    const barSeriesA = { dataKey: 'DoseOne', type: 'Bar', axis: 'Left', tooltip: true }
+    const barSeriesB = { dataKey: 'DoseTwo', type: 'Bar', axis: 'Left', tooltip: true }
+    const rightLineSeries = { dataKey: 'Rate', type: 'Line', axis: 'Right', tooltip: true }
+    const data = [
+      { DoseOne: 520, DoseTwo: 80, Rate: 900 },
+      { DoseOne: 0, DoseTwo: 600, Rate: 725 }
+    ]
+    const config = createConfig({
+      visualizationType: 'Combo',
+      visualizationSubType: 'stacked',
+      series: [barSeriesA, barSeriesB, rightLineSeries],
+      runtime: {
+        ...createConfig().runtime,
+        yAxis: {
+          ...createConfig().runtime.yAxis,
+          min: '',
+          max: ''
+        },
+        series: [barSeriesA, barSeriesB, rightLineSeries],
+        seriesKeys: ['DoseOne', 'DoseTwo', 'Rate'],
+        barSeriesKeys: ['DoseOne', 'DoseTwo'],
+        lineSeriesKeys: ['Rate']
+      } as any
+    })
+
+    const result = getMinMax({
+      config,
+      minValue: 0,
+      maxValue: 900,
+      existPositiveValue: true,
+      data,
+      tableData: data,
+      isAllLine: false
+    })
+
+    expect(result.leftMax).toBe(600)
+    expect(result.leftMax).not.toBe(1120)
+    expect(result.rightMax).toBe(900)
+  })
+
   it('forces a zero min for line charts when boundary suppression is present', () => {
     const config = createConfig({
       visualizationType: 'Line',

--- a/packages/chart/src/helpers/tests/getStackedSeriesMax.test.ts
+++ b/packages/chart/src/helpers/tests/getStackedSeriesMax.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import getStackedSeriesMax from '../getStackedSeriesMax'
+
+describe('getStackedSeriesMax', () => {
+  it('uses the tallest row sum instead of summing independent series maxima', () => {
+    const data = [
+      { apples: 400, oranges: 10 },
+      { apples: 50, oranges: 300 }
+    ]
+
+    expect(getStackedSeriesMax(data, ['apples', 'oranges'])).toBe(410)
+  })
+
+  it('accepts series objects and dynamic category original data keys', () => {
+    const data = [
+      { apples: 125, oranges: 75, dynamicFruit: 999 },
+      { apples: 10, oranges: 50, dynamicFruit: 999 }
+    ]
+    const series = [
+      { dataKey: 'apples' },
+      { dataKey: 'dynamicFruit', originalDataKey: 'oranges', dynamicCategory: true }
+    ]
+
+    expect(getStackedSeriesMax(data, series)).toBe(200)
+  })
+})

--- a/packages/chart/src/hooks/useReduceData.ts
+++ b/packages/chart/src/hooks/useReduceData.ts
@@ -1,5 +1,6 @@
 import isNumber from '@cdc/core/helpers/isNumber'
 import { useMemo } from 'react'
+import getStackedSeriesMax from '../helpers/getStackedSeriesMax'
 
 function useReduceData(config, data) {
   return useMemo(() => {
@@ -30,13 +31,11 @@ function useReduceData(config, data) {
     let minValue = Infinity
     let maxValue = -Infinity
     let existPositiveValue = false
-    const stackedTotals = []
 
     for (let i = 0; i < data.length; i++) {
       const row = data[i]
       let rowMax = -Infinity
       let rowMin = Infinity
-      let stackedSum = 0
 
       for (const key of config.runtime.seriesKeys) {
         const seriesKey = seriesKeysMap.get(key)
@@ -49,26 +48,22 @@ function useReduceData(config, data) {
           if (numValue < rowMin) rowMin = numValue
 
           if (numValue >= 0) existPositiveValue = true
-
-          if (!isNaN(numValue)) stackedSum += numValue
         }
       }
 
       if (rowMax > maxValue) maxValue = rowMax
       if (rowMin < minValue) minValue = rowMin
-
-      if (!isNaN(stackedSum)) stackedTotals.push(stackedSum)
     }
 
     if (
       (config.visualizationType === 'Bar' || (config.visualizationType === 'Combo' && isBar)) &&
       config.visualizationSubType === 'stacked'
     ) {
-      maxValue = Math.max(...stackedTotals)
+      maxValue = getStackedSeriesMax(data, config.runtime.series)
     }
 
     if (config.visualizationSubType === 'stacked' && config.visualizationType === 'Area Chart') {
-      maxValue = Math.max(...stackedTotals)
+      maxValue = getStackedSeriesMax(data, config.runtime.series)
     }
 
     if (
@@ -89,34 +84,7 @@ function useReduceData(config, data) {
 
     if (config.visualizationType === 'Combo' && config.visualizationSubType === 'stacked' && !isBar) {
       if (config.runtime.barSeriesKeys && config.runtime.lineSeriesKeys) {
-        let barMax = -Infinity
-        let lineMax = -Infinity
-
-        for (const row of data) {
-          let barSum = 0
-          let rowLineMax = -Infinity
-
-          for (const key of config.runtime.barSeriesKeys) {
-            const cleanValue = cleanChars(row[key])
-            if (isNumber(cleanValue)) {
-              const numValue = Number(cleanValue)
-              if (!isNaN(numValue)) barSum += numValue
-            }
-          }
-
-          for (const key of config.runtime.lineSeriesKeys) {
-            const cleanValue = cleanChars(row[key])
-            if (isNumber(cleanValue)) {
-              const numValue = Number(cleanValue)
-              if (numValue > rowLineMax) rowLineMax = numValue
-            }
-          }
-
-          if (barSum > barMax) barMax = barSum
-          if (rowLineMax > lineMax) lineMax = rowLineMax
-        }
-
-        maxValue = Math.max(barMax, lineMax)
+        maxValue = Math.max(maxValue, getStackedSeriesMax(data, config.runtime.barSeriesKeys))
       }
     }
 


### PR DESCRIPTION
## Summary

This fixes a bug where we were calculating the maximum of a stacked bar chart by summing the maximum values of each series, instead of combining the series and calculating the max of the combined series. This PR fixes the bug and centralizes the max-calculation logic so it doesn't happen again.

## Testing Steps

Open [cyclospora.json](https://github.com/user-attachments/files/31421920/cyclospora.json). The left axis max should be 600 on this branch. It was 1200 on `dev` 
