### PR TITLE
fix: show boxplot data

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -558,7 +558,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
     }
 
     if (newConfig.visualizationType === 'Box Plot' && newConfig.series) {
-      const [plots, categories] = getBoxPlotConfig(newConfig, stateData)
+      const [plots, categories] = getBoxPlotConfig(newConfig, data || [])
       newConfig.boxplot['categories'] = categories
       newConfig.boxplot.plots = plots
       newConfig.yAxis.labelPlacement = 'On Date/Category Axis'

--- a/packages/chart/src/helpers/getBoxPlotConfig.ts
+++ b/packages/chart/src/helpers/getBoxPlotConfig.ts
@@ -1,5 +1,4 @@
 import capitalize from 'lodash/capitalize'
-import chain from 'lodash/chain'
 import filter from 'lodash/filter'
 import flatMap from 'lodash/flatMap'
 import map from 'lodash/map'
@@ -20,17 +19,9 @@ export const getBoxPlotConfig = (newConfig: ChartConfig, data: object[]) => {
       try {
         if (!g) throw new Error('No groups resolved in box plots')
 
-        // Start handle operations on combinedData
-        const { count, sortedData } = chain(combinedData)
-          // Filter by xAxis data key
-          .filter(item => item[newConfig.xAxis.dataKey] === g)
-          // perform multiple operations on the filtered data
-          .thru(filteredData => ({
-            count: filteredData.length,
-            sortedData: map(filteredData, item => Number(item[seriesKey])).sort()
-          }))
-          // get the results from the chain
-          .value()
+        const filteredData = combinedData.filter(item => item[newConfig.xAxis.dataKey] === g)
+        const count = filteredData.length
+        const sortedData = map(filteredData, item => Number(item[seriesKey])).sort()
 
         if (!sortedData) throw new Error('boxplots dont have data yet')
         if (!plots) throw new Error('boxplots dont have plots yet')

--- a/packages/chart/src/test/CdcChart.dataTable.test.tsx
+++ b/packages/chart/src/test/CdcChart.dataTable.test.tsx
@@ -188,6 +188,50 @@ describe('CdcChart data table dataset wiring', () => {
     expect(dataTableProps.at(-1).runtimeData.map(row => row.category)).toEqual(['A', 'C', 'D', 'L'])
   })
 
+  it('derives Box Plot table rows from prepared data before rendering the DataTable', async () => {
+    const formattedData = [
+      { Group: 'Group A', Score: '8' },
+      { Group: 'Group A', Score: '24' },
+      { Group: 'Group A', Score: '32' }
+    ]
+
+    render(
+      <CdcChart
+        config={
+          {
+            type: 'chart',
+            visualizationType: 'Box Plot',
+            title: 'Prepared Box Plot',
+            formattedData,
+            xAxis: { type: 'categorical', dataKey: 'Group' },
+            yAxis: { dataKey: 'Score' },
+            series: [{ dataKey: 'Score' }],
+            table: {
+              show: true,
+              expanded: true,
+              download: true,
+              label: 'Data Table',
+              indexLabel: ''
+            }
+          } as any
+        }
+        interactionLabel='chart-box-plot-table-test'
+      />
+    )
+
+    await waitFor(() => {
+      expect(dataTableProps.at(-1)?.config?.boxplot?.plots?.length).toBe(1)
+    })
+
+    expect(dataTableProps.at(-1).config.boxplot.categories).toEqual(['Group A'])
+    expect(dataTableProps.at(-1).config.boxplot.plots[0]).toMatchObject({
+      columnCategory: 'Group A',
+      columnCount: 3,
+      columnMax: 32,
+      columnMin: 8
+    })
+  })
+
   it('updates metadata-backed chart title and text when dataMetadata changes and data does not', async () => {
     const data = [{ category: 'A', value: 1 }]
     const config = {

--- a/packages/core/components/DataTable/DataTable.test.tsx
+++ b/packages/core/components/DataTable/DataTable.test.tsx
@@ -897,6 +897,95 @@ describe('DataTable search', () => {
     expect(screen.queryByText('Skip Data Table')).not.toBeInTheDocument()
   })
 
+  it('renders Box Plot rows when derived plots are populated after the first render', () => {
+    const rawData = [{ Group_Category: 'Category A', value: 12 }]
+    const labels = {
+      maximum: 'Maximum',
+      q3: 'Upper Quartile',
+      median: 'Median',
+      q1: 'Lower Quartile',
+      minimum: 'Minimum',
+      count: 'Count',
+      mean: 'Mean',
+      iqr: 'Interquartile Range',
+      outliers: 'Outliers',
+      values: 'Values',
+      lowerBounds: 'Lower Bounds',
+      upperBounds: 'Upper Bounds'
+    }
+    const baseConfig = {
+      type: 'chart',
+      visualizationType: 'Box Plot',
+      general: {},
+      columns: {},
+      data: rawData,
+      xAxis: { dataKey: 'Group_Category', type: 'categorical' },
+      yAxis: { dataKey: 'value' },
+      table: {
+        label: 'Data Table',
+        expanded: true,
+        showDownloadLinkBelow: false,
+        download: false,
+        indexLabel: ''
+      },
+      boxplot: {
+        categories: ['Category A'],
+        labels,
+        plots: []
+      },
+      runtime: { seriesKeys: ['value'] },
+      preliminaryData: []
+    } as any
+    const renderTable = (config: any) => (
+      <DataTable
+        config={config}
+        columns={config.columns}
+        rawData={rawData}
+        runtimeData={rawData as any}
+        expandDataTable={true}
+        tableTitle='Data Table'
+        viewport='lg'
+        tabbingId='box-plot-derived-data-table'
+      />
+    )
+
+    const { rerender } = render(renderTable(baseConfig))
+
+    expect(screen.getByText('No Data')).toBeInTheDocument()
+
+    rerender(
+      renderTable({
+        ...baseConfig,
+        boxplot: {
+          ...baseConfig.boxplot,
+          plots: [
+            {
+              columnCategory: 'Category A',
+              columnMax: 12,
+              columnThirdQuartile: 12,
+              columnMedian: '12',
+              columnFirstQuartile: 12,
+              columnMin: 12,
+              columnCount: 1,
+              columnSd: '0',
+              columnMean: '12',
+              columnIqr: 0,
+              values: [12],
+              columnLowerBounds: 12,
+              columnUpperBounds: 12,
+              columnOutliers: [],
+              columnNonOutliers: [12]
+            }
+          ]
+        }
+      })
+    )
+
+    expect(screen.queryByText('No Data')).not.toBeInTheDocument()
+    expect(screen.getByText('Maximum')).toBeInTheDocument()
+    expect(screen.getAllByText('12').length).toBeGreaterThan(0)
+  })
+
   it('downloads searched rows when visible-data-only downloads are enabled', () => {
     downloadState.latest = []
     downloadState.fileName = ''

--- a/packages/core/components/DataTable/DataTable.tsx
+++ b/packages/core/components/DataTable/DataTable.tsx
@@ -358,18 +358,15 @@ const DataTable = (props: DataTableProps) => {
     return BothFixed || NeitherFixed || ToFixedFromNotSet || FromFixedToNotSet
   })
 
-  // prettier-ignore
-  const tableData = useMemo(() => (
-    config.data?.[0]?.tableData
-      ? config.data?.[0]?.tableData
-      : config.visualizationType === 'Sankey'
-        ? config.data?.[0]?.tableData
-        : config.visualizationType === 'Pie'
-          ? [config.yAxis.dataKey]
-          : config.visualizationType === 'Box Plot'
-            ? config?.boxplot?.plots?.[0] ? Object.entries(config.boxplot.plots[0]) : []
-            : config.runtime?.seriesKeys),
-    [config.runtime?.seriesKeys]) // eslint-disable-line
+  const tableData = useMemo(() => {
+    if (config.data?.[0]?.tableData) return config.data[0].tableData
+    if (config.visualizationType === 'Sankey') return config.data?.[0]?.tableData
+    if (config.visualizationType === 'Pie') return [config.yAxis.dataKey]
+    if (config.visualizationType === 'Box Plot') {
+      return config.boxplot?.plots?.[0] ? Object.entries(config.boxplot.plots[0]) : []
+    }
+    return config.runtime?.seriesKeys
+  }, [config.data, config.visualizationType, config.yAxis?.dataKey, config.boxplot?.plots, config.runtime?.seriesKeys])
 
   if (isLoading) return <Loading />
 


### PR DESCRIPTION
This pull request improves the handling and rendering of Box Plot visualizations and their associated data tables. The main focus is on ensuring that Box Plot data is correctly derived, passed, and displayed in both the chart and data table components, with additional tests to verify this behavior. The changes also include code simplification and improved test coverage.

**Box Plot Data Handling and Rendering:**

* Updated `CdcChartComponent.tsx` to use the correct data source for Box Plot configuration, ensuring that `getBoxPlotConfig` receives the intended data array instead of potentially stale state data.
* Refactored `getBoxPlotConfig.ts` to remove unnecessary lodash `chain` usage, simplifying the logic for filtering and sorting data for Box Plot plots. [[1]](diffhunk://#diff-cbb6961a9dbb27bd756eeaa5f652c3afdcf168019a1a2fb62e4eecb402b2a74aL2) [[2]](diffhunk://#diff-cbb6961a9dbb27bd756eeaa5f652c3afdcf168019a1a2fb62e4eecb402b2a74aL23-R24)
* Improved the `DataTable` component's logic for determining table data, making it more robust and ensuring Box Plot plots are properly displayed when present.

**Testing and Verification:**

* Added a test in `CdcChart.dataTable.test.tsx` to verify that Box Plot table rows are derived from prepared data before rendering, ensuring correct integration between chart configuration and data table display.
* Added a test in `DataTable.test.tsx` to confirm that Box Plot rows render correctly when derived plots are populated after the first render, and that the table updates appropriately from "No Data" to displaying the correct values.