### PR TITLE
fix: remove filtered-text from dashboard package.json

### DIFF
--- a/docs/FILTERED_TEXT_DEPRECATION.md
+++ b/docs/FILTERED_TEXT_DEPRECATION.md
@@ -95,7 +95,7 @@ Implementation note: Phase 1 was the user-visible deprecation and migration phas
 
 ## Phase 2
 
-Status: implemented for `4.26.6`.
+Status: implemented for `4.26.8`.
 
 ### Preconditions
 
@@ -105,6 +105,7 @@ Status: implemented for `4.26.6`.
 ### Removal Work
 
 - Delete the `@cdc/filtered-text` package workspace, including its tests, examples, and package metadata.
+- Remove `@cdc/filtered-text` from package manifests and lockfiles so installs do not pull the retired package from npm.
 - Remove remaining imports/usages of `CdcFilteredText` from dashboard, editor, stories, and runtime code.
 - Remove legacy rendering/editing branches for `type === 'filtered-text'`.
 - Remove temporary Phase 1 migrated/deprecated-message behavior along with the package.

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -47,7 +47,6 @@ Core repo areas:
 | `packages/data-table/` | Standalone tabular data component. |
 | `packages/markup-include/` | Component for authored inline or remote HTML content. |
 | `packages/waffle-chart/` | Waffle-style highlighted metric component. |
-| `packages/filtered-text/` | Deprecated legacy filtered-text component kept for existing saved configs. |
 | `.storybook/` | Root Storybook configuration, themes, preview setup, and static assets. |
 | `_stories/` | Root-level guide and comparison stories. |
 | `dev-portal/` | Local multi-package development portal and compare-mode Vite config. |
@@ -140,7 +139,6 @@ yarn dev:dashboard
 yarn dev:data-bite
 yarn dev:data-table
 yarn dev:editor
-yarn dev:filtered-text
 yarn dev:map
 yarn dev:markup-include
 yarn dev:waffle-chart
@@ -155,7 +153,6 @@ Default package dev ports from root scripts:
 | `yarn dev:data-bite` | `3004` |
 | `yarn dev:data-table` | `3005` |
 | `yarn dev:editor` | `3006` |
-| `yarn dev:filtered-text` | `3007` |
 | `yarn dev:map` | `3008` |
 | `yarn dev:markup-include` | `3009` |
 | `yarn dev:waffle-chart` | `3010` |

--- a/packages/core/helpers/tests/filteredTextCleanup.test.ts
+++ b/packages/core/helpers/tests/filteredTextCleanup.test.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+const packageName = '@cdc/filtered-text'
+
+const readSource = (relativePath: string) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+
+const getFiles = (dir: string): string[] => {
+  if (!fs.existsSync(dir)) return []
+
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    if (['dist', 'node_modules'].includes(entry.name)) return []
+
+    const entryPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) return getFiles(entryPath)
+    return [entryPath]
+  })
+}
+
+describe('filtered-text package cleanup', () => {
+  it('does not keep filtered-text as an installable workspace package', () => {
+    expect(fs.existsSync(path.join(repoRoot, 'packages/filtered-text/package.json'))).toBe(false)
+  })
+
+  it('does not depend on the retired filtered-text package', () => {
+    const packageJsonPaths = [
+      path.join(repoRoot, 'package.json'),
+      ...fs
+        .readdirSync(path.join(repoRoot, 'packages'), { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => path.join(repoRoot, 'packages', entry.name, 'package.json'))
+        .filter(fs.existsSync)
+    ]
+
+    const dependencySections = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies', 'resolutions']
+    const offenders = packageJsonPaths
+      .filter(packageJsonPath => {
+        const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+        return dependencySections.some(section => manifest[section]?.[packageName])
+      })
+      .map(packageJsonPath => path.relative(repoRoot, packageJsonPath))
+
+    expect(offenders).toEqual([])
+  })
+
+  it('does not keep a filtered-text lockfile entry', () => {
+    expect(readSource('yarn.lock')).not.toContain(`${packageName}@`)
+  })
+
+  it('does not import the retired filtered-text package from source', () => {
+    const importPattern = /(?:from\s+|import\s+)['"]@cdc\/filtered-text(?:\/[^'"]*)?['"]/
+    const offenders = getFiles(path.join(repoRoot, 'packages'))
+      .filter(filePath => /\.(js|jsx|ts|tsx)$/.test(filePath))
+      .filter(filePath => importPattern.test(fs.readFileSync(filePath, 'utf8')))
+      .map(filePath => path.relative(repoRoot, filePath))
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -9,7 +9,6 @@
     "@cdc/chart": "^4.26.6",
     "@cdc/core": "^4.26.6",
     "@cdc/data-bite": "^4.26.6",
-    "@cdc/filtered-text": "^4.26.6",
     "@cdc/map": "^4.26.6",
     "@cdc/markup-include": "^4.26.6",
     "@cdc/waffle-chart": "^4.26.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,15 +1132,6 @@
     vega "^6.1.0"
     vega-lite "^6.1.0"
 
-"@cdc/filtered-text@^4.26.6":
-  version "4.26.7"
-  resolved "https://registry.yarnpkg.com/@cdc/filtered-text/-/filtered-text-4.26.7.tgz#96e80208dedb142c7392ead7f561a67b60784aeb"
-  integrity sha512-aOqDKOw4UBkElJTz8ybLCgU1AnLTtkkM4TuI52KE084smTzavqwjtFCGbKhlUAv9BbVzv6bYyrHhjGmYEAYkMw==
-  dependencies:
-    "@cdc/core" "^4.26.7"
-    html-react-parser "^5.2.3"
-    lodash "^4.17.23"
-
 "@csstools/color-helpers@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz#106c54c808cabfd1ab4c602d8505ee584c2996ef"


### PR DESCRIPTION
This pull request completes the removal of the deprecated `@cdc/filtered-text` package from the codebase. It updates documentation to reflect the removal, eliminates all references to the package in manifests and scripts, and adds automated tests to ensure the package is fully retired.

**Removal of `@cdc/filtered-text` package and references:**

* Removed `@cdc/filtered-text` from `dashboard/package.json` dependencies.
* Removed all documentation references to the filtered-text package, including from component lists, dev scripts, and port tables in `PROJECT_OVERVIEW.md`. [[1]](diffhunk://#diff-f795de9ca89c8fe88f218da24262035ad5508f8cc6acc8fa7fcc93074996b74cL50) [[2]](diffhunk://#diff-f795de9ca89c8fe88f218da24262035ad5508f8cc6acc8fa7fcc93074996b74cL143) [[3]](diffhunk://#diff-f795de9ca89c8fe88f218da24262035ad5508f8cc6acc8fa7fcc93074996b74cL158)
* Updated the deprecation/removal status in `FILTERED_TEXT_DEPRECATION.md` to indicate implementation in version `4.26.8`, and clarified removal steps to include lockfiles and manifests. [[1]](diffhunk://#diff-7301b666371c2b5e82d2fbef18d88d1b08d5f6f320c34b42486eca9e56730eebL98-R98) [[2]](diffhunk://#diff-7301b666371c2b5e82d2fbef18d88d1b08d5f6f320c34b42486eca9e56730eebR108)

**Verification and enforcement:**

* Added `filteredTextCleanup.test.ts` to automatically verify that the filtered-text package is not present in the repo, manifests, lockfiles, or as an import in source code.