### PR TITLE
enhancement: break forecast chart on group

### DIFF
--- a/packages/chart/src/_stories/Chart.Forecast.CILegend.stories.tsx
+++ b/packages/chart/src/_stories/Chart.Forecast.CILegend.stories.tsx
@@ -1,0 +1,217 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import Chart from '../CdcChartComponent'
+import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import { expect, waitFor } from 'storybook/test'
+
+const meta: Meta<typeof Chart> = {
+  title: 'Components/Templates/Chart/Forecast Chart/CI Legend',
+  component: Chart
+}
+
+type Story = StoryObj<typeof Chart>
+
+const forecastCiLegendConfig = {
+  type: 'chart',
+  version: '4.26.8',
+  title: 'Forecast Chart With Multiple CI Series',
+  showTitle: true,
+  visualizationType: 'Forecasting',
+  visualizationSubType: 'regular',
+  orientation: 'vertical',
+  general: {
+    palette: {
+      name: 'sequential_bluereverse',
+      version: '2.0',
+      isReversed: true
+    }
+  },
+  legend: {
+    hide: false,
+    behavior: 'isolate',
+    position: 'right',
+    style: 'circles',
+    singleRow: false,
+    reverseLabelOrder: false,
+    verticalSorted: false,
+    dynamicLegend: false,
+    colorCode: '',
+    seriesHighlight: [],
+    groupBy: '',
+    orderedValues: [],
+    patterns: {},
+    hideSuppressionLink: false,
+    hideBorder: {
+      side: false,
+      topBottom: false
+    }
+  },
+  xAxis: {
+    dataKey: 'date',
+    type: 'date-time',
+    dateParseFormat: '%Y-%m-%d',
+    dateDisplayFormat: '%m/%d/%Y',
+    sortDates: false,
+    label: 'Date',
+    hideAxis: false,
+    hideLabel: false,
+    hideTicks: false,
+    numTicks: 4,
+    tickRotation: 0
+  },
+  yAxis: {
+    label: 'Count',
+    min: '0',
+    max: '',
+    numTicks: 5,
+    gridLines: true,
+    hideAxis: false,
+    hideLabel: false,
+    hideTicks: false
+  },
+  visual: {
+    border: true,
+    accent: true,
+    background: true,
+    verticalHoverLine: false,
+    horizontalHoverLine: false,
+    lineDatapointSymbol: 'none',
+    maximumShapeAmount: 7
+  },
+  table: {
+    show: false,
+    showDataTableLink: false
+  },
+  tooltips: {
+    opacity: 90,
+    singleSeries: false
+  },
+  dataDescription: {
+    horizontal: false,
+    series: false
+  },
+  filters: [],
+  columns: {},
+  confidenceKeys: {},
+  series: [
+    {
+      dataKey: 'stage',
+      type: 'Forecasting',
+      axis: 'Left',
+      tooltip: false,
+      stageColumn: 'stage',
+      stages: [
+        { key: 'Estimate', color: 'sequential-blue' },
+        { key: 'Estimate Based on Partial Data', color: 'sequential-green' },
+        { key: 'Forecast', color: 'sequential-orange' }
+      ],
+      confidenceIntervals: [
+        { high: 'Upper 50%', low: 'Lower 50%' },
+        { high: 'Upper 90%', low: 'Lower 90%' }
+      ]
+    }
+  ],
+  data: [
+    { date: '2026-01-01', stage: 'Estimate', 'Lower 50%': 84, 'Upper 50%': 128, 'Lower 90%': 58, 'Upper 90%': 160 },
+    { date: '2026-01-08', stage: 'Estimate', 'Lower 50%': 98, 'Upper 50%': 154, 'Lower 90%': 72, 'Upper 90%': 190 },
+    { date: '2026-01-15', stage: 'Estimate', 'Lower 50%': 116, 'Upper 50%': 183, 'Lower 90%': 86, 'Upper 90%': 226 },
+    {
+      date: '2026-01-22',
+      stage: 'Estimate Based on Partial Data',
+      'Lower 50%': 100,
+      'Upper 50%': 174,
+      'Lower 90%': 74,
+      'Upper 90%': 214
+    },
+    {
+      date: '2026-01-29',
+      stage: 'Estimate Based on Partial Data',
+      'Lower 50%': 88,
+      'Upper 50%': 158,
+      'Lower 90%': 64,
+      'Upper 90%': 198
+    },
+    { date: '2026-02-05', stage: 'Forecast', 'Lower 50%': 72, 'Upper 50%': 144, 'Lower 90%': 46, 'Upper 90%': 184 },
+    { date: '2026-02-12', stage: 'Forecast', 'Lower 50%': 60, 'Upper 50%': 126, 'Lower 90%': 34, 'Upper 90%': 166 }
+  ]
+}
+
+const getLegendRows = (canvasElement: HTMLElement) =>
+  Array.from(
+    canvasElement.querySelectorAll<HTMLElement>('.legend-container__inner > .legend-item--interactive[role="button"]')
+  ).map(item => {
+    const marker = item.querySelector<HTMLElement>('span.legend-item')
+
+    return {
+      text: item.textContent?.trim(),
+      markerColor: marker ? getComputedStyle(marker).backgroundColor : ''
+    }
+  })
+
+const getAlpha = (rgbaColor: string) => {
+  const match = rgbaColor.match(/^rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+(?:\s*,\s*([\d.]+))?\s*\)$/)
+  if (!match) return null
+
+  return match[1] ? Number(match[1]) : 1
+}
+
+const getRenderedForecastAreas = (canvasElement: HTMLElement) =>
+  Array.from(canvasElement.querySelectorAll<SVGPathElement>('.forecasting-items path')).filter(path => {
+    const fill = path.getAttribute('fill')
+    return fill && fill !== 'none' && fill !== 'transparent'
+  })
+
+const expectRenderableForecastAreas = (canvasElement: HTMLElement) => {
+  const areas = getRenderedForecastAreas(canvasElement)
+
+  expect(areas.length).toBeGreaterThanOrEqual(6)
+  areas.forEach(area => {
+    const pathData = area.getAttribute('d') || ''
+
+    expect(pathData).not.toContain('NaN')
+    expect(pathData).not.toContain('undefined')
+    expect(area.getBBox().width).toBeGreaterThan(0)
+    expect(area.getBBox().height).toBeGreaterThan(0)
+  })
+}
+
+const expectDarkerInnerCiMarkers = (legendRows: ReturnType<typeof getLegendRows>) => {
+  const ci50Rows = legendRows.slice(0, 3)
+  const ci90Rows = legendRows.slice(3)
+
+  ci50Rows.forEach((ci50Row, index) => {
+    const ci50Alpha = getAlpha(ci50Row.markerColor)
+    const ci90Alpha = getAlpha(ci90Rows[index].markerColor)
+
+    expect(ci50Alpha).not.toBeNull()
+    expect(ci90Alpha).not.toBeNull()
+    expect(ci50Alpha!).toBeGreaterThan(ci90Alpha!)
+  })
+}
+
+export const Multiple_CI_Legend_Indicators: Story = {
+  args: {
+    config: forecastCiLegendConfig as any,
+    isEditor: false
+  },
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    await waitFor(() => {
+      const legendRows = getLegendRows(canvasElement)
+
+      expectRenderableForecastAreas(canvasElement)
+      expect(legendRows.map(row => row.text)).toEqual([
+        '50% CI Estimate',
+        '50% CI Estimate Based on Partial Data',
+        '50% CI Forecast',
+        '90% CI Estimate',
+        '90% CI Estimate Based on Partial Data',
+        '90% CI Forecast'
+      ])
+
+      expectDarkerInnerCiMarkers(legendRows)
+    })
+  }
+}
+
+export default meta

--- a/packages/chart/src/components/Legend/Legend.Component.tsx
+++ b/packages/chart/src/components/Legend/Legend.Component.tsx
@@ -201,13 +201,11 @@ const Legend: React.FC<LegendProps> = forwardRef(
                         return null
                       }
 
-                      if (runtime.seriesLabels) {
+                      if (runtime?.forecastingSeriesKeys?.length > 0) {
+                        itemName = label.datum
+                      } else if (runtime.seriesLabels) {
                         let index = config.runtime.seriesLabelsAll.indexOf(itemName)
                         itemName = config.runtime.seriesKeys[index]
-
-                        if (runtime?.forecastingSeriesKeys?.length > 0) {
-                          itemName = label.text
-                        }
                       }
 
                       if (seriesHighlight.length) {

--- a/packages/chart/src/components/Legend/helpers/createFormatLabels.test.ts
+++ b/packages/chart/src/components/Legend/helpers/createFormatLabels.test.ts
@@ -46,6 +46,50 @@ const colorScale = scaleOrdinal({
 
 const formatLabels = (config: ChartConfig) => createFormatLabels(config, [], [], colorScale, vi.fn())(defaultLabels)
 
+const forecastingSeries = {
+  dataKey: 'type',
+  type: 'Forecasting',
+  axis: 'Left',
+  tooltip: false,
+  stageColumn: 'type',
+  stages: [
+    { key: 'Estimate', color: 'sequential-blue' },
+    { key: 'Forecast', color: 'sequential-orange' }
+  ],
+  confidenceIntervals: [
+    { high: 'Upper 50%', low: 'Lower 50%' },
+    { high: 'upper_90', low: 'lower_90' }
+  ]
+}
+
+const buildForecastingConfig = (confidenceIntervals = forecastingSeries.confidenceIntervals): ChartConfig =>
+  buildConfig({
+    visualizationType: 'Forecasting',
+    smallMultiples: undefined,
+    legend: {
+      reverseLabelOrder: false,
+      verticalSorted: false
+    } as any,
+    series: [
+      {
+        ...forecastingSeries,
+        confidenceIntervals
+      }
+    ] as any,
+    runtime: {
+      series: [],
+      seriesKeys: [],
+      seriesLabels: {},
+      seriesLabelsAll: [],
+      forecastingSeriesKeys: [
+        {
+          ...forecastingSeries,
+          confidenceIntervals
+        }
+      ]
+    } as any
+  })
+
 describe('createFormatLabels small multiples legend colors', () => {
   it('uses the first color for by-series same-color legends by default', () => {
     const labels = formatLabels(buildConfig())
@@ -84,5 +128,61 @@ describe('createFormatLabels small multiples legend colors', () => {
     )
 
     expect(labels.map(label => label.value)).toEqual(['#aa0000', '#aa0000'])
+  })
+})
+
+describe('createFormatLabels forecast confidence interval legends', () => {
+  it('expands multi-CI forecast labels by confidence interval and stage', () => {
+    const labels = formatLabels(buildForecastingConfig())
+
+    expect(labels.map(label => label.text)).toEqual([
+      '50% CI Estimate',
+      '50% CI Forecast',
+      '90% CI Estimate',
+      '90% CI Forecast'
+    ])
+    expect(labels.map(label => label.datum)).toEqual(['Estimate', 'Forecast', 'Estimate', 'Forecast'])
+    expect(labels[0].value).toMatch(/^rgba\(\d+, \d+, \d+, 0\.75\)$/)
+    expect(labels[2].value).toMatch(/^rgba\(\d+, \d+, \d+, 0\.5\)$/)
+  })
+
+  it('orders multi-CI labels by parsed confidence level', () => {
+    const labels = formatLabels(
+      buildForecastingConfig([
+        { high: 'upper_90', low: 'lower_90' },
+        { high: 'Upper 50%', low: 'Lower 50%' }
+      ])
+    )
+
+    expect(labels.map(label => label.text)).toEqual([
+      '50% CI Estimate',
+      '50% CI Forecast',
+      '90% CI Estimate',
+      '90% CI Forecast'
+    ])
+    expect(labels[0].value).toMatch(/^rgba\(\d+, \d+, \d+, 0\.75\)$/)
+    expect(labels[2].value).toMatch(/^rgba\(\d+, \d+, \d+, 0\.5\)$/)
+  })
+
+  it('preserves stage-only labels when a forecast series has one CI', () => {
+    const labels = formatLabels(buildForecastingConfig([{ high: 'upper_90', low: 'lower_90' }]))
+
+    expect(labels.map(label => label.text)).toEqual(['Estimate', 'Forecast'])
+  })
+
+  it('falls back to numbered CI labels when percentage values are unavailable', () => {
+    const labels = formatLabels(
+      buildForecastingConfig([
+        { high: 'upper_forecast', low: 'lower_forecast' },
+        { high: 'upper_prediction', low: 'lower_prediction' }
+      ])
+    )
+
+    expect(labels.map(label => label.text)).toEqual([
+      'CI 1 Estimate',
+      'CI 1 Forecast',
+      'CI 2 Estimate',
+      'CI 2 Forecast'
+    ])
   })
 })

--- a/packages/chart/src/components/Legend/helpers/createFormatLabels.tsx
+++ b/packages/chart/src/components/Legend/helpers/createFormatLabels.tsx
@@ -24,6 +24,88 @@ import { scaleSequential } from 'd3-scale'
 import { interpolateRgbBasis } from 'd3-interpolate'
 import { filterChartColorPalettes } from '@cdc/core/helpers/filterColorPalettes'
 
+const FORECASTING_CI_FILL_OPACITY = 0.5
+
+type ForecastConfidenceInterval = {
+  high?: string
+  low?: string
+  showInTooltip?: boolean
+}
+
+const getConfidenceLevel = (confidenceInterval: ForecastConfidenceInterval): number | null => {
+  const sourceText = [confidenceInterval.high, confidenceInterval.low].filter(Boolean).join(' ')
+  const percentMatch = sourceText.match(/(\d+(?:\.\d+)?)\s*%/)
+  if (percentMatch) return Number(percentMatch[1])
+
+  const upperLowerMatch = sourceText.match(
+    /(?:^|[\s_-])(?:upper|lower|high|low|hi|lo)[\s_-]*(\d+(?:\.\d+)?)(?=$|[\s_%_-])/i
+  )
+  if (upperLowerMatch) return Number(upperLowerMatch[1])
+
+  const confidenceMatch = sourceText.match(
+    /(?:^|[\s_-])(\d+(?:\.\d+)?)[\s_-]*(?:confidence|ci|interval)(?=$|[\s_%_-])/i
+  )
+  if (confidenceMatch) return Number(confidenceMatch[1])
+
+  return null
+}
+
+const getConfidenceIntervalLegendText = (confidenceInterval: ForecastConfidenceInterval, index: number): string => {
+  const confidenceLevel = getConfidenceLevel(confidenceInterval)
+  return confidenceLevel === null ? `CI ${index + 1}` : `${confidenceLevel}% CI`
+}
+
+const getForecastingConfidenceIntervalLegendItems = (confidenceIntervals: ForecastConfidenceInterval[] = []) =>
+  confidenceIntervals
+    .map((confidenceInterval, originalIndex) => ({
+      confidenceInterval,
+      originalIndex,
+      confidenceLevel: getConfidenceLevel(confidenceInterval)
+    }))
+    .filter(({ confidenceInterval }) => confidenceInterval.high && confidenceInterval.low)
+    .sort((a, b) => {
+      if (a.confidenceLevel !== null && b.confidenceLevel !== null) {
+        return a.confidenceLevel - b.confidenceLevel
+      }
+
+      if (a.confidenceLevel !== null) return -1
+      if (b.confidenceLevel !== null) return 1
+
+      return a.originalIndex - b.originalIndex
+    })
+
+const parseColorToRgb = (color: string): [number, number, number] | null => {
+  const normalizedColor = color.trim()
+  const hex = normalizedColor.startsWith('#') ? normalizedColor.slice(1) : normalizedColor
+
+  if (/^[0-9a-f]{3}$/i.test(hex)) {
+    return hex.split('').map(value => parseInt(`${value}${value}`, 16)) as [number, number, number]
+  }
+
+  if (/^[0-9a-f]{6}$/i.test(hex)) {
+    return [0, 2, 4].map(index => parseInt(hex.slice(index, index + 2), 16)) as [number, number, number]
+  }
+
+  const rgbMatch = normalizedColor.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i)
+  if (!rgbMatch) return null
+
+  return [Number(rgbMatch[1]), Number(rgbMatch[2]), Number(rgbMatch[3])]
+}
+
+const applyAlphaToColor = (color: string, alpha: number): string => {
+  const rgb = parseColorToRgb(color)
+  if (!rgb) return color
+
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${alpha})`
+}
+
+const getForecastingCiLegendFill = (fill: string, ciIndex: number, ciCount: number): string => {
+  const layerCount = Math.max(ciCount - ciIndex, 1)
+  const alpha = Number((1 - Math.pow(1 - FORECASTING_CI_FILL_OPACITY, layerCount)).toFixed(3))
+
+  return applyAlphaToColor(fill, alpha)
+}
+
 export const createFormatLabels =
   (
     config: ChartConfig,
@@ -309,16 +391,39 @@ export const createFormatLabels =
       const processedPalettes = updatePaletteNames(forecastPalettes)
       const forecastingPalettes = buildForecastPaletteMappings(processedPalettes, paletteVersion)
 
-      //store unique values to Set by colorCode
-      // loop through each stage/group/area on the chart and create a label
-      config.runtime?.forecastingSeriesKeys?.map((outerGroup, index) => {
-        return outerGroup?.stages?.map((stage, index) => {
+      config.runtime?.forecastingSeriesKeys?.forEach(outerGroup => {
+        const confidenceIntervals = getForecastingConfidenceIntervalLegendItems(outerGroup?.confidenceIntervals)
+        const shouldShowConfidenceIntervalLabels = confidenceIntervals.length > 1
+
+        if (shouldShowConfidenceIntervalLabels) {
+          confidenceIntervals.forEach(({ confidenceInterval, originalIndex }, ciIndex) => {
+            const confidenceIntervalText = getConfidenceIntervalLegendText(confidenceInterval, originalIndex)
+
+            outerGroup?.stages?.forEach(stage => {
+              const palette = forecastingPalettes[stage.color] || false
+              const colorValue = getForecastingCiLegendFill(palette?.[2] || '#ccc', ciIndex, confidenceIntervals.length)
+
+              const newLabel = {
+                datum: stage.key,
+                index: seriesLabels.length,
+                text: `${confidenceIntervalText} ${stage.key}`,
+                value: colorValue
+              }
+
+              seriesLabels.push(newLabel)
+            })
+          })
+
+          return
+        }
+
+        outerGroup?.stages?.forEach(stage => {
           const palette = forecastingPalettes[stage.color] || false
           let colorValue = palette?.[2] || '#ccc'
 
           const newLabel = {
             datum: stage.key,
-            index: index,
+            index: seriesLabels.length,
             text: stage.key,
             value: colorValue
           }


### PR DESCRIPTION
This pull request adds robust support for displaying multiple confidence interval (CI) series in forecast chart legends, ensuring correct labeling, ordering, and color rendering for CI legend items. It also introduces comprehensive tests and a Storybook story to verify these behaviors.

**Forecast Chart Legend Improvements:**

* Added logic to generate legend items for multiple CI series, including parsing and ordering by confidence level, and generating appropriate legend text (e.g., "50% CI Estimate") and color opacity for each CI layer. [[1]](diffhunk://#diff-e3a3efb31e4ecea2475727edaa73546c3b5c383b8f5211d4c09ffe1cfa28f337R27-R108) [[2]](diffhunk://#diff-e3a3efb31e4ecea2475727edaa73546c3b5c383b8f5211d4c09ffe1cfa28f337L312-R426)
* Improved legend rendering logic in `Legend.Component.tsx` to correctly handle and display forecasting series with multiple CI entries.

**Testing and Documentation:**

* Added unit tests to verify legend label generation for forecast charts with multiple and single CI series, ensuring correct ordering, labeling, and color assignment. [[1]](diffhunk://#diff-cd746922d642e5b9161f32e4b51c15a4e650f06d92381ecba76b90080bd3d685R49-R92) [[2]](diffhunk://#diff-cd746922d642e5b9161f32e4b51c15a4e650f06d92381ecba76b90080bd3d685R133-R188)
* Introduced a Storybook story (`Chart.Forecast.CILegend.stories.tsx`) that demonstrates and tests the rendering of forecast chart legends with multiple CI series, including visual and accessibility checks.