### PR TITLE
fix: separate zero on new equal number legend

### DIFF
--- a/packages/map/src/helpers/generateRuntimeLegend.ts
+++ b/packages/map/src/helpers/generateRuntimeLegend.ts
@@ -547,11 +547,13 @@ export const generateRuntimeLegend = (
         }
 
         result.items.push({ min, max })
-        result.items[result.items.length - 1].color = applyColorToLegend(
-          result.items.length - 1,
-          configObj,
-          result.items
-        )
+      }
+
+      // Manual colors depend on the final legend item count, especially when a separate zero class was added first.
+      for (let i = 0; i < result.items.length; i++) {
+        if (!result.items[i].special) {
+          result.items[i].color = applyColorToLegend(i, configObj, result.items)
+        }
       }
     }
 

--- a/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
+++ b/packages/map/src/helpers/tests/generateRuntimeLegend.test.ts
@@ -560,6 +560,29 @@ describe('generateRuntimeLegend', () => {
     expect(legendMemo.current.get(hashObj(config.data[0]))).toBe(0)
   })
 
+  it('assigns distinct colors to separated-zero manual breakpoint legend items', () => {
+    const config = buildEqualNumberConfig(true)
+    config.general.palette = {
+      isReversed: false,
+      name: 'sequential_blue',
+      version: '2.1'
+    }
+    config.legend.type = 'manual'
+    config.legend.breakpoints = [25]
+
+    const { runtimeLegend, legendMemo } = getRuntimeLegend(config, config.data)
+    const colors = runtimeLegend.items.map(item => item.color)
+
+    expect(runtimeLegend.items.map(item => [item.min, item.max])).toEqual([
+      [0, 0],
+      [10, 25],
+      [25, 40]
+    ])
+    expect(colors).toEqual(v2ColorDistribution[3].map(index => mapColorPalettesV2.sequential_blue[index]))
+    expect(new Set(colors).size).toBe(colors.length)
+    expect(legendMemo.current.get(hashObj(config.data[0]))).toBe(0)
+  })
+
   it('automatically orders numeric and range category values', () => {
     const config = buildCategoryConfig(['1,000 - 1,999', '1.5', '1 - 14', '0', '1,000.5', '15-29', '1,000'])
 


### PR DESCRIPTION
This pull request improves the handling of color assignment for legend items in maps with manual breakpoints, particularly when a separate zero class is present. The main change ensures that colors are assigned only after all legend items are finalized, which fixes issues with distinct color allocation. Additionally, a new test verifies that colors are correctly and uniquely assigned in this scenario.

Legend color assignment improvements:

* Refactored `generateRuntimeLegend` to assign colors to legend items in a separate loop after all items are created, ensuring correct color distribution when a separate zero class is present.

Testing enhancements:

* Added a test to verify that manual breakpoint legends with a separated zero class receive distinct colors for each item, and that the color assignment matches the expected palette distribution.