### PR TITLE
chore: centralize viewport type in core

### DIFF
--- a/packages/chart/src/components/Legend/Legend.Component.tsx
+++ b/packages/chart/src/components/Legend/Legend.Component.tsx
@@ -7,12 +7,13 @@ import { getLegendClasses } from './helpers/getLegendClasses'
 import { useHighlightedBars } from '../../hooks/useHighlightedBars'
 import { getMarginTop, getGradientConfig, getMarginBottom } from './helpers/index'
 import { Label } from '../../types/Label'
-import { ChartConfig, ViewportSize } from '../../types/ChartConfig'
+import { ChartConfig } from '../../types/ChartConfig'
 import { ColorScale } from '../../types/ChartContext'
 import { forwardRef } from 'react'
 import LegendSuppression from './Legend.Suppression'
 import LegendGradient from '@cdc/core/components/Legend/Legend.Gradient'
 import { DimensionsType } from '@cdc/core/types/Dimensions'
+import type { ViewPort } from '@cdc/core/types/ViewPort'
 import { isLegendWrapViewport } from '@cdc/core/helpers/viewports'
 import LegendLineShape from './LegendLine.Shape'
 import LegendGroup from './LegendGroup'
@@ -28,7 +29,7 @@ const LEGEND_PADDING = 36
 interface LegendProps {
   colorScale: ColorScale
   config: ChartConfig
-  currentViewport: ViewportSize
+  currentViewport: ViewPort
   formatLabels: (labels: Label[]) => Label[]
   formatNumber?: (value: number, axis?: string) => string
   highlight: Function

--- a/packages/chart/src/helpers/axisLabelFontSize.ts
+++ b/packages/chart/src/helpers/axisLabelFontSize.ts
@@ -1,8 +1,8 @@
 import { isMobileFontViewport } from '@cdc/core/helpers/viewports'
-import { ViewportSize } from '../types/ChartConfig'
+import type { ViewPort } from '@cdc/core/types/ViewPort'
 
 export const AXIS_LABEL_FONT_SIZE = 18
 export const AXIS_LABEL_FONT_SIZE_SMALL = 14
 
-export const getAxisLabelFontSize = (vizViewport: ViewportSize) =>
+export const getAxisLabelFontSize = (vizViewport: ViewPort) =>
   isMobileFontViewport(vizViewport) ? AXIS_LABEL_FONT_SIZE_SMALL : AXIS_LABEL_FONT_SIZE

--- a/packages/chart/src/helpers/sizeHelpers.ts
+++ b/packages/chart/src/helpers/sizeHelpers.ts
@@ -1,10 +1,11 @@
 import { isMobileHeightViewport } from '@cdc/core/helpers/viewports'
-import { ChartConfig, ViewportSize } from '../types/ChartConfig'
+import { ChartConfig } from '../types/ChartConfig'
 import { EDITOR_WIDTH } from '@cdc/core/helpers/constants'
+import type { ViewPort } from '@cdc/core/types/ViewPort'
 
 export function getOrientation(
   { orientation, heights, visualizationType }: Pick<ChartConfig, 'orientation' | 'heights' | 'visualizationType'>,
-  currentViewport: ViewportSize
+  currentViewport: ViewPort
 ): 'vertical' | 'horizontal' | 'mobileVertical' {
   const isForestPlot = visualizationType === 'Forest Plot'
   const useVertical = orientation === 'vertical' || isForestPlot
@@ -15,7 +16,7 @@ export function getOrientation(
 }
 export function calcInitialHeight(
   { heights, orientation, visualizationType }: Pick<ChartConfig, 'heights' | 'orientation' | 'visualizationType'>,
-  currentViewport: ViewportSize
+  currentViewport: ViewPort
 ): number {
   // if no heights are provided assume config has not been loaded
   if (!heights) return 0

--- a/packages/chart/src/store/chart.reducer.ts
+++ b/packages/chart/src/store/chart.reducer.ts
@@ -1,7 +1,8 @@
 import ChartActions from './chart.actions'
 import defaults from '../data/initial-state.js'
-import { ChartConfig, type ViewportSize } from '../types/ChartConfig'
+import { ChartConfig } from '../types/ChartConfig'
 import { DimensionsType } from '@cdc/core/types/Dimensions'
+import type { ViewPort } from '@cdc/core/types/ViewPort'
 
 type ChartState = {
   isLoading: boolean
@@ -11,8 +12,8 @@ type ChartState = {
   excludedData: object[]
   filteredData: object[]
   seriesHighlight: string[]
-  currentViewport: ViewportSize
-  vizViewport: ViewportSize
+  currentViewport: ViewPort
+  vizViewport: ViewPort
   dimensions: DimensionsType
   container: HTMLElement | null
   coveLoadedEventRan: boolean

--- a/packages/chart/src/types/ChartConfig.ts
+++ b/packages/chart/src/types/ChartConfig.ts
@@ -33,7 +33,6 @@ import { type Annotation } from '@cdc/core/types/Annotation'
 import { Version } from '@cdc/core/types/Version'
 import Footnotes from '@cdc/core/types/Footnotes'
 
-export type ViewportSize = 'xxs' | 'xs' | 'sm' | 'md' | 'lg'
 type ChartColumns = Record<string, Column>
 export type ChartOrientation = 'vertical' | 'horizontal'
 export type VisualizationType =

--- a/packages/core/helpers/getViewport.ts
+++ b/packages/core/helpers/getViewport.ts
@@ -1,4 +1,4 @@
-import { ViewPort } from '../types/ViewPort'
+import type { ViewPort } from '../types/ViewPort'
 
 export const viewports = {
   lg: 1200,

--- a/packages/core/helpers/tests/viewports.test.ts
+++ b/packages/core/helpers/tests/viewports.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { isBelowBreakpoint, isLegendWrapViewport, isMobileFontViewport } from '../viewports'
+
+describe('viewport helpers', () => {
+  it('treats smaller viewport keys as below larger breakpoint keys', () => {
+    expect(isBelowBreakpoint('sm', 'xs')).toBe(true)
+    expect(isBelowBreakpoint('sm', 'sm')).toBe(false)
+    expect(isBelowBreakpoint('sm', 'md')).toBe(false)
+  })
+
+  it('uses core viewport ordering for shared mobile checks', () => {
+    expect(isLegendWrapViewport('xs')).toBe(true)
+    expect(isLegendWrapViewport('sm')).toBe(false)
+    expect(isMobileFontViewport('xxs')).toBe(true)
+    expect(isMobileFontViewport('lg')).toBe(false)
+  })
+})

--- a/packages/core/helpers/viewports.ts
+++ b/packages/core/helpers/viewports.ts
@@ -1,8 +1,8 @@
-import { ViewportSize } from '@cdc/map/src/types/MapConfig'
+import type { ViewPort } from '../types/ViewPort'
 
-const BREAKPOINTS = ['xxs', 'xs', 'sm', 'md', 'lg']
+const BREAKPOINTS: ViewPort[] = ['xxs', 'xs', 'sm', 'md', 'lg']
 
-export const isBelowBreakpoint = (breakpoint: ViewportSize, currentViewport: ViewportSize) =>
+export const isBelowBreakpoint = (breakpoint: ViewPort, currentViewport: ViewPort) =>
   BREAKPOINTS.indexOf(currentViewport) < BREAKPOINTS.indexOf(breakpoint)
 
 export const isLegendWrapViewport = currentViewport => isBelowBreakpoint('sm', currentViewport)

--- a/packages/data-table/src/store/dataTable.reducer.ts
+++ b/packages/data-table/src/store/dataTable.reducer.ts
@@ -4,7 +4,7 @@ import { Config } from '../types/Config'
 import { Column } from '@cdc/core/types/Column'
 import { Table } from '@cdc/core/types/Table'
 import { VizFilter } from '@cdc/core/types/VizFilter'
-import { ViewportSize } from '@cdc/chart/src/types/ChartConfig'
+import type { ViewPort } from '@cdc/core/types/ViewPort'
 import { FilterBehavior } from '@cdc/core/types/FilterBehavior'
 
 export const getInitialState = (isEditor: boolean): State => {
@@ -29,7 +29,7 @@ export type State = {
   table: Table
   filters: VizFilter[]
   filterBehavior?: FilterBehavior
-  currentViewport: ViewportSize
+  currentViewport: ViewPort
   filterIntro: string
 }
 


### PR DESCRIPTION
This pull request refactors viewport type usage across the chart and data-table packages to standardize on the `ViewPort` type from `@cdc/core/types/ViewPort`, replacing the previously used `ViewportSize` type. This improves type consistency and maintainability, and ensures that viewport-related helpers and state definitions are aligned throughout the codebase. Additionally, a new test suite is added for viewport helper functions.

**Viewport type standardization:**

* Replaced all usages of `ViewportSize` with `ViewPort` in chart components, helpers, reducers, and types, ensuring consistent viewport typing throughout the chart package. [[1]](diffhunk://#diff-08cebafcbcf27bdf20ee0e022578d3c38bd3a1a813cf0f63fc886a814ed73a43L10-R16) [[2]](diffhunk://#diff-08cebafcbcf27bdf20ee0e022578d3c38bd3a1a813cf0f63fc886a814ed73a43L31-R32) [[3]](diffhunk://#diff-7402bbac48e4971c660b89ddcde386eb3d3cf0ede768534b5dd8c88a6db65295L2-R7) [[4]](diffhunk://#diff-5fa49f596d4a6c1dda583cba60c5823d6e20a54245f6e1f895ef567267d1594dL2-R8) [[5]](diffhunk://#diff-5fa49f596d4a6c1dda583cba60c5823d6e20a54245f6e1f895ef567267d1594dL18-R19) [[6]](diffhunk://#diff-ef876833ea6a6d88f27c8e083a8118a7acf7f08f8a0368140b3fa4f02909d17dL3-R5) [[7]](diffhunk://#diff-ef876833ea6a6d88f27c8e083a8118a7acf7f08f8a0368140b3fa4f02909d17dL14-R16) [[8]](diffhunk://#diff-3915bc3590f94975a826f1c3ac07db60e0c34059cec61b53db33533d1ee02bb8L36)
* Updated data-table reducer to use `ViewPort` instead of `ViewportSize` for the `currentViewport` property and related imports. [[1]](diffhunk://#diff-1f774afd40ccd2dd2c376bfbcc48ce4459f52ac6f013943a2ac969c39723da88L7-R7) [[2]](diffhunk://#diff-1f774afd40ccd2dd2c376bfbcc48ce4459f52ac6f013943a2ac969c39723da88L32-R32)

**Core helpers and tests:**

* Updated core viewport helpers (`viewports.ts`, `getViewport.ts`) to use `ViewPort` type, and improved type annotations for breakpoint arrays and helper functions. [[1]](diffhunk://#diff-3a684f16a1459107679372f71cabc1dacd4fb0049c594df47260a63b947d5ddbL1-R5) [[2]](diffhunk://#diff-f3862cb47278a79e7d72e47a81d98912bf57a9935e1c4e89831bf402dbae30acL1-R1)
* Added a new test file for viewport helpers to validate breakpoint logic and mobile viewport detection.