### PR TITLE
Enhancement [DEV-13758] Improve data file updates

### DIFF
--- a/packages/core/CONFIG.md
+++ b/packages/core/CONFIG.md
@@ -87,6 +87,7 @@ Dashboards and dataset-driven packages use `DataSet` entries inside a `datasets`
 
 | Field | Type | Required | Description | Allowed values / Notes |
 | --- | --- | --- | --- | --- |
+| `label` | `string` | No | User-facing dataset name shown by dashboard editor controls. | Dataset map keys remain the stable internal identifiers. When omitted, editors display the dataset key for backward compatibility. |
 | `dataUrl` | `string` | No | Source URL for the dataset. | May point at JSON, CSV, or another supported fetch target. Omit when the dataset is provided inline through `data`. |
 | `loadQueryParam` | `string` | No | Browser query-string parameter appended to `dataUrl` during dashboard dataset loading. | Used when an embedded dashboard should vary a dataset URL from the page query string. |
 | `dataKey`, `data`, `dataMetadata`, `dataDescription` | Shared `ConfigureData` fields | No | Same shared loading fields described above. | `DataSet` extends `ConfigureData`, so these fields follow the same rules as above. |

--- a/packages/core/components/EditorPanel/FootnotesEditor.tsx
+++ b/packages/core/components/EditorPanel/FootnotesEditor.tsx
@@ -20,6 +20,7 @@ import {
   AccordionItemHeading,
   AccordionItemPanel
 } from 'react-accessible-accordion'
+import { getDatasetDisplayLabel } from '@cdc/core/helpers/dashboardDatasetLabels'
 interface FootnotesEditorProps {
   config: AnyVisualization
   updateField: UpdateFieldFunc<Footnote[] | Object>
@@ -78,14 +79,16 @@ const FootnotesEditor: React.FC<FootnotesEditorProps> = ({ config, updateField, 
     updateField('footnotes', null, 'staticFootnotes', footnoteCopy)
   }
 
-  const getSelectOptions = (opts: string[]) => {
-    return [{ value: '', label: '--Select--' }].concat(opts.map(key => ({ value: key, label: key })))
+  const getSelectOptions = (opts: string[], getLabel = (key: string) => key) => {
+    return [{ value: '', label: '--Select--' }].concat(opts.map(key => ({ value: key, label: getLabel(key) })))
   }
 
   const dataColumns = footnotesConfig.dataKey
     ? getSelectOptions(Object.keys(datasetsCache[footnotesConfig.dataKey]?.data?.[0] || {}))
     : []
-  const dataSetOptions = getSelectOptions(Object.keys(datasetsCache))
+  const dataSetOptions = getSelectOptions(Object.keys(datasetsCache), key =>
+    getDatasetDisplayLabel(key, datasetsCache)
+  )
 
   const changeFootnoteDataKey = async value => {
     if (value) {

--- a/packages/core/contexts/editor.actions.ts
+++ b/packages/core/contexts/editor.actions.ts
@@ -9,10 +9,7 @@ type EDITOR_TEMP_SAVE = Action<'EDITOR_TEMP_SAVE', Visualization>
 type EDITOR_SET_ERRORS = Action<'EDITOR_SET_ERRORS', string[]>
 type EDITOR_SET_VIEWPORT = Action<'EDITOR_SET_VIEWPORT', ViewPort>
 type EDITOR_SET_GLOBALACTIVE = Action<'EDITOR_SET_GLOBALACTIVE', number>
-type SET_DASHBOARD_DATASET = Action<
-  'SET_DASHBOARD_DATASET',
-  { datasetKey: string; oldDatasetKey?: string; dataset: DataSet }
->
+type SET_DASHBOARD_DATASET = Action<'SET_DASHBOARD_DATASET', { datasetKey: string; dataset: DataSet }>
 type DELETE_DATASET = Action<'DELETE_DASHBOARD_DATASET', { datasetKey: string }>
 
 type actions =

--- a/packages/core/contexts/editor.reducer.test.ts
+++ b/packages/core/contexts/editor.reducer.test.ts
@@ -158,6 +158,8 @@ describe('editor reducer dashboard datasets', () => {
     state.config.datasets.new_source = {
       ...importedDataset,
       label: 'Old source',
+      dataDescription: { horizontal: true, series: false },
+      loadQueryParam: 'state',
       formattedData: [{ value: 'stale-row' }]
     }
     state.config.visualizations['dashboard-table-new-source'] = createGeneratedTable('new_source')
@@ -173,6 +175,8 @@ describe('editor reducer dashboard datasets', () => {
 
     expect(nextState.config.datasets.new_source.data).toEqual([{ value: 'replacement-row' }])
     expect(nextState.config.datasets.new_source.label).toBe('New source')
+    expect(nextState.config.datasets.new_source.dataDescription).toEqual({ horizontal: true, series: false })
+    expect(nextState.config.datasets.new_source.loadQueryParam).toBeUndefined()
     expect(nextState.config.datasets.new_source.formattedData).toBeUndefined()
     expect(generatedTablesFor(nextState.config, 'new_source')).toHaveLength(1)
     expect(nextState.config.rows).toHaveLength(1)

--- a/packages/core/contexts/editor.reducer.test.ts
+++ b/packages/core/contexts/editor.reducer.test.ts
@@ -140,9 +140,26 @@ describe('editor reducer dashboard datasets', () => {
     expect(nextState.config.rows[0].columns[0].widget).toBe('dashboard-table-new-source-1')
   })
 
+  it('uses the dataset label when creating its generated table', () => {
+    const state = createEmptyDashboardState()
+    const nextState = reducer(state, {
+      type: 'SET_DASHBOARD_DATASET',
+      payload: {
+        datasetKey: 'weekly-cases',
+        dataset: { ...importedDataset, label: 'Weekly cases' }
+      }
+    } as any)
+
+    expect(nextState.config.visualizations['dashboard-table-weekly-cases'].table.label).toBe('Weekly cases')
+  })
+
   it('does not duplicate generated tables when replacing an existing dataset with the same key', () => {
     const state = createEmptyDashboardState()
-    state.config.datasets.new_source = importedDataset
+    state.config.datasets.new_source = {
+      ...importedDataset,
+      label: 'Old source',
+      formattedData: [{ value: 'stale-row' }]
+    }
     state.config.visualizations['dashboard-table-new-source'] = createGeneratedTable('new_source')
     state.config.rows = [{ columns: [{ width: 12, widget: 'dashboard-table-new-source' }] }]
 
@@ -150,33 +167,15 @@ describe('editor reducer dashboard datasets', () => {
       type: 'SET_DASHBOARD_DATASET',
       payload: {
         datasetKey: 'new_source',
-        dataset: { ...importedDataset, data: [{ value: 'replacement-row' }] }
+        dataset: { ...importedDataset, label: 'New source', data: [{ value: 'replacement-row' }] }
       }
     } as any)
 
     expect(nextState.config.datasets.new_source.data).toEqual([{ value: 'replacement-row' }])
+    expect(nextState.config.datasets.new_source.label).toBe('New source')
+    expect(nextState.config.datasets.new_source.formattedData).toBeUndefined()
     expect(generatedTablesFor(nextState.config, 'new_source')).toHaveLength(1)
     expect(nextState.config.rows).toHaveLength(1)
-  })
-
-  it('updates generated table data keys on dataset rename while preserving user-edited labels', () => {
-    const state = createState()
-    state.config.visualizations.generatedDefault = createGeneratedTable('old_source')
-    state.config.visualizations.generatedEdited = createGeneratedTable('old_source', 'Custom label')
-
-    const nextState = reducer(state, {
-      type: 'SET_DASHBOARD_DATASET',
-      payload: {
-        datasetKey: 'new_source',
-        oldDatasetKey: 'old_source',
-        dataset: importedDataset
-      }
-    } as any)
-
-    expect(nextState.config.visualizations.generatedDefault.dataKey).toBe('new_source')
-    expect(nextState.config.visualizations.generatedDefault.table.label).toBe('new_source')
-    expect(nextState.config.visualizations.generatedEdited.dataKey).toBe('new_source')
-    expect(nextState.config.visualizations.generatedEdited.table.label).toBe('Custom label')
   })
 
   it('replaces dashboard datasets immutably and marks the new source for preview', () => {
@@ -187,8 +186,7 @@ describe('editor reducer dashboard datasets', () => {
     const nextState = reducer(state, {
       type: 'SET_DASHBOARD_DATASET',
       payload: {
-        datasetKey: 'new_source',
-        oldDatasetKey: 'old_source',
+        datasetKey: 'old_source',
         dataset: {
           data: [{ value: 'new-row' }],
           dataFileName: 'new.csv',
@@ -200,12 +198,11 @@ describe('editor reducer dashboard datasets', () => {
 
     expect(nextState.config.datasets).not.toBe(previousDatasets)
     expect(nextState.config.datasets.secondary).not.toBe(previousSecondary)
-    expect(nextState.config.datasets.old_source).toBeUndefined()
-    expect(nextState.config.datasets.new_source.data).toEqual([{ value: 'new-row' }])
-    expect(nextState.config.datasets.new_source.preview).toBe(true)
+    expect(nextState.config.datasets.old_source.data).toEqual([{ value: 'new-row' }])
+    expect(nextState.config.datasets.old_source.preview).toBe(true)
     expect(nextState.config.datasets.secondary.preview).toBe(false)
-    expect(nextState.config.rows[0].dataKey).toBe('new_source')
-    expect(nextState.config.visualizations.first.dataKey).toBe('new_source')
+    expect(nextState.config.rows[0].dataKey).toBe('old_source')
+    expect(nextState.config.visualizations.first.dataKey).toBe('old_source')
   })
 
   it('removes generated tables and their table-only rows when deleting a dataset', () => {

--- a/packages/core/contexts/editor.reducer.ts
+++ b/packages/core/contexts/editor.reducer.ts
@@ -2,11 +2,7 @@ import EditorActions from './editor.actions'
 import { Visualization } from '@cdc/core/types/Visualization'
 import { devToolsWrapper } from '@cdc/core/helpers/withDevTools'
 import { cloneConfig } from '@cdc/core/helpers/cloneConfig'
-import {
-  addGeneratedTablesForDataset,
-  removeGeneratedTablesForDataset,
-  updateGeneratedTableLabelOnDatasetRename
-} from './helpers/dashboardDatasetTables'
+import { addGeneratedTablesForDataset, removeGeneratedTablesForDataset } from './helpers/dashboardDatasetTables'
 
 export type EditorState = {
   config?: Visualization
@@ -25,29 +21,11 @@ const reducer = (state: EditorState, action: EditorActions): EditorState => {
       return { ...state, config: action.payload }
     }
     case 'SET_DASHBOARD_DATASET': {
-      const { dataset, datasetKey, oldDatasetKey } = action.payload
-      const oldDataset = oldDatasetKey ? state.config?.datasets[oldDatasetKey] : {}
+      const { dataset, datasetKey } = action.payload
       const config = cloneConfig(state.config)
-      const isBrandNewDataset = !oldDatasetKey && !Object.prototype.hasOwnProperty.call(config.datasets || {}, datasetKey)
+      const isBrandNewDataset = !Object.prototype.hasOwnProperty.call(config.datasets || {}, datasetKey)
       const nextDatasets = cloneDatasets(config.datasets, currentDataset => ({ ...currentDataset, preview: false }))
-      if (oldDatasetKey) {
-        const changeDatasets = _config => {
-          _config.rows?.forEach(row => {
-            if (row.dataKey === oldDatasetKey) {
-              row.dataKey = datasetKey
-            }
-          })
-          Object.values(_config.visualizations || {}).forEach((viz: any) => {
-            if (viz.dataKey === oldDatasetKey) {
-              viz.dataKey = datasetKey
-              updateGeneratedTableLabelOnDatasetRename(viz, oldDatasetKey, datasetKey)
-            }
-          })
-        }
-        applyMultiDashboards(config, changeDatasets)
-        delete nextDatasets[oldDatasetKey]
-      }
-      nextDatasets[datasetKey] = { ...oldDataset, ...dataset }
+      nextDatasets[datasetKey] = { ...dataset }
       config.datasets = nextDatasets
       if (isBrandNewDataset) {
         addGeneratedTablesForDataset(config, datasetKey, dataset)

--- a/packages/core/contexts/editor.reducer.ts
+++ b/packages/core/contexts/editor.reducer.ts
@@ -24,8 +24,12 @@ const reducer = (state: EditorState, action: EditorActions): EditorState => {
       const { dataset, datasetKey } = action.payload
       const config = cloneConfig(state.config)
       const isBrandNewDataset = !Object.prototype.hasOwnProperty.call(config.datasets || {}, datasetKey)
+      const existingDataDescription = config.datasets?.[datasetKey]?.dataDescription
       const nextDatasets = cloneDatasets(config.datasets, currentDataset => ({ ...currentDataset, preview: false }))
-      nextDatasets[datasetKey] = { ...dataset }
+      nextDatasets[datasetKey] = {
+        ...dataset,
+        ...(existingDataDescription !== undefined ? { dataDescription: existingDataDescription } : {})
+      }
       config.datasets = nextDatasets
       if (isBrandNewDataset) {
         addGeneratedTablesForDataset(config, datasetKey, dataset)

--- a/packages/core/contexts/helpers/dashboardDatasetTables.ts
+++ b/packages/core/contexts/helpers/dashboardDatasetTables.ts
@@ -1,3 +1,5 @@
+import { getDatasetLabel } from '@cdc/core/helpers/dashboardDatasetLabels'
+
 const DATASET_IMPORT_GENERATED_BY = 'dataset-import'
 const GENERATED_TABLE_KEY_PREFIX = 'dashboard-table'
 const DEFAULT_DATA_DESCRIPTION = { horizontal: false, series: false }
@@ -19,12 +21,6 @@ export const addGeneratedTablesForDataset = (
   }
 
   addGeneratedTableForDataset(config, datasetKey, dataset)
-}
-
-export const updateGeneratedTableLabelOnDatasetRename = (viz: any, oldDatasetKey: string, datasetKey: string) => {
-  if (isGeneratedDatasetImportTable(viz) && viz.table?.label === oldDatasetKey) {
-    viz.table.label = datasetKey
-  }
 }
 
 const addGeneratedTableForDataset = (
@@ -60,7 +56,7 @@ const createGeneratedTableVisualization = (datasetKey: string, dataset: Dashboar
     showVertical: true,
     expanded: false,
     collapsible: true,
-    label: datasetKey
+    label: getDatasetLabel(datasetKey, dataset)
   },
   columns: {},
   dataFormat: {},

--- a/packages/core/helpers/dashboardDatasetLabels.test.ts
+++ b/packages/core/helpers/dashboardDatasetLabels.test.ts
@@ -1,0 +1,31 @@
+import { getDatasetDisplayLabel, getDatasetLabel, getUniqueDatasetKey } from './dashboardDatasetLabels'
+
+describe('dashboard dataset labels', () => {
+  it('falls back to the dataset key for legacy datasets without a label', () => {
+    expect(getDatasetLabel('legacy-key', {})).toBe('legacy-key')
+  })
+
+  it('uses a trimmed authored label', () => {
+    expect(getDatasetLabel('stable-key', { label: '  Weekly cases  ' })).toBe('Weekly cases')
+  })
+
+  it('adds a numeric suffix when a dataset key is already in use', () => {
+    const datasets = {
+      cases: {},
+      'cases-2': {},
+      'cases-3': {}
+    } as any
+
+    expect(getUniqueDatasetKey(' cases ', datasets)).toBe('cases-4')
+  })
+
+  it('disambiguates duplicate display labels without changing their keys', () => {
+    const datasets = {
+      cases: { label: 'Weekly cases' },
+      'cases-2': { label: 'Weekly cases' }
+    } as any
+
+    expect(getDatasetDisplayLabel('cases', datasets)).toBe('Weekly cases (cases)')
+    expect(getDatasetDisplayLabel('cases-2', datasets)).toBe('Weekly cases (cases-2)')
+  })
+})

--- a/packages/core/helpers/dashboardDatasetLabels.ts
+++ b/packages/core/helpers/dashboardDatasetLabels.ts
@@ -1,0 +1,22 @@
+import { DataSet, Datasets } from '@cdc/core/types/DataSet'
+
+export const getDatasetLabel = (datasetKey: string, dataset?: Partial<DataSet>) => dataset?.label?.trim() || datasetKey
+
+export const getDatasetDisplayLabel = (datasetKey: string, datasets: Datasets = {}) => {
+  const label = getDatasetLabel(datasetKey, datasets[datasetKey])
+  const matchingKeys = Object.keys(datasets).filter(key => getDatasetLabel(key, datasets[key]) === label)
+
+  return matchingKeys.length > 1 ? `${label} (${datasetKey})` : label
+}
+
+export const getUniqueDatasetKey = (label: string, datasets: Datasets = {}) => {
+  const baseKey = label.trim()
+  if (!Object.prototype.hasOwnProperty.call(datasets, baseKey)) return baseKey
+
+  let suffix = 2
+  while (Object.prototype.hasOwnProperty.call(datasets, `${baseKey}-${suffix}`)) {
+    suffix += 1
+  }
+
+  return `${baseKey}-${suffix}`
+}

--- a/packages/core/types/DataSet.ts
+++ b/packages/core/types/DataSet.ts
@@ -1,6 +1,7 @@
 import { ConfigureData } from '@cdc/core/types/ConfigureData'
 
 export type DataSet = ConfigureData & {
+  label?: string
   dataFileFormat?: string
   dataFileName?: string
   dataFileSize?: number

--- a/packages/dashboard/CONFIG.md
+++ b/packages/dashboard/CONFIG.md
@@ -34,7 +34,8 @@ Use the example in [README.md](./README.md) for the copy-pasteable minimum confi
 | `locale` | `string` | No | `en-US` after migration/runtime preparation | Locale used by dashboard-level table date and number formatting and copied into child visualizations by migration. | Any valid `Intl` locale is accepted. |
 | `data` | `object[]` | No | `[]` | Legacy inline data used to seed the dashboard when named datasets are not provided. | An empty array is enough for a dashboard that only renders markup or chrome. |
 | `dataUrl` | `string` | No | None | Remote data source for legacy single-dataset dashboards. | When present, the loader fetches data at runtime. |
-| `datasets` | `Record<string, DataSet>` | No | None | Named datasets used by the dashboard and its child visualizations. | Each child viz points at a dataset with `dataKey`. |
+| `datasets` | `Record<string, DataSet>` | No | None | Named datasets used by the dashboard and its child visualizations. | Map keys are stable internal identifiers. Each child viz points at one with `dataKey`; use the optional dataset `label` for an editable user-facing name. |
+| `datasets.*.label` | `string` | No | Dataset map key | User-facing dataset name shown in dashboard editor controls. | Editing a label does not change the dataset key or any `dataKey` references. Existing configs can omit it. |
 | `datasets.*.loadQueryParam` | `string` | No | None | Browser query-string parameter appended to that dataset's `dataUrl` at load time. | Used for dataset URLs that need to be varied by the embedding page's query string. |
 
 Rows, datasets, and child visualizations also use the shared [`ConfigureData`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#configuredata) fields described in the core reference. Named dataset entries use shared [`DataSet`](https://github.com/CDCgov/cdc-open-viz/blob/main/packages/core/CONFIG.md#dataset).

--- a/packages/dashboard/src/components/DashboardConditionModal.test.tsx
+++ b/packages/dashboard/src/components/DashboardConditionModal.test.tsx
@@ -24,6 +24,7 @@ const buildConfig = () =>
     },
     datasets: {
       'condition-data': {
+        label: 'Condition data',
         data: [
           { region: 'North', status: 'visible' },
           { region: 'South', status: 'hidden' }
@@ -212,6 +213,8 @@ describe('DashboardConditionModal', () => {
     fireEvent.change(screen.getByRole('combobox', { name: /Condition Type/i }), {
       target: { value: 'columnHasAnyValue' }
     })
+
+    expect(screen.getByRole('option', { name: 'Condition data' })).toHaveValue('condition-data')
 
     expect(screen.queryByText(/Select the dataset column to inspect for this condition/)).not.toBeInTheDocument()
     expect(screen.queryByText(/Choose one or more matching values from the selected column/)).not.toBeInTheDocument()

--- a/packages/dashboard/src/components/DashboardConditionModal.tsx
+++ b/packages/dashboard/src/components/DashboardConditionModal.tsx
@@ -16,6 +16,7 @@ import { getDashboardConditionIds } from '../helpers/dashboardConditions'
 import { DASHBOARD_CONDITION_TYPE_OPTIONS, DashboardConditionTypeOption } from '../helpers/dashboardConditionUi'
 import { dashboardConditionsSupportedForRow } from '../helpers/dashboardFilterTargets'
 import { DashboardCondition } from '../types/ConfigRow'
+import { getDatasetDisplayLabel } from '@cdc/core/helpers/dashboardDatasetLabels'
 
 import './dashboard-condition-modal.css'
 
@@ -257,7 +258,10 @@ export const DashboardConditionModal: React.FC<DashboardConditionModalProps> = (
                   label='Condition Dataset'
                   options={[
                     { value: '', label: '- Select Option -' },
-                    ...availableDatasets.map(key => ({ value: key, label: key }))
+                    ...availableDatasets.map(key => ({
+                      value: key,
+                      label: getDatasetDisplayLabel(key, config.datasets)
+                    }))
                   ]}
                   value={formState.datasetKey}
                   onChange={event => {

--- a/packages/dashboard/src/components/DataDesignerModal.tsx
+++ b/packages/dashboard/src/components/DataDesignerModal.tsx
@@ -12,6 +12,7 @@ import DataTransform from '@cdc/core/helpers/DataTransform'
 import { ConfigureData } from '@cdc/core/types/ConfigureData'
 import Icon from '@cdc/core/components/ui/Icon'
 import { getColumnWidgetKeys } from '../helpers/dashboardColumnWidgets'
+import { getDatasetDisplayLabel } from '@cdc/core/helpers/dashboardDatasetLabels'
 
 type DataDesignerModalProps = {
   rowIndex: number
@@ -143,7 +144,7 @@ export const DataDesignerModal: React.FC<DataDesignerModalProps> = ({ vizKey, ro
             {config.datasets &&
               Object.keys(config.datasets).map(datasetKey => (
                 <option key={datasetKey} value={datasetKey}>
-                  {datasetKey}
+                  {getDatasetDisplayLabel(datasetKey, config.datasets)}
                 </option>
               ))}
           </select>

--- a/packages/dashboard/src/components/VisualizationRow.tsx
+++ b/packages/dashboard/src/components/VisualizationRow.tsx
@@ -27,6 +27,7 @@ import { ChartConfig } from '@cdc/chart/src/types/ChartConfig'
 import { publishAnalyticsEvent } from '@cdc/core/helpers/metrics/helpers'
 import { getVizTitle, getVizSubType } from '@cdc/core/helpers/metrics/utils'
 import { hasVisibleDashboardFiltersForIndexes } from '../helpers/filterVisibility'
+import { getDatasetDisplayLabel } from '@cdc/core/helpers/dashboardDatasetLabels'
 
 type VisualizationWrapperProps = {
   allExpanded: boolean
@@ -404,7 +405,7 @@ const VisualizationRow: React.FC<VizRowProps> = ({
                 })
               }}
             >
-              {dataKey} (Go to Table)
+              {getDatasetDisplayLabel(dataKey, config.datasets)} (Go to Table)
             </a>
           )
 

--- a/packages/editor/src/_stories/Editor.stories.tsx
+++ b/packages/editor/src/_stories/Editor.stories.tsx
@@ -164,6 +164,29 @@ export const DownloadDashboardDatasetCSV: Story = {
   }
 }
 
+export const EditDashboardDatasetLabel: Story = {
+  args: { config: {} },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const user = userEvent.setup()
+
+    await loadConfigFromTextArea(canvasElement, DashboardConfig)
+    await user.click(canvas.getByText('2. Import Data'))
+    await expect(canvas.findByText('Data Sources')).resolves.toBeTruthy()
+
+    await user.click(await canvas.findByRole('button', { name: 'Edit' }))
+    const nameInput = await canvas.findByLabelText('Enter Dataset Name')
+    await expect(nameInput).toHaveValue('dashboard_example_map.csv')
+
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Dashboard map data')
+    await user.click(canvas.getByRole('button', { name: 'Save' }))
+
+    await expect(canvas.findByText('Dashboard map data')).resolves.toBeTruthy()
+    await expect(canvas.findByText('Location')).resolves.toBeTruthy()
+  }
+}
+
 export const DownloadSingleVizCSV: Story = {
   args: { config: {} },
   play: async ({ canvasElement }) => {
@@ -217,9 +240,20 @@ export const LoadFromApiUrlPreview: Story = {
       { state: 'Alaska', value: '37' },
       { state: 'Arizona', value: '55' }
     ]
+    const replacementData = [
+      { state: 'California', value: '99' },
+      { state: 'Colorado', value: '88' }
+    ]
     const mockBlob = new Blob([JSON.stringify(mockData)], { type: 'application/json; charset=utf-8' })
+    const replacementBlob = new Blob([JSON.stringify(replacementData)], {
+      type: 'application/json; charset=utf-8'
+    })
     const originalFetch = window.fetch
-    window.fetch = () => Promise.resolve({ ok: true, blob: () => Promise.resolve(mockBlob) } as Response)
+    window.fetch = input =>
+      Promise.resolve({
+        ok: true,
+        blob: () => Promise.resolve(String(input).includes('replacement.json') ? replacementBlob : mockBlob)
+      } as Response)
 
     try {
       // Select Dashboard so the dataset name becomes meaningful and the
@@ -258,6 +292,21 @@ export const LoadFromApiUrlPreview: Story = {
       await expect(canvas.findByText('Data Sources')).resolves.toBeTruthy()
       await expect(canvas.findByText('Data Preview')).resolves.toBeTruthy()
       await expect(canvas.findByText('Alabama')).resolves.toBeTruthy()
+
+      // Replacing a URL-backed dataset keeps its stable key but fully replaces
+      // source-derived fields, so stale formattedData cannot win in Configure.
+      await user.click(await canvas.findByRole('button', { name: 'Edit' }))
+      const editUrlInput = await canvas.findByLabelText('Load data from external URL')
+      await user.clear(editUrlInput)
+      await user.type(editUrlInput, 'https://example.gov/api/replacement.json')
+      await user.click(canvas.getByRole('button', { name: 'Save & Load' }))
+
+      await expect(canvas.findByText('California')).resolves.toBeTruthy()
+      expect(canvas.queryByText('Alabama')).not.toBeInTheDocument()
+
+      await user.click(canvas.getByText('3. Configure'))
+      await user.click(await canvas.findByText('Dashboard Preview'))
+      await expect(canvas.findByText('California')).resolves.toBeTruthy()
     } finally {
       window.fetch = originalFetch
     }

--- a/packages/editor/src/_stories/Editor.stories.tsx
+++ b/packages/editor/src/_stories/Editor.stories.tsx
@@ -24,6 +24,12 @@ const DATA_TABLE_EDITOR_CONFIG = {
   filters: []
 }
 
+const FILE_BACKED_CHART_CONFIG = {
+  ...ChartEditorConfig,
+  dataFileName: 'prototype.csv',
+  dataFileSourceType: 'file'
+}
+
 const loadConfigFromTextArea = async (canvasElement, config) => {
   const user = userEvent.setup()
   const textArea = canvasElement.querySelector('#pasteConfig') as HTMLTextAreaElement
@@ -299,6 +305,70 @@ export const LoadStandaloneFromApiUrl: Story = {
       await expect(canvas.findByRole('button', { name: 'Save & Load' })).resolves.toBeEnabled()
     } finally {
       window.fetch = originalFetch
+    }
+  }
+}
+
+export const ReplaceStandaloneFileWithUrl: Story = {
+  args: { config: FILE_BACKED_CHART_CONFIG },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const user = userEvent.setup()
+    const remoteData = [
+      {
+        Year: '2030',
+        Category: 'Remote data',
+        'White, non-Hispanic': '4.2'
+      }
+    ]
+    const mockBlob = new Blob([JSON.stringify(remoteData)], { type: 'application/json' })
+    const originalFetch = window.fetch
+    const originalConsoleError = console.error
+    console.error = () => {}
+    window.fetch = input => {
+      if (String(input).includes('fails.json')) {
+        return Promise.resolve({ ok: false, status: 500 } as Response)
+      }
+      return Promise.resolve({ ok: true, blob: () => Promise.resolve(mockBlob) } as Response)
+    }
+
+    try {
+      await user.click(canvas.getByText('2. Import Data'))
+      await expect(canvas.findByText('prototype.csv')).resolves.toBeTruthy()
+
+      const replaceWithUrlButton = await canvas.findByRole('button', { name: 'or replace with URL' })
+      await user.click(replaceWithUrlButton)
+
+      expect(canvas.queryByLabelText('Enter Dataset Name')).not.toBeInTheDocument()
+      await expect(canvas.findByLabelText(/Always load from URL/)).resolves.toBeChecked()
+
+      const draftUrlInput = await canvas.findByLabelText('Load data from external URL')
+      await user.type(draftUrlInput, 'https://example.gov/api/draft.json')
+      await user.click(await canvas.findByRole('button', { name: 'Cancel' }))
+
+      expect(canvas.queryByLabelText('Load data from external URL')).not.toBeInTheDocument()
+      await expect(canvas.findByText('prototype.csv')).resolves.toBeTruthy()
+
+      await user.click(await canvas.findByRole('button', { name: 'or replace with URL' }))
+      const urlInput = await canvas.findByLabelText('Load data from external URL')
+      await user.type(urlInput, 'https://example.gov/api/fails.json')
+      await user.click(await canvas.findByRole('button', { name: 'Save & Load' }))
+
+      await expect(canvas.findByText('Error fetching or parsing data file.')).resolves.toBeTruthy()
+      await expect(canvas.findByText('prototype.csv')).resolves.toBeTruthy()
+
+      await user.clear(urlInput)
+      await user.type(urlInput, 'https://example.gov/api/chart.json')
+      await user.click(await canvas.findByRole('button', { name: 'Save & Load' }))
+
+      await expect(canvas.findByText('2030')).resolves.toBeTruthy()
+      await expect(canvas.findByLabelText('Load data from external URL')).resolves.toHaveValue(
+        'https://example.gov/api/chart.json'
+      )
+      expect(canvas.queryByRole('button', { name: 'or replace with URL' })).not.toBeInTheDocument()
+    } finally {
+      window.fetch = originalFetch
+      console.error = originalConsoleError
     }
   }
 }

--- a/packages/editor/src/_stories/Editor.stories.tsx
+++ b/packages/editor/src/_stories/Editor.stories.tsx
@@ -187,6 +187,86 @@ export const EditDashboardDatasetLabel: Story = {
   }
 }
 
+export const ReplaceDashboardFileDataset: Story = {
+  args: { config: {} },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const user = userEvent.setup()
+    const remoteData = [{ Location: 'Remote State', Rate: '4321' }]
+    const remoteBlob = new Blob([JSON.stringify(remoteData)], { type: 'application/json' })
+    const originalFetch = window.fetch
+    const originalConsoleError = console.error
+    console.error = () => {}
+    window.fetch = input => {
+      if (String(input).includes('fails.json')) {
+        return Promise.resolve({ ok: false, status: 500 } as Response)
+      }
+      return Promise.resolve({
+        ok: true,
+        blob: () => Promise.resolve(remoteBlob),
+        json: () => Promise.resolve(remoteData)
+      } as Response)
+    }
+
+    try {
+      await loadConfigFromTextArea(canvasElement, DashboardConfig)
+      await user.click(canvas.getByText('2. Import Data'))
+      await expect(canvas.findByText('Data Sources')).resolves.toBeTruthy()
+
+      await user.click(await canvas.findByRole('button', { name: 'Edit' }))
+      const replacementFile = new File(['Location,Rate\nReplacement State,9876'], 'replacement.csv', {
+        type: 'text/csv'
+      })
+      await user.upload(await canvas.findByLabelText('Replace dataset file'), replacementFile)
+
+      await expect(canvas.findByText('replacement.csv')).resolves.toBeTruthy()
+      await expect(canvas.findByText('Alabama')).resolves.toBeTruthy()
+      expect(canvas.queryByText('Replacement State')).not.toBeInTheDocument()
+      await user.click(await canvas.findByRole('button', { name: 'Save & Load' }))
+
+      await expect(canvas.findByText('Replacement State')).resolves.toBeTruthy()
+      expect(canvas.queryByText('Alabama')).not.toBeInTheDocument()
+
+      await user.click(await canvas.findByRole('button', { name: 'Edit' }))
+      await expect(canvas.findByText('Current file: replacement.csv')).resolves.toBeTruthy()
+      await user.click(await canvas.findByRole('button', { name: 'or replace with URL' }))
+      await expect(canvas.findByLabelText(/Always load from URL/)).resolves.toBeChecked()
+
+      const draftUrlInput = await canvas.findByLabelText('Load data from external URL')
+      await user.type(draftUrlInput, 'https://example.gov/api/draft.json')
+      await user.click(await canvas.findByRole('button', { name: 'Cancel' }))
+
+      expect(canvas.queryByLabelText('Load data from external URL')).not.toBeInTheDocument()
+      await expect(canvas.findByText('Current file: replacement.csv')).resolves.toBeTruthy()
+      await expect(canvas.findByText('Replacement State')).resolves.toBeTruthy()
+
+      await user.click(await canvas.findByRole('button', { name: 'or replace with URL' }))
+      const urlInput = await canvas.findByLabelText('Load data from external URL')
+      await user.type(urlInput, 'https://example.gov/api/fails.json')
+      await user.click(await canvas.findByRole('button', { name: 'Save & Load' }))
+
+      await expect(canvas.findByText('Error fetching or parsing data file.')).resolves.toBeTruthy()
+      await expect(canvas.findByText('Replacement State')).resolves.toBeTruthy()
+
+      await user.clear(urlInput)
+      await user.type(urlInput, 'https://example.gov/api/dashboard.json')
+      await user.click(await canvas.findByRole('button', { name: 'Save & Load' }))
+
+      await expect(canvas.findByText('Remote State')).resolves.toBeTruthy()
+      expect(canvas.queryByText('Replacement State')).not.toBeInTheDocument()
+
+      await user.click(await canvas.findByRole('button', { name: 'Edit' }))
+      await expect(canvas.findByLabelText('Load data from external URL')).resolves.toHaveValue(
+        'https://example.gov/api/dashboard.json'
+      )
+      await expect(canvas.findByLabelText(/Always load from URL/)).resolves.toBeChecked()
+    } finally {
+      window.fetch = originalFetch
+      console.error = originalConsoleError
+    }
+  }
+}
+
 export const DownloadSingleVizCSV: Story = {
   args: { config: {} },
   play: async ({ canvasElement }) => {

--- a/packages/editor/src/_stories/Editor.stories.tsx
+++ b/packages/editor/src/_stories/Editor.stories.tsx
@@ -227,12 +227,16 @@ export const LoadFromApiUrlPreview: Story = {
 
       // Both fields are required before the button is enabled
       const nameInput = await canvas.findByLabelText('Enter Dataset Name')
-      await user.type(nameInput, 'api-data')
-
       const urlInput = await canvas.findByLabelText('Load data from external URL')
       await user.type(urlInput, 'https://example.gov/api/data.json')
 
-      await user.click(await canvas.findByRole('button', { name: 'Save & Load' }))
+      const loadButton = await canvas.findByRole('button', { name: 'Save & Load' })
+      await expect(loadButton).toBeDisabled()
+
+      await user.type(nameInput, 'api-data')
+      await expect(loadButton).toBeEnabled()
+
+      await user.click(loadButton)
 
       // After a successful dashboard dataset load the Data Sources table appears
       // and the preview panel should auto-populate (dataset is created with preview: true)
@@ -242,15 +246,57 @@ export const LoadFromApiUrlPreview: Story = {
       await expect(canvas.findByText('Alabama')).resolves.toBeTruthy()
 
       // Navigate away to tab 3 then back to tab 2 — the dataset must survive the round-trip
-      await new Promise(r => setTimeout(r, 1500))
       await user.click(canvas.getByText('3. Configure'))
-      await new Promise(r => setTimeout(r, 500))
       await user.click(canvas.getByText('2. Import Data'))
-      await new Promise(r => setTimeout(r, 500))
 
       await expect(canvas.findByText('Data Sources')).resolves.toBeTruthy()
       await expect(canvas.findByText('Data Preview')).resolves.toBeTruthy()
       await expect(canvas.findByText('Alabama')).resolves.toBeTruthy()
+    } finally {
+      window.fetch = originalFetch
+    }
+  }
+}
+
+export const LoadStandaloneFromApiUrl: Story = {
+  args: { config: {} },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const user = userEvent.setup()
+    const mockData = [
+      { category: 'Alpha', value: '42' },
+      { category: 'Beta', value: '37' }
+    ]
+    const mockBlob = new Blob([JSON.stringify(mockData)], { type: 'application/json' })
+    const originalFetch = window.fetch
+    window.fetch = () => Promise.resolve({ ok: true, blob: () => Promise.resolve(mockBlob) } as Response)
+
+    try {
+      await user.click(await canvas.findByRole('button', { name: 'Bar' }))
+      await user.click(await canvas.findByText('Load from URL'))
+
+      expect(canvas.queryByLabelText('Enter Dataset Name')).not.toBeInTheDocument()
+
+      const urlInput = await canvas.findByLabelText('Load data from external URL')
+      const loadButton = await canvas.findByRole('button', { name: 'Save & Load' })
+      await expect(loadButton).toBeDisabled()
+
+      await user.type(urlInput, 'https://example.gov/api/chart.json')
+      await expect(loadButton).toBeEnabled()
+      await user.click(loadButton)
+
+      await expect(canvas.findByText('Data Preview')).resolves.toBeTruthy()
+      await expect(canvas.findByText('Alpha')).resolves.toBeTruthy()
+
+      // Force DataImport to unmount and remount, matching an author leaving and returning to the tab.
+      await user.click(canvas.getByText('1. Choose Visualization Type'))
+      await user.click(canvas.getByText('2. Import Data'))
+
+      expect(canvas.queryByLabelText('Enter Dataset Name')).not.toBeInTheDocument()
+      await expect(canvas.findByLabelText('Load data from external URL')).resolves.toHaveValue(
+        'https://example.gov/api/chart.json'
+      )
+      await expect(canvas.findByRole('button', { name: 'Save & Load' })).resolves.toBeEnabled()
     } finally {
       window.fetch = originalFetch
     }

--- a/packages/editor/src/components/DataImport/components/DataImport.tsx
+++ b/packages/editor/src/components/DataImport/components/DataImport.tsx
@@ -66,11 +66,14 @@ const DataImport = () => {
   const [addingDataset, setAddingDataset] = useState(config.type === 'dashboard' || !config.data)
   const [editingDataset, _setEditingDataset] = useState<string>(undefined)
   const [newDatasetName, setNewDatasetName] = useState<string>(undefined)
+  const [replacementFile, setReplacementFile] = useState<File>(undefined)
   const [pastedConfig, setPastedConfig] = useState<string>(undefined)
   const [replacingFileWithUrl, setReplacingFileWithUrl] = useState(false)
   const setEditingDataset = (datasetKey: string) => {
     _setEditingDataset(datasetKey)
     setNewDatasetName(datasetKey ? getDatasetLabel(datasetKey, config.datasets?.[datasetKey]) : undefined)
+    setReplacementFile(undefined)
+    setReplacingFileWithUrl(false)
   }
 
   const loadExternal = async () => {
@@ -131,14 +134,14 @@ const DataImport = () => {
     return responseBlob
   }
 
-  const onDrop = ([uploadedFile]) => loadData(uploadedFile, editingDataset, editingDataset)
+  const onDrop = ([uploadedFile]) => loadData(uploadedFile, uploadedFile?.name, editingDataset)
 
   /**
    * Handle loading data
    */
   const loadData = async (fileBlob = null, fileName, editingDatasetKey: string) => {
     let fileData = fileBlob
-    let fileSource = fileData?.path ?? fileName ?? externalURL
+    let fileSource = fileName ?? fileData?.path ?? externalURL
     if (fileSource && typeof fileSource === 'string') fileSource = fileSource.trim()
     const fileSourceType = fileBlob ? 'file' : 'url'
 
@@ -221,6 +224,8 @@ const DataImport = () => {
           }
           if (setDataURL) {
             newConfig.dataUrl = fileSource
+          } else {
+            delete newConfig.dataUrl
           }
           setConfig(newConfig)
         }
@@ -310,33 +315,22 @@ const DataImport = () => {
     }
   }
 
-  const changeKeepURL = (value, editingDatasetKey) => {
-    if (editingDatasetKey) {
-      let newDatasets = { ...config.datasets }
-      if (value === false) {
-        delete newDatasets[editingDatasetKey].dataUrl
-      } else {
-        newDatasets[editingDatasetKey].dataUrl = newDatasets[editingDatasetKey].dataFileName
-      }
-      setConfig({ ...config, datasets: newDatasets })
-    } else if (config.type !== 'dashboard') {
-      let newConfig = { ...config }
-      if (value === false) {
-        delete newConfig.dataUrl
-      } else {
-        newConfig.dataUrl = newConfig.dataFileName
-      }
-      setConfig(newConfig)
-    }
-    setKeepURL(value)
-  }
-
   const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop })
   const {
     getRootProps: getRootProps2,
     getInputProps: getInputProps2,
     isDragActive: isDragActive2
   } = useDropzone({ onDrop })
+  const {
+    getRootProps: getReplacementRootProps,
+    getInputProps: getReplacementInputProps,
+    isDragActive: isReplacementDragActive
+  } = useDropzone({
+    onDrop: ([uploadedFile]) => {
+      setReplacementFile(uploadedFile)
+      setErrors([])
+    }
+  })
 
   const requiresDatasetName = config.type === 'dashboard'
   const urlLoadDisabled = !externalURL || (requiresDatasetName && !newDatasetName?.trim())
@@ -356,6 +350,14 @@ const DataImport = () => {
     setEditingDataset(undefined)
   }
 
+  const saveFileDatasetChanges = () => {
+    if (replacementFile) {
+      loadData(replacementFile, replacementFile.name, editingDataset)
+      return
+    }
+    saveFileDatasetLabel()
+  }
+
   const renderFileDatasetLabelEditor = () => (
     <>
       <label htmlFor='dataset-name' className='col-12 mt-2'>
@@ -370,6 +372,47 @@ const DataImport = () => {
           onChange={e => setNewDatasetName(e.target.value)}
         />
       </label>
+      <div className='heading-3 mt-3'>Update Dataset</div>
+      <p>Current file: {config.datasets[editingDataset].dataFileName}</p>
+      <div className='data-source-options'>
+        <div
+          className={
+            isReplacementDragActive
+              ? 'drag-active cdcdataviz-file-selector loaded-file'
+              : 'cdcdataviz-file-selector loaded-file'
+          }
+          {...getReplacementRootProps()}
+        >
+          <input {...getReplacementInputProps({ 'aria-label': 'Replace dataset file' })} />
+          {isReplacementDragActive ? (
+            <p>Drop file here</p>
+          ) : (
+            <p>
+              <FileUploadIcon /> <span>{replacementFile ? replacementFile.name : 'Replace file'}</span>
+            </p>
+          )}
+        </div>
+        <div className='link link-replace'>
+          <p>
+            <span
+              role='button'
+              tabIndex={0}
+              onClick={startReplacingFileWithUrl}
+              onKeyDown={event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  startReplacingFileWithUrl()
+                }
+              }}
+            >
+              or replace with URL
+            </span>
+          </p>
+        </div>
+      </div>
+      <p className='footnote'>
+        Supported file types: {Object.keys(supportedDataTypes).join(', ')}. Maximum file size {maxFileSize} MB.
+      </p>
       <div className='d-flex justify-content-end gap-2 mt-2 mb-3'>
         <Button variant='secondary' className='btn px-4' type='button' onClick={() => setEditingDataset(undefined)}>
           Cancel
@@ -378,9 +421,9 @@ const DataImport = () => {
           className='btn btn-primary px-4'
           type='button'
           disabled={!newDatasetName?.trim()}
-          onClick={saveFileDatasetLabel}
+          onClick={saveFileDatasetChanges}
         >
-          Save
+          {replacementFile ? 'Save & Load' : 'Save'}
         </Button>
       </div>
     </>
@@ -431,13 +474,8 @@ const DataImport = () => {
           />
         </label>
         <label htmlFor='keep-url' className='mt-1 d-flex keep-url'>
-          <input
-            type='checkbox'
-            id='keep-url'
-            checked={keepURL}
-            onChange={() => changeKeepURL(!keepURL, editingDataset)}
-          />{' '}
-          Always load from URL (normally will only pull once)
+          <input type='checkbox' id='keep-url' checked={keepURL} onChange={() => setKeepURL(!keepURL)} /> Always load
+          from URL (normally will only pull once)
         </label>
         <div className='d-flex justify-content-end gap-2 mt-2 mb-3'>
           {onCancel && (
@@ -474,6 +512,7 @@ const DataImport = () => {
     setExternalURL('')
     setKeepURL(true)
     setErrors([])
+    setReplacementFile(undefined)
     setReplacingFileWithUrl(true)
   }
 
@@ -1051,6 +1090,15 @@ const DataImport = () => {
               config.datasets[editingDataset].dataFileSourceType === 'url' ? (
                 <TabPane title='Load from URL' icon={<LinkIcon className='inline-icon' />}>
                   {loadDataFromUrl()}
+                </TabPane>
+              ) : replacingFileWithUrl ? (
+                <TabPane title='Load from URL' icon={<LinkIcon className='inline-icon' />}>
+                  {loadDataFromUrl(() => {
+                    setExternalURL('')
+                    setKeepURL(false)
+                    setErrors([])
+                    setReplacingFileWithUrl(false)
+                  })}
                 </TabPane>
               ) : (
                 renderFileDatasetLabelEditor()

--- a/packages/editor/src/components/DataImport/components/DataImport.tsx
+++ b/packages/editor/src/components/DataImport/components/DataImport.tsx
@@ -66,6 +66,7 @@ const DataImport = () => {
   const [editingDataset, _setEditingDataset] = useState<string>(undefined)
   const [newDatasetName, setNewDatasetName] = useState<string>(undefined)
   const [pastedConfig, setPastedConfig] = useState<string>(undefined)
+  const [replacingFileWithUrl, setReplacingFileWithUrl] = useState(false)
   const setEditingDataset = (datasetKey: string) => {
     _setEditingDataset(datasetKey)
     setNewDatasetName(datasetKey)
@@ -264,6 +265,7 @@ const DataImport = () => {
         if (editingDataset) {
           setEditingDataset(undefined)
         }
+        setReplacingFileWithUrl(false)
         setAddingDataset(false)
       } catch (err) {
         setErrors(err)
@@ -335,7 +337,21 @@ const DataImport = () => {
   const requiresDatasetName = config.type === 'dashboard'
   const urlLoadDisabled = !externalURL || (requiresDatasetName && !newDatasetName)
 
-  const loadDataFromUrl = () => {
+  const renderErrors = () =>
+    errors &&
+    (Array.isArray(errors)
+      ? errors.map((message, index) => (
+          <div className='error-box slim mt-2' key={`error-${message}`}>
+            <span>{message}</span>{' '}
+            <CloseIcon
+              className='inline-icon dismiss-error'
+              onClick={() => setErrors(errors.filter((val, i) => i !== index))}
+            />
+          </div>
+        ))
+      : errors.message)
+
+  const loadDataFromUrl = (onCancel?: () => void) => {
     return (
       <>
         {requiresDatasetName && (
@@ -374,7 +390,12 @@ const DataImport = () => {
           />{' '}
           Always load from URL (normally will only pull once)
         </label>
-        <div className='d-flex justify-content-end mt-2 mb-3'>
+        <div className='d-flex justify-content-end gap-2 mt-2 mb-3'>
+          {onCancel && (
+            <Button variant='secondary' className='btn px-4' type='button' onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
           <Button
             className='btn btn-primary px-4'
             type='submit'
@@ -400,6 +421,13 @@ const DataImport = () => {
     }
   }
 
+  const startReplacingFileWithUrl = () => {
+    setExternalURL('')
+    setKeepURL(true)
+    setErrors([])
+    setReplacingFileWithUrl(true)
+  }
+
   const resetButton = () => {
     return (
       //todo convert to modal
@@ -418,12 +446,31 @@ const DataImport = () => {
         </Button>
         {/* DEV-851 link to replace file should pop file dialog */}
         {config.dataFileSourceType === 'file' && (
-          <div className='link link-replace' {...getRootProps2()}>
-            <input {...getInputProps2()} />
-            <p>
-              <span>or replace file</span>
-            </p>
-          </div>
+          <>
+            <div className='link link-replace' {...getRootProps2()}>
+              <input {...getInputProps2()} />
+              <p>
+                <span>or replace file</span>
+              </p>
+            </div>
+            <div className='link link-replace'>
+              <p>
+                <span
+                  role='button'
+                  tabIndex={0}
+                  onClick={startReplacingFileWithUrl}
+                  onKeyDown={event => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      startReplacingFileWithUrl()
+                    }
+                  }}
+                >
+                  or replace with URL
+                </span>
+              </p>
+            </div>
+          </>
         )}
       </>
     )
@@ -775,34 +822,48 @@ const DataImport = () => {
                 <div className='heading-3'>Data Source</div>
                 <div className='file-loaded-area'>
                   {(config.dataFileSourceType === 'file' || !config.dataFileSourceType) && (
-                    <div className='data-source-options'>
-                      <div
-                        className={
-                          isDragActive2
-                            ? 'drag-active cdcdataviz-file-selector loaded-file'
-                            : 'cdcdataviz-file-selector loaded-file'
-                        }
-                        {...getRootProps2()}
-                      >
-                        <input {...getInputProps2()} />
-                        {isDragActive2 ? (
-                          <p>Drop file here</p>
-                        ) : (
-                          <p>
-                            <FileUploadIcon /> <span>{config.dataFileName ?? 'Replace data file'}</span>
-                          </p>
+                    <>
+                      <div className='data-source-options'>
+                        <div
+                          className={
+                            isDragActive2
+                              ? 'drag-active cdcdataviz-file-selector loaded-file'
+                              : 'cdcdataviz-file-selector loaded-file'
+                          }
+                          {...getRootProps2()}
+                        >
+                          <input {...getInputProps2()} />
+                          {isDragActive2 ? (
+                            <p>Drop file here</p>
+                          ) : (
+                            <p>
+                              <FileUploadIcon /> <span>{config.dataFileName ?? 'Replace data file'}</span>
+                            </p>
+                          )}
+                        </div>
+                        <div>{resetButton()}</div>
+                        {config.data?.length > 0 && (
+                          <button
+                            className='btn btn-link p-1'
+                            onClick={() => downloadCSV(config.data, config.dataFileName || 'data')}
+                          >
+                            Download CSV
+                          </button>
                         )}
                       </div>
-                      <div>{resetButton()}</div>
-                      {config.data?.length > 0 && (
-                        <button
-                          className='btn btn-link p-1'
-                          onClick={() => downloadCSV(config.data, config.dataFileName || 'data')}
-                        >
-                          Download CSV
-                        </button>
+                      {replacingFileWithUrl && (
+                        <div className='replace-with-url'>
+                          <div className='heading-3'>Replace with URL</div>
+                          {loadDataFromUrl(() => {
+                            setExternalURL(config.dataUrl || '')
+                            setKeepURL(!!config.dataUrl)
+                            setErrors([])
+                            setReplacingFileWithUrl(false)
+                          })}
+                          {renderErrors()}
+                        </div>
                       )}
-                    </div>
+                    </>
                   )}
 
                   {config.dataFileSourceType === 'url' && (
@@ -966,18 +1027,7 @@ const DataImport = () => {
                 </TabPane>
               </Tabs>
             )}
-            {errors &&
-              (Array.isArray(errors)
-                ? errors.map((message, index) => (
-                    <div className='error-box slim mt-2' key={`error-${message}`}>
-                      <span>{message}</span>{' '}
-                      <CloseIcon
-                        className='inline-icon dismiss-error'
-                        onClick={() => setErrors(errors.filter((val, i) => i !== index))}
-                      />
-                    </div>
-                  ))
-                : errors.message)}
+            {renderErrors()}
 
             {/* prettier-ignore */}
             <SampleDataContext.Provider value={{ loadData, editingDataset, config }}>

--- a/packages/editor/src/components/DataImport/components/DataImport.tsx
+++ b/packages/editor/src/components/DataImport/components/DataImport.tsx
@@ -44,6 +44,7 @@ import {
   updateVegaData
 } from '@cdc/core/helpers/vegaConfig'
 import { extractDataAndMetadata } from '@cdc/core/helpers/extractDataAndMetadata'
+import { getDatasetDisplayLabel, getDatasetLabel, getUniqueDatasetKey } from '@cdc/core/helpers/dashboardDatasetLabels'
 
 const DataImport = () => {
   const { config, errors, tempConfig, sharepath } = useContext(ConfigContext)
@@ -69,7 +70,7 @@ const DataImport = () => {
   const [replacingFileWithUrl, setReplacingFileWithUrl] = useState(false)
   const setEditingDataset = (datasetKey: string) => {
     _setEditingDataset(datasetKey)
-    setNewDatasetName(datasetKey)
+    setNewDatasetName(datasetKey ? getDatasetLabel(datasetKey, config.datasets?.[datasetKey]) : undefined)
   }
 
   const loadExternal = async () => {
@@ -176,7 +177,9 @@ const DataImport = () => {
         const setDataURL = keepURL && fileSourceType === 'url'
         if (config.type === 'dashboard') {
           const dataFileFormat = mimeType.split('/')[1].toUpperCase()
+          const datasetLabel = (newDatasetName || fileSource).trim()
           const dataset = {
+            label: datasetLabel,
             data: newData,
             dataMetadata,
             dataFileSize: fileSize,
@@ -193,11 +196,11 @@ const DataImport = () => {
           const conf = useTempConfig ? { ...config, ...tempConfig } : config
           setConfig(conf)
 
-          const oldDatasetKey = newDatasetName !== editingDatasetKey ? editingDatasetKey : undefined
+          const datasetKey = editingDatasetKey || getUniqueDatasetKey(datasetLabel, config.datasets)
 
           dispatch({
             type: 'SET_DASHBOARD_DATASET',
-            payload: { datasetKey: newDatasetName || fileSource, dataset, oldDatasetKey }
+            payload: { datasetKey, dataset }
           })
         } else {
           const configWithAutoDetectedDateFormat = applyAutoDetectedDateParseFormat(
@@ -265,6 +268,7 @@ const DataImport = () => {
         if (editingDataset) {
           setEditingDataset(undefined)
         }
+        setNewDatasetName(undefined)
         setReplacingFileWithUrl(false)
         setAddingDataset(false)
       } catch (err) {
@@ -335,7 +339,52 @@ const DataImport = () => {
   } = useDropzone({ onDrop })
 
   const requiresDatasetName = config.type === 'dashboard'
-  const urlLoadDisabled = !externalURL || (requiresDatasetName && !newDatasetName)
+  const urlLoadDisabled = !externalURL || (requiresDatasetName && !newDatasetName?.trim())
+
+  const saveFileDatasetLabel = () => {
+    if (!editingDataset || !newDatasetName?.trim()) return
+    setConfig({
+      ...config,
+      datasets: {
+        ...config.datasets,
+        [editingDataset]: {
+          ...config.datasets[editingDataset],
+          label: newDatasetName.trim()
+        }
+      }
+    })
+    setEditingDataset(undefined)
+  }
+
+  const renderFileDatasetLabelEditor = () => (
+    <>
+      <label htmlFor='dataset-name' className='col-12 mt-2'>
+        <span>Dataset Name</span>
+        <input
+          id='dataset-name'
+          placeholder='Enter Dataset Name'
+          type='text'
+          aria-label='Enter Dataset Name'
+          value={newDatasetName || ''}
+          className='form-control'
+          onChange={e => setNewDatasetName(e.target.value)}
+        />
+      </label>
+      <div className='d-flex justify-content-end gap-2 mt-2 mb-3'>
+        <Button variant='secondary' className='btn px-4' type='button' onClick={() => setEditingDataset(undefined)}>
+          Cancel
+        </Button>
+        <Button
+          className='btn btn-primary px-4'
+          type='button'
+          disabled={!newDatasetName?.trim()}
+          onClick={saveFileDatasetLabel}
+        >
+          Save
+        </Button>
+      </div>
+    </>
+  )
 
   const renderErrors = () =>
     errors &&
@@ -753,7 +802,7 @@ const DataImport = () => {
                   datasetKey =>
                     config.datasets[datasetKey].dataFileName && (
                       <tr key={`tr-${datasetKey}`}>
-                        <td>{datasetKey}</td>
+                        <td>{getDatasetDisplayLabel(datasetKey, config.datasets)}</td>
                         <td className='p-1'>{displaySize(config.datasets[datasetKey].dataFileSize)}</td>
                         <td className='p-1'>{config.datasets[datasetKey].dataFileFormat}</td>
                         <td>
@@ -780,27 +829,27 @@ const DataImport = () => {
                           </button>
                         </td>
                         <td>
-                          {config.datasets[datasetKey].dataFileSourceType === 'url' && (
-                            <Button
-                              variant='link'
-                              className='p-1'
-                              onClick={() => {
-                                if (editingDataset === datasetKey) {
-                                  setEditingDataset(undefined)
-                                  setExternalURL('')
-                                  setKeepURL(false)
-                                } else {
-                                  setEditingDataset(datasetKey)
+                          <Button
+                            variant='link'
+                            className='p-1'
+                            onClick={() => {
+                              if (editingDataset === datasetKey) {
+                                setEditingDataset(undefined)
+                                setExternalURL('')
+                                setKeepURL(false)
+                              } else {
+                                setEditingDataset(datasetKey)
+                                if (config.datasets[datasetKey].dataFileSourceType === 'url') {
                                   setExternalURL(
                                     config.datasets[datasetKey].dataUrl || config.datasets[datasetKey].dataFileName
                                   )
                                   setKeepURL(!!config.datasets[datasetKey].dataUrl)
                                 }
-                              }}
-                            >
-                              Edit
-                            </Button>
-                          )}
+                              }
+                            }}
+                          >
+                            Edit
+                          </Button>
                         </td>
                         <td>
                           <Button variant='danger' onClick={() => removeDataset(datasetKey)}>
@@ -995,11 +1044,17 @@ const DataImport = () => {
 
         {(editingDataset || addingDataset) && ( // dataFileSourceType needs to be checked here since earlier versions did not track this state
           <div className='load-data-area'>
-            <div className='heading-3'>{editingDataset ? `Editing ${editingDataset}` : 'Add Dataset'}</div>
+            <div className='heading-3'>
+              {editingDataset ? `Editing ${getDatasetDisplayLabel(editingDataset, config.datasets)}` : 'Add Dataset'}
+            </div>
             {editingDataset ? (
-              <TabPane title='Load from URL' icon={<LinkIcon className='inline-icon' />}>
-                {loadDataFromUrl()}
-              </TabPane>
+              config.datasets[editingDataset].dataFileSourceType === 'url' ? (
+                <TabPane title='Load from URL' icon={<LinkIcon className='inline-icon' />}>
+                  {loadDataFromUrl()}
+                </TabPane>
+              ) : (
+                renderFileDatasetLabelEditor()
+              )
             ) : (
               <Tabs startingTab={0}>
                 <TabPane title='Upload File' icon={<FileUploadIcon className='inline-icon' />}>

--- a/packages/editor/src/components/DataImport/components/DataImport.tsx
+++ b/packages/editor/src/components/DataImport/components/DataImport.tsx
@@ -64,7 +64,7 @@ const DataImport = () => {
   const [keepURL, setKeepURL] = useState(!!config.dataUrl || !!config.vegaType)
   const [addingDataset, setAddingDataset] = useState(config.type === 'dashboard' || !config.data)
   const [editingDataset, _setEditingDataset] = useState<string>(undefined)
-  const [newDatasetName, setNewDatasetName] = useState<string>(config.vegaType ? 'vega_data' : undefined)
+  const [newDatasetName, setNewDatasetName] = useState<string>(undefined)
   const [pastedConfig, setPastedConfig] = useState<string>(undefined)
   const setEditingDataset = (datasetKey: string) => {
     _setEditingDataset(datasetKey)
@@ -332,21 +332,26 @@ const DataImport = () => {
     isDragActive: isDragActive2
   } = useDropzone({ onDrop })
 
+  const requiresDatasetName = config.type === 'dashboard'
+  const urlLoadDisabled = !externalURL || (requiresDatasetName && !newDatasetName)
+
   const loadDataFromUrl = () => {
     return (
       <>
-        <label htmlFor='dataset-name' className='col-12 mt-2'>
-          <span>Dataset Name</span>
-          <input
-            id='dataset-name'
-            placeholder='Enter Dataset Name'
-            type='text'
-            aria-label='Enter Dataset Name'
-            value={newDatasetName}
-            className='form-control'
-            onChange={e => setNewDatasetName(e.target.value)}
-          />
-        </label>
+        {requiresDatasetName && (
+          <label htmlFor='dataset-name' className='col-12 mt-2'>
+            <span>Dataset Name</span>
+            <input
+              id='dataset-name'
+              placeholder='Enter Dataset Name'
+              type='text'
+              aria-label='Enter Dataset Name'
+              value={newDatasetName}
+              className='form-control'
+              onChange={e => setNewDatasetName(e.target.value)}
+            />
+          </label>
+        )}
         <label htmlFor='external-datas' className='col-12 mt-2'>
           <span>URL </span>
           <textarea
@@ -374,7 +379,7 @@ const DataImport = () => {
             className='btn btn-primary px-4'
             type='submit'
             id='load-data'
-            disabled={!newDatasetName || !externalURL}
+            disabled={urlLoadDisabled}
             onClick={() => loadData(null, externalURL, editingDataset)}
           >
             Save & Load
@@ -904,7 +909,7 @@ const DataImport = () => {
                         className='px-4'
                         type='submit'
                         id='load-data'
-                        disabled={!newDatasetName || !externalURL}
+                        disabled={urlLoadDisabled}
                         onClick={() => loadData(null, externalURL, editingDataset)}
                       >
                         Save & Load

--- a/packages/editor/src/components/DataImport/components/data-import.scss
+++ b/packages/editor/src/components/DataImport/components/data-import.scss
@@ -129,6 +129,7 @@
     .keep-url {
       font-size: 0.8rem;
       color: var(--mediumGray);
+      gap: 0.25rem;
     }
 
     .sample-data-list {

--- a/packages/editor/src/scss/main.scss
+++ b/packages/editor/src/scss/main.scss
@@ -112,6 +112,10 @@
     text-decoration: none;
     cursor: pointer;
     font-size: 14px;
+
+    &:hover span {
+      text-decoration: underline;
+    }
   }
 
   .value-list {


### PR DESCRIPTION
## Summary

Adds features that make updating data sources easier.

For standalone visualizations:
* File-backed visualizations can be converted to URL-backed data.

For dashboards:
* The file backing an existing dataset can be replaced.
* A file-backed dataset can be converted to a URL-backed dataset.

## Testing Steps

Create or open a visualization that uses a file-backed dataset, upgrade it to a URL-backed visualization. This config & data file can be used as an example:

[chart_example1.json](https://github.com/user-attachments/files/31708701/chart_example1.json)
[chart_example1_data_v2.json](https://github.com/user-attachments/files/31708698/chart_example1_data_v2.json)
