### PR TITLE
test: data bite average purple

### DIFF
--- a/packages/data-bite/src/_stories/DataBite.smoke.stories.tsx
+++ b/packages/data-bite/src/_stories/DataBite.smoke.stories.tsx
@@ -3,6 +3,7 @@ import DataBite from '../CdcDataBite'
 import { assertVisualizationRendered, getDisplayValue, waitForPresence } from '@cdc/core/helpers/testing'
 import { expect } from 'storybook/test'
 import MinimalExampleConfig from '../../examples/minimal-example.json'
+import CalculatedAverageConfig from '../../examples/gallery/calculated-average.json'
 
 const meta: Meta<typeof DataBite> = {
   title: 'Components/Templates/Data Bite',
@@ -24,6 +25,18 @@ type Story = StoryObj<typeof DataBite>
 export const Data_Bite_Circle_Average: Story = {
   args: {
     configUrl: 'https://www.cdc.gov/wcms/4.0/cdc-wp/data-presentation/examples/Data_Bite_Circle_Average.json'
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+  }
+}
+
+export const Data_Bite_Circle_Average_Purple: Story = {
+  args: {
+    config: {
+      ...CalculatedAverageConfig,
+      theme: 'theme-purple'
+    }
   },
   play: async ({ canvasElement }) => {
     await assertVisualizationRendered(canvasElement)

--- a/packages/waffle-chart/src/_stories/WaffleChart.HTMLTitle.Editor.stories.tsx
+++ b/packages/waffle-chart/src/_stories/WaffleChart.HTMLTitle.Editor.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, within } from 'storybook/test'
+import WaffleChart from '../CdcWaffleChart'
+import { performAndAssert, waitForEditor, openAccordion } from '@cdc/core/helpers/testing'
+import TestConfig from '../../tests/fixtures/test-config.json'
+
+const htmlTitle = 'Waffle <em>Chart</em> Title <strong>Test</strong><sup> 40</sup>'
+
+const meta: Meta<typeof WaffleChart> = {
+  title: 'Components/Templates/WaffleChart/Editor Tests',
+  component: WaffleChart,
+  parameters: {
+    layout: 'fullscreen'
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof WaffleChart>
+
+export const GeneralSectionHTMLTitleTests: Story = {
+  args: {
+    config: {
+      ...TestConfig,
+      title: 'Waffle Chart Title Test'
+    },
+    isEditor: true
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitForEditor(canvas)
+    await openAccordion(canvas, 'General')
+
+    const titleInput = canvas.getByDisplayValue('Waffle Chart Title Test')
+    await userEvent.clear(titleInput)
+    await userEvent.type(titleInput, htmlTitle)
+
+    await performAndAssert(
+      'HTML Title Update',
+      () => canvasElement.querySelector('.cove-visualization__header h2')?.innerHTML.trimEnd() || '',
+      async () => {},
+      (_, after) => after === 'Waffle <em>Chart</em> Title <strong>Test</strong><sup> 40</sup>'
+    )
+
+    const chartTitleHeader = canvasElement.querySelector('.cove-visualization__header h2')
+    expect(chartTitleHeader).toBeTruthy()
+    expect(chartTitleHeader?.textContent?.trimEnd()).toBe('Waffle Chart Title Test 40')
+    expect(chartTitleHeader?.querySelector('em')?.textContent).toBe('Chart')
+    expect(chartTitleHeader?.querySelector('strong')?.textContent).toBe('Test')
+    expect(chartTitleHeader?.querySelector('sup')?.textContent).toBe(' 40')
+  }
+}


### PR DESCRIPTION

This pull request adds a new smoke test story for the `DataBite` component, specifically testing the "calculated average" gallery example with a purple theme. This helps ensure that the component renders correctly with this configuration.

**Storybook smoke test enhancements:**

* Added import for `CalculatedAverageConfig` from the gallery examples to support the new test case.
* Added a new story, `Data_Bite_Circle_Average_Purple`, which uses the calculated average configuration with the purple theme and asserts that the visualization renders correctly.