### PR TITLE
fix: sort by fips column

### DIFF
--- a/packages/core/components/DataTable/DataTable.test.tsx
+++ b/packages/core/components/DataTable/DataTable.test.tsx
@@ -158,6 +158,123 @@ describe('DataTable search', () => {
     expect(screen.getByRole('button', { name: 'Download Map as PDF' })).toBeInTheDocument()
   })
 
+  it('preserves source order for unsorted map rows with zero-padded FIPS keys', () => {
+    const rawData = [
+      { county_fips: '01001', uid: 'stale-uid', value: 'Alabama row' },
+      { county_fips: '10001', value: 'Delaware row' },
+      { county_fips: '08001', value: 'Colorado row' }
+    ]
+    const runtimeData = rawData.reduce((acc, row) => {
+      acc[row.county_fips] = row
+      return acc
+    }, {} as Record<string, (typeof rawData)[number]>)
+
+    const config = {
+      type: 'map',
+      visualizationType: 'Map',
+      general: { geoType: 'us-county', type: 'map' },
+      columns: {
+        geo: { name: 'county_fips', label: 'Location', dataTable: true },
+        value: { name: 'value', label: 'Value', dataTable: true, prefix: '', suffix: '', useCommas: false }
+      },
+      legend: { specialClasses: [] },
+      table: {
+        label: 'Data Table',
+        search: false,
+        expanded: true,
+        collapsible: false,
+        showDownloadLinkBelow: false,
+        download: false,
+        indexLabel: '',
+        cellMinWidth: 0
+      },
+      runtime: { uniqueId: 'county-fips-map' },
+      preliminaryData: []
+    } as any
+
+    render(
+      <DataTable
+        config={config}
+        columns={config.columns}
+        rawData={rawData}
+        runtimeData={runtimeData as any}
+        expandDataTable={true}
+        tableTitle='Data Table'
+        viewport='lg'
+        tabbingId='county-fips-source-order-data-table'
+        displayGeoName={row => row}
+        formatLegendLocation={row => row}
+        applyLegendToRow={() => ['#000']}
+        getPatternForRow={() => null}
+      />
+    )
+
+    const firstColumnValues = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map(row => row.querySelector('td')?.textContent)
+    expect(firstColumnValues).toEqual(['01001', '10001', '08001'])
+  })
+
+  it('sorts map rows by zero-padded FIPS default sort before non-padded integer-like keys', () => {
+    const rawData = [
+      { county_fips: '10001', value: 'Delaware row' },
+      { county_fips: '01001', value: 'Alabama row' },
+      { county_fips: '08001', value: 'Colorado row' }
+    ]
+    const runtimeData = rawData.reduce((acc, row) => {
+      acc[row.county_fips] = row
+      return acc
+    }, {} as Record<string, (typeof rawData)[number]>)
+
+    const config = {
+      type: 'map',
+      visualizationType: 'Map',
+      general: { geoType: 'us-county', type: 'map' },
+      columns: {
+        geo: { name: 'county_fips', label: 'Location', dataTable: true },
+        value: { name: 'value', label: 'Value', dataTable: true, prefix: '', suffix: '', useCommas: false }
+      },
+      legend: { specialClasses: [] },
+      table: {
+        label: 'Data Table',
+        search: false,
+        expanded: true,
+        collapsible: false,
+        showDownloadLinkBelow: false,
+        download: false,
+        indexLabel: '',
+        cellMinWidth: 0,
+        defaultSort: { column: 'geo', sortDirection: 'asc' }
+      },
+      runtime: { uniqueId: 'county-fips-default-sort-map' },
+      preliminaryData: []
+    } as any
+
+    render(
+      <DataTable
+        config={config}
+        columns={config.columns}
+        rawData={rawData}
+        runtimeData={runtimeData as any}
+        expandDataTable={true}
+        tableTitle='Data Table'
+        viewport='lg'
+        tabbingId='county-fips-default-sort-data-table'
+        displayGeoName={row => row}
+        formatLegendLocation={row => row}
+        applyLegendToRow={() => ['#000']}
+        getPatternForRow={() => null}
+      />
+    )
+
+    const firstColumnValues = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map(row => row.querySelector('td')?.textContent)
+    expect(firstColumnValues).toEqual(['01001', '08001', '10001'])
+  })
+
   it('uses the map index label for full CSV download geo headers', () => {
     downloadState.latest = []
     downloadState.fileName = ''
@@ -1095,9 +1212,7 @@ describe('DataTable search', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Download Chart as Image' }))
 
-    expect(downloadState.mediaDownloads).toEqual([
-      { title: 'Download Chart as Image', imageFilenameFallback: 'abc' }
-    ])
+    expect(downloadState.mediaDownloads).toEqual([{ title: 'Download Chart as Image', imageFilenameFallback: 'abc' }])
   })
 
   it('filters standalone table rows by visible values only', () => {

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -121,6 +121,58 @@ const getMediaDownloadVisualizationLabel = (type?: string) => {
   return 'Chart'
 }
 
+const getRuntimeDataKeys = (runtimeData: Object[] | Record<string, Object>) => {
+  return Object.keys(runtimeData || {}).filter(column => column !== 'columns')
+}
+
+const isArrayIndexKey = (key: string) => {
+  const numericKey = Number(key)
+  return Number.isInteger(numericKey) && numericKey >= 0 && numericKey < 2 ** 32 - 1 && String(numericKey) === key
+}
+
+const isZeroPaddedIntegerKey = (key: string) => {
+  return /^0\d+$/.test(key)
+}
+
+const getMapRuntimeDataKeys = (
+  rawData: Object[],
+  runtimeData: Object[] | Record<string, Object>,
+  columns?: Record<string, Column>
+) => {
+  const runtimeDataKeys = getRuntimeDataKeys(runtimeData)
+  if (!runtimeData || Array.isArray(runtimeData) || !Array.isArray(rawData) || runtimeDataKeys.length === 0) {
+    return runtimeDataKeys
+  }
+
+  const hasIntegerOrderingRisk = runtimeDataKeys.some(isArrayIndexKey) && runtimeDataKeys.some(isZeroPaddedIntegerKey)
+  if (!hasIntegerOrderingRisk) return runtimeDataKeys
+
+  const runtimeDataKeySet = new Set(runtimeDataKeys)
+  const seen = new Set<string>()
+  const geoColumnName = columns?.geo?.name
+  const sourceOrderedKeys = rawData.reduce<string[]>((acc, row) => {
+    if (!row || typeof row !== 'object') return acc
+
+    const rowRecord = row as Record<string, any>
+    const rowKey = [rowRecord.uid, geoColumnName ? rowRecord[geoColumnName] : undefined].find(candidate => {
+      return candidate !== undefined && candidate !== null && runtimeDataKeySet.has(String(candidate))
+    })
+    if (rowKey === undefined || rowKey === null) return acc
+
+    const normalizedRowKey = String(rowKey)
+    if (runtimeDataKeySet.has(normalizedRowKey) && !seen.has(normalizedRowKey)) {
+      seen.add(normalizedRowKey)
+      acc.push(normalizedRowKey)
+    }
+
+    return acc
+  }, [])
+
+  if (!sourceOrderedKeys.length) return runtimeDataKeys
+
+  return [...sourceOrderedKeys, ...runtimeDataKeys.filter(key => !seen.has(key))]
+}
+
 const TableMediaControls = ({
   belowTable,
   config,
@@ -290,7 +342,10 @@ const DataTable = (props: DataTableProps) => {
     displayGeoName
   })
 
-  const rawRows = Object.keys(searchedRuntimeData || {}).filter(column => column !== 'columns')
+  const rawRows =
+    config.type === 'map'
+      ? getMapRuntimeDataKeys(rawData, searchedRuntimeData, columns || config.columns)
+      : getRuntimeDataKeys(searchedRuntimeData)
 
   // Determine if custom order sort is active (user hasn't overridden by clicking a column header)
   const isCustomOrderActive =

--- a/packages/core/components/DataTable/helpers/customSort.ts
+++ b/packages/core/components/DataTable/helpers/customSort.ts
@@ -1,6 +1,33 @@
 import { parseDate } from '@cdc/core/helpers/cove/date'
 import { standardizeStateName } from './standardizeState'
 
+const compareStrings = (a: string, b: string, asc: boolean): number => {
+  if (a === b) return 0
+  return asc ? (a < b ? -1 : 1) : b < a ? -1 : 1
+}
+
+const getSortColumnName = (sortBy, config): string => {
+  if (!sortBy?.column) return ''
+
+  if (config.type === 'map') {
+    return config.columns?.[sortBy.column]?.name || sortBy.column
+  }
+
+  return sortBy.column
+}
+
+const isZeroPaddedInteger = (value: unknown): boolean => {
+  return typeof value === 'string' && /^0\d+$/.test(value.trim())
+}
+
+const isIntegerString = (value: string): boolean => {
+  return /^\d+$/.test(value)
+}
+
+const isFipsCapableGeoSort = (sortBy, config): boolean => {
+  return sortBy?.column === 'geo' && ['us', 'us-county', 'single-state'].includes(config.general?.geoType)
+}
+
 export const customSort = (a, b, sortBy, config) => {
   let valueA = a
   let valueB = b
@@ -46,6 +73,17 @@ export const customSort = (a, b, sortBy, config) => {
   if (trimmedA === '' && trimmedB === '') return 0
   if (trimmedA === '' && trimmedB !== '') return 1
   if (trimmedA !== '' && trimmedB === '') return -1
+
+  const preservesZeroPaddedFips =
+    config.type === 'map' && (isFipsCapableGeoSort(sortBy, config) || /fips/i.test(getSortColumnName(sortBy, config)))
+  if (
+    preservesZeroPaddedFips &&
+    isIntegerString(trimmedA) &&
+    isIntegerString(trimmedB) &&
+    (isZeroPaddedInteger(valueA) || isZeroPaddedInteger(valueB))
+  ) {
+    return compareStrings(trimmedA, trimmedB, sortBy.asc)
+  }
 
   // Both are numbers: Compare numerically
   if (isNumA && isNumB) {

--- a/packages/core/components/DataTable/helpers/tests/customSort.test.ts
+++ b/packages/core/components/DataTable/helpers/tests/customSort.test.ts
@@ -50,6 +50,22 @@ describe('customSort()', () => {
     expect(customSort(b, a, sortBy, { type: 'notMap' })).lessThan(0)
   })
 
+  it('sorts zero-padded FIPS identifiers as strings', () => {
+    const sortBy = { column: 'geo', asc: true, colIndex: 0 }
+    const config = {
+      type: 'map',
+      general: { geoType: 'us-county' },
+      columns: {
+        geo: { name: 'Location' }
+      }
+    }
+
+    expect(customSort('01010', '0102', sortBy, config)).lessThan(0)
+    expect(customSort('01010', '10001', sortBy, config)).lessThan(0)
+    expect(customSort('10001', '01010', { ...sortBy, asc: false }, config)).lessThan(0)
+    expect(customSort('01010', '0102', sortBy, { type: 'table' })).greaterThan(0)
+  })
+
   it('does not throw when map region values are null', () => {
     const sortBy = { column: 'someColumn', asc: true, colIndex: 0 }
 


### PR DESCRIPTION
This pull request improves the handling and sorting of zero-padded FIPS codes (such as county FIPS) in the `DataTable` component, ensuring that map data with mixed key formats is displayed and sorted correctly. It adds new logic to preserve the source order for unsorted map data and sorts zero-padded FIPS identifiers as strings when appropriate. The changes are covered by new and updated tests.

**Map data key handling and sorting improvements:**

* Added helper functions (`getRuntimeDataKeys`, `isArrayIndexKey`, `isZeroPaddedIntegerKey`, `getMapRuntimeDataKeys`) to preserve the source order of map rows with zero-padded FIPS keys, preventing JavaScript's default integer key sorting from reordering them unexpectedly. (`[packages/core/components/DataTable/DataTable.tsxR124-R175](diffhunk://#diff-262afb6d83a5eb0ced6cc67142011a2e834d638550235ec01d1b1e590f05fabfR124-R175)`)
* Updated the `DataTable` component to use the new map key extraction logic, ensuring correct row order for maps. (`[packages/core/components/DataTable/DataTable.tsxL293-R348](diffhunk://#diff-262afb6d83a5eb0ced6cc67142011a2e834d638550235ec01d1b1e590f05fabfL293-R348)`)
* Enhanced the `customSort` function to detect zero-padded FIPS codes and sort them as strings (not numbers) when used as geo columns in map visualizations, preventing incorrect ordering. (`[[1]](diffhunk://#diff-64a5cc4c587fea6e821fcc1ed56784cd3a306cff7041875abfa3503af0028a35R4-R30)`, `[[2]](diffhunk://#diff-64a5cc4c587fea6e821fcc1ed56784cd3a306cff7041875abfa3503af0028a35R77-R87)`)

**Test coverage:**

* Added and updated tests in `DataTable.test.tsx` to verify that source order is preserved for unsorted map rows and that default sorting correctly orders zero-padded FIPS keys. (`[packages/core/components/DataTable/DataTable.test.tsxR161-R277](diffhunk://#diff-08d749e0f466fe58186dbeacf8a80b8fb65bfdbba756176d88db888b50eee5bfR161-R277)`)
* Added a test in `customSort.test.ts` to confirm that zero-padded FIPS identifiers are sorted as strings in map contexts. (`[packages/core/components/DataTable/helpers/tests/customSort.test.tsR53-R68](diffhunk://#diff-a67f1debb5bca95302d2bbe5893f0f0262154446f381c1101472bcd9229068aeR53-R68)`)

**Other:**

* Minor formatting adjustment in a test assertion for clarity. (`[packages/core/components/DataTable/DataTable.test.tsxL1098-R1215](diffhunk://#diff-08d749e0f466fe58186dbeacf8a80b8fb65bfdbba756176d88db888b50eee5bfL1098-R1215)`)