### PR TITLE
DEV-13351 Allow wrapping on data table headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Thumbs.db
 # IDE Specific
 .claude
 CLAUDE.local.md
+.playwright-mcp/*
 nbproject
 .~lock.*
 .buildpath

--- a/packages/core/components/DataTable/data-table.css
+++ b/packages/core/components/DataTable/data-table.css
@@ -131,6 +131,8 @@
         background-size: 10px 5px;
         color: #fff !important;
         cursor: pointer;
+        overflow-wrap: break-word;
+        white-space: normal;
         a {
           color: inherit;
         }


### PR DESCRIPTION
## Summary
Small change to allow line breaks on data table headers. Was trying some other options but was overthinking it as this seems to work out just fine.

Also added .playwright-mcp to .gitignore so that the screenshot elements it produces aren't checked in.

## Testing Steps
Load up any data table, especially ones with longer header strings. Resize the screen size smaller and observe line breaking behavior.
