### PR TITLE
fix: download link tabbing

### DIFF
--- a/packages/core/components/DownloadButton.test.tsx
+++ b/packages/core/components/DownloadButton.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 
 import DownloadButton from './DownloadButton'
@@ -19,8 +20,38 @@ describe('DownloadButton', () => {
 
     const button = screen.getByRole('button', { name: 'Download this data in a CSV file format.' })
 
+    expect(button.tagName).toBe('BUTTON')
+    expect(button).toHaveAttribute('type', 'button')
+    expect(button).toHaveClass('download-button-link')
     expect(button).toHaveClass('download-link-with-icon')
     expect(button).toHaveTextContent('Download Data (CSV)')
     expect(button.querySelector('.cove-download-link-icon--data')).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.queryByRole('link', { name: 'Download this data in a CSV file format.' })).not.toBeInTheDocument()
+  })
+
+  it('includes CSV downloads in sequential keyboard focus', async () => {
+    render(
+      <>
+        <a href='#before'>Before</a>
+        <DownloadButton
+          getRawData={() => []}
+          fileName='download.csv'
+          config={{
+            type: 'chart',
+            table: {}
+          }}
+        />
+        <a href='#after'>After</a>
+      </>
+    )
+
+    await userEvent.tab()
+    expect(screen.getByRole('link', { name: 'Before' })).toHaveFocus()
+
+    await userEvent.tab()
+    expect(screen.getByRole('button', { name: 'Download this data in a CSV file format.' })).toHaveFocus()
+
+    await userEvent.tab()
+    expect(screen.getByRole('link', { name: 'After' })).toHaveFocus()
   })
 })

--- a/packages/core/components/DownloadButton.tsx
+++ b/packages/core/components/DownloadButton.tsx
@@ -23,9 +23,9 @@ const DownloadButton = ({
   title,
   config
 }: DownloadButtonProps) => {
-  const linkRef = useRef<HTMLAnchorElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
 
-  const handleDownload = (event: React.MouseEvent<HTMLAnchorElement>) => {
+  const handleDownload = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault()
 
     const data = getRawData()
@@ -64,19 +64,19 @@ const DownloadButton = ({
   }
 
   return (
-    <a
-      ref={linkRef}
+    <button
+      ref={buttonRef}
       type='button'
       onClick={handleDownload}
       aria-label='Download this data in a CSV file format.'
-      className='no-border download-link-with-icon'
+      className='download-button-link no-border download-link-with-icon'
       id={skipId != null ? `${skipId}` : undefined}
+      title={title}
       data-html2canvas-ignore
-      role='button'
       style={{ cursor: 'pointer' }}
     >
       <DownloadLinkContent type='data'>{config?.table?.downloadDataLabel || 'Download Data (CSV)'}</DownloadLinkContent>
-    </a>
+    </button>
   )
 }
 

--- a/packages/core/components/MediaControls.test.tsx
+++ b/packages/core/components/MediaControls.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import html2canvas from 'html2canvas'
 import MediaControls from './MediaControls'
@@ -319,9 +320,13 @@ describe('MediaControls.DownloadLink', () => {
 
     const link = screen.getByRole('button', { name: 'Download Chart as Image' })
 
+    expect(link.tagName).toBe('BUTTON')
+    expect(link).toHaveAttribute('type', 'button')
     expect(link).toHaveClass('download-link-with-icon')
+    expect(link).toHaveClass('download-button-link')
     expect(getDownloadIcon(link, 'image')).toHaveAttribute('aria-hidden', 'true')
     expect(screen.getByText('Download Chart (PNG)')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Download Chart as Image' })).not.toBeInTheDocument()
   })
 
   it('does not render an icon for PDF download links', () => {
@@ -336,9 +341,36 @@ describe('MediaControls.DownloadLink', () => {
 
     const link = screen.getByRole('button', { name: 'Download Chart as PDF' })
 
+    expect(link.tagName).toBe('BUTTON')
+    expect(link).toHaveAttribute('type', 'button')
     expect(link).not.toHaveClass('download-link-with-icon')
+    expect(link).toHaveClass('download-button-link')
     expect(getDownloadIcon(link, 'image')).not.toBeInTheDocument()
     expect(screen.getByText('Download Chart (PDF)')).toBeInTheDocument()
+  })
+
+  it('includes generated media actions in sequential keyboard focus', async () => {
+    render(
+      <>
+        <a href='#before'>Before</a>
+        <MediaControls.DownloadLink
+          state={{ type: 'chart', table: {} }}
+          type='image'
+          title='Download Chart as Image'
+          elementToCapture='chart-download'
+        />
+        <a href='#after'>After</a>
+      </>
+    )
+
+    await userEvent.tab()
+    expect(screen.getByRole('link', { name: 'Before' })).toHaveFocus()
+
+    await userEvent.tab()
+    expect(screen.getByRole('button', { name: 'Download Chart as Image' })).toHaveFocus()
+
+    await userEvent.tab()
+    expect(screen.getByRole('link', { name: 'After' })).toHaveFocus()
   })
 
   it('forwards image filename fallbacks to media generation', async () => {

--- a/packages/core/components/MediaControls.tsx
+++ b/packages/core/components/MediaControls.tsx
@@ -251,7 +251,7 @@ const Button = ({
   )
 }
 
-// DownloadLink component for Chart/Map downloads (renders as text link)
+// DownloadLink component for Chart/Map downloads (renders as link-styled button)
 const DownloadLink = ({
   state,
   type,
@@ -268,19 +268,19 @@ const DownloadLink = ({
   const showDownloadIcon = type === 'image'
 
   return (
-    <a
-      role='button'
+    <button
+      type='button'
       onClick={() =>
         generateMedia(state, type, elementToCapture, interactionLabel, includeContextInDownload, imageFilenameFallback)
       }
       aria-label={title}
       title={title}
-      className={`no-border${showDownloadIcon ? ' download-link-with-icon' : ''}`}
+      className={`download-button-link no-border${showDownloadIcon ? ' download-link-with-icon' : ''}`}
       style={{ cursor: 'pointer' }}
       data-html2canvas-ignore
     >
       {showDownloadIcon ? <DownloadLinkContent type='image'>{linkText}</DownloadLinkContent> : linkText}
-    </a>
+    </button>
   )
 }
 

--- a/packages/map/src/_stories/CdcMap.Editor.DataTableSectionTests.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Editor.DataTableSectionTests.stories.tsx
@@ -282,8 +282,8 @@ export const DataTableSectionTests: Story = {
     await performAndAssert(
       'Show Download CSV Link → Toggle off',
       () => {
-        const downloadLink = Array.from(canvasElement.querySelectorAll('a')).find(link =>
-          link.textContent?.includes('Download Data')
+        const downloadLink = canvasElement.querySelector(
+          'button[aria-label="Download this data in a CSV file format."]'
         )
         return {
           hasDownloadLink: Boolean(downloadLink)
@@ -301,8 +301,8 @@ export const DataTableSectionTests: Story = {
     await performAndAssert(
       'Show Download CSV Link → Toggle back on',
       () => {
-        const downloadLink = Array.from(canvasElement.querySelectorAll('a')).find(link =>
-          link.textContent?.includes('Download Data')
+        const downloadLink = canvasElement.querySelector(
+          'button[aria-label="Download this data in a CSV file format."]'
         )
         return {
           hasDownloadLink: Boolean(downloadLink)
@@ -384,13 +384,12 @@ export const DataTableSectionTests: Story = {
     await performAndAssert(
       'Enable Image Download → Enable button',
       () => {
-        const downloadImgButton =
-          Array.from(canvasElement.querySelectorAll('button')).find(
-            btn => btn.textContent?.includes('Download Image') || btn.classList.contains('download-image')
-          ) ||
-          Array.from(canvasElement.querySelectorAll('a[role="button"]')).find(
-            link => link.textContent?.includes('Download Map') && link.textContent?.includes('PNG')
-          )
+        const downloadImgButton = Array.from(canvasElement.querySelectorAll('button')).find(
+          button =>
+            button.getAttribute('aria-label') === 'Download Map as Image' ||
+            button.getAttribute('title') === 'Download Map as Image' ||
+            (button.textContent?.includes('Download Map') && button.textContent?.includes('PNG'))
+        )
         return {
           hasDownloadImgButton: Boolean(downloadImgButton)
         }

--- a/packages/map/src/_stories/CdcMap.Logo.stories.tsx
+++ b/packages/map/src/_stories/CdcMap.Logo.stories.tsx
@@ -26,8 +26,8 @@ const assertLogoRendered = async (canvasElement: HTMLElement) => {
   expect(logo).toBeInTheDocument()
   expect(logo?.getAttribute('src')).toBe(CdcLogo)
 
-  const downloadPngLink = await waitForPresence('a[aria-label="Download Map as Image"]', canvasElement)
-  expect(downloadPngLink).toBeInTheDocument()
+  const downloadPngButton = await waitForPresence('button[aria-label="Download Map as Image"]', canvasElement)
+  expect(downloadPngButton).toBeInTheDocument()
 }
 
 const logoStory = (config: NonNullable<Story['args']>['config'], description: string): Story => ({


### PR DESCRIPTION
This pull request refactors the download controls in the `DownloadButton` and `MediaControls.DownloadLink` components to render as accessible `<button>` elements instead of styled `<a>` tags. This improves accessibility, ensures correct keyboard navigation, and updates related tests to reflect these changes.

**Accessibility and semantic improvements:**

* Refactored both `DownloadButton` (`DownloadButton.tsx`) and `MediaControls.DownloadLink` (`MediaControls.tsx`) components to render as `<button type="button">` elements with appropriate classes, instead of `<a>` tags with `role="button"`. This ensures correct semantics and accessibility for assistive technologies. [[1]](diffhunk://#diff-34c12513fd564ce3a3ad2646380c816ca978aff5730bb87e5f545dc1767d6073L26-R28) [[2]](diffhunk://#diff-34c12513fd564ce3a3ad2646380c816ca978aff5730bb87e5f545dc1767d6073L67-R79) [[3]](diffhunk://#diff-63080c4caf695d5321af1ae63641b6432e7f6567cdb36750b97314aa1e8e64e4L254-R254) [[4]](diffhunk://#diff-63080c4caf695d5321af1ae63641b6432e7f6567cdb36750b97314aa1e8e64e4L271-R283)

**Testing and keyboard navigation:**

* Updated and expanded tests for `DownloadButton` and `MediaControls.DownloadLink` to verify the new button rendering, correct attributes, and keyboard focus order, ensuring that the download buttons are included in sequential keyboard navigation. [[1]](diffhunk://#diff-4ed7f1f0267207f709cfc40586464352186cd621eb92b51fc647f4a44ea6f919R3) [[2]](diffhunk://#diff-4ed7f1f0267207f709cfc40586464352186cd621eb92b51fc647f4a44ea6f919R23-R55) [[3]](diffhunk://#diff-a51a1652b12601d4d7da565bedfdae213c6491df9cb1a6e48fd41eb0918203c5R3) [[4]](diffhunk://#diff-a51a1652b12601d4d7da565bedfdae213c6491df9cb1a6e48fd41eb0918203c5R323-R329) [[5]](diffhunk://#diff-a51a1652b12601d4d7da565bedfdae213c6491df9cb1a6e48fd41eb0918203c5R344-R375)

These changes improve both the user experience and accessibility compliance of the download controls.