### PR TITLE
DEV-10589 Hide bar thickness option in pie charts

### DIFF
--- a/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
+++ b/packages/chart/src/components/EditorPanel/components/Panels/Panel.Visual.tsx
@@ -521,7 +521,8 @@ const PanelVisual: FC<PanelProps> = props => {
 
         {(config.orientation !== 'horizontal' || config.visualizationType === 'Combo') &&
           config.visualizationType !== 'Warming Stripes' &&
-          config.visualizationType !== 'Sankey' && (
+          config.visualizationType !== 'Sankey' &&
+          config.visualizationType !== 'Pie' && (
             <TextField
               value={config.barThickness}
               type='number'


### PR DESCRIPTION
## Summary
Small change to hide bar thickness option for pie charts

## Testing Steps
Load a pie chart, bar thickness should no longer be an option
