### PR TITLE
fix: preserve rank-by-value order without mutating data

### DIFF
--- a/packages/chart/src/CdcChartComponent.tsx
+++ b/packages/chart/src/CdcChartComponent.tsx
@@ -447,7 +447,7 @@ const CdcChart: React.FC<CdcChartProps> = ({
       }
     }
 
-    const newExcludedData: any[] = getExcludedData(newConfig, dataOverride || stateData)
+    const newExcludedData: any[] = getExcludedData(newConfig, data)
     dispatch({ type: 'SET_EXCLUDED_DATA', payload: newExcludedData })
 
     // After data is grabbed, loop through and generate filter column values if there are any

--- a/packages/chart/src/_stories/Chart.RankByValueMutation.stories.tsx
+++ b/packages/chart/src/_stories/Chart.RankByValueMutation.stories.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, waitFor } from 'storybook/test'
+
+import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import Chart from '../CdcChartComponent'
+import { ChartConfig } from '../types/ChartConfig'
+
+const meta: Meta<typeof RankByValueMutationHarness> = {
+  title: 'Components/Templates/Chart/Rank By Value Mutation Regression',
+  component: RankByValueMutationHarness,
+  parameters: {
+    layout: 'fullscreen'
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof RankByValueMutationHarness>
+
+type RankRow = {
+  category: string
+  value: number
+}
+
+const sourceOrder = 'Alpha, Charlie, Bravo'
+const rankedOrder = 'Charlie, Bravo, Alpha'
+const rankedExcludingAlphaOrder = 'Charlie, Bravo'
+
+const getOrder = (rows: RankRow[]) => rows.map(row => row.category).join(', ')
+
+const getRenderedCategoryOrder = (panel: Element) => {
+  const categoryNames = sourceOrder.split(', ')
+  return Array.from(panel.querySelectorAll('svg text'))
+    .filter(textElement => categoryNames.includes(textElement.textContent?.trim() || ''))
+    .sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left)
+    .map(textElement => textElement.textContent?.trim())
+    .join(', ')
+}
+
+const getConfig = (
+  title: string,
+  data: RankRow[],
+  rankByValue?: 'asc' | 'desc',
+  excludedCategories: string[] = []
+): ChartConfig =>
+  ({
+    version: '4.26.8',
+    type: 'chart',
+    visualizationType: 'Bar',
+    title,
+    rankByValue,
+    data,
+    animate: false,
+    legend: {
+      hide: true
+    },
+    table: {
+      show: false
+    },
+    xAxis: {
+      dataKey: 'category',
+      type: 'categorical',
+      label: 'Category'
+    },
+    yAxis: {
+      label: 'Value',
+      hideAxis: false,
+      hideTicks: false,
+      gridLines: true,
+      numTicks: 4
+    },
+    series: [
+      {
+        dataKey: 'value',
+        name: 'Value',
+        type: 'Bar'
+      }
+    ],
+    dataFormat: {
+      roundTo: 0,
+      commas: false
+    },
+    exclusions: {
+      active: excludedCategories.length > 0,
+      keys: excludedCategories
+    }
+  } as ChartConfig)
+
+const panelStyle = {
+  background: '#fff',
+  border: '1px solid #d9dfe7',
+  borderRadius: 6,
+  minWidth: 0,
+  padding: 16
+}
+
+const labelStyle = {
+  color: '#4b5563',
+  fontSize: 12,
+  fontWeight: 700,
+  margin: '0 0 8px',
+  textTransform: 'uppercase' as const
+}
+
+const diagnosticStyle = {
+  background: '#f7f8fa',
+  border: '1px solid #d9dfe7',
+  borderRadius: 6,
+  display: 'grid',
+  gap: 8,
+  gridColumn: '1 / -1',
+  padding: 12
+}
+
+function RankByValueMutationHarness() {
+  const sharedRows = useMemo<RankRow[]>(
+    () => [
+      { category: 'Alpha', value: 30 },
+      { category: 'Charlie', value: 10 },
+      { category: 'Bravo', value: 20 }
+    ],
+    []
+  )
+
+  const [observedOrder, setObservedOrder] = useState<string>('Checking shared data order...')
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setObservedOrder(getOrder(sharedRows))
+    }, 100)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [sharedRows])
+
+  const rankedConfig = useMemo(() => getConfig('Ranked by value ascending', sharedRows, 'asc'), [sharedRows])
+  const rankedExclusionConfig = useMemo(
+    () => getConfig('Ranked by value ascending with Alpha excluded', sharedRows, 'asc', ['Alpha']),
+    [sharedRows]
+  )
+  const sourceOrderConfig = useMemo(() => getConfig('Should preserve source order', sharedRows), [sharedRows])
+  const isChecking = observedOrder === 'Checking shared data order...'
+  const hasMutated = !isChecking && observedOrder !== sourceOrder
+
+  return (
+    <div
+      style={{
+        background: '#eef2f7',
+        display: 'grid',
+        gap: 16,
+        gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
+        padding: 16
+      }}
+    >
+      <section style={panelStyle} data-rank-by-value-panel='ranked'>
+        <p style={labelStyle}>Ranked chart</p>
+        <Chart config={rankedConfig} isEditor={false} interactionLabel='' />
+      </section>
+
+      <section style={panelStyle} data-rank-by-value-panel='source-order'>
+        <p style={labelStyle}>Source-order chart sharing the same data</p>
+        <Chart config={sourceOrderConfig} isEditor={false} interactionLabel='' />
+      </section>
+
+      <section style={panelStyle} data-rank-by-value-panel='ranked-exclusion'>
+        <p style={labelStyle}>Ranked chart with Alpha excluded</p>
+        <Chart config={rankedExclusionConfig} isEditor={false} interactionLabel='' />
+      </section>
+
+      <section style={diagnosticStyle} aria-label='Shared data order diagnostic'>
+        <div>
+          <strong>Expected shared data order:</strong> <span>{sourceOrder}</span>
+        </div>
+        <div>
+          <strong>Observed shared data order:</strong>{' '}
+          <span data-testid='rank-by-value-observed-order'>{observedOrder}</span>
+        </div>
+        <div data-testid='rank-by-value-mutation-status'>
+          <strong>Status:</strong> {hasMutated ? 'Shared data was mutated' : 'Shared data order is preserved'}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export const Shared_Data_Order_Is_Preserved: Story = {
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    await waitFor(() => {
+      const rankedPanel = canvasElement.querySelector('[data-rank-by-value-panel="ranked"]')
+      const sourceOrderPanel = canvasElement.querySelector('[data-rank-by-value-panel="source-order"]')
+      const rankedExclusionPanel = canvasElement.querySelector('[data-rank-by-value-panel="ranked-exclusion"]')
+
+      expect(rankedPanel?.querySelector('svg')).toBeTruthy()
+      expect(sourceOrderPanel?.querySelector('svg')).toBeTruthy()
+      expect(rankedExclusionPanel?.querySelector('svg')).toBeTruthy()
+      expect(rankedPanel ? getRenderedCategoryOrder(rankedPanel) : '').toBe(rankedOrder)
+      expect(sourceOrderPanel ? getRenderedCategoryOrder(sourceOrderPanel) : '').toBe(sourceOrder)
+      expect(rankedExclusionPanel ? getRenderedCategoryOrder(rankedExclusionPanel) : '').toBe(rankedExcludingAlphaOrder)
+      expect(canvasElement.querySelector('[data-testid="rank-by-value-observed-order"]')?.textContent).toBe(sourceOrder)
+      expect(canvasElement.querySelector('[data-testid="rank-by-value-mutation-status"]')?.textContent).toContain(
+        'Shared data order is preserved'
+      )
+    })
+  }
+}

--- a/packages/chart/src/helpers/handleRankByValue.ts
+++ b/packages/chart/src/helpers/handleRankByValue.ts
@@ -8,7 +8,7 @@ const getNumericValue = number => {
 export const handleRankByValue = (data, passedConfig: ChartConfig) => {
   if (passedConfig.rankByValue) {
     const series = passedConfig.series[0].dataKey
-    const sorted = data.sort((a, b) => getNumericValue(a[series]) - getNumericValue(b[series]))
+    const sorted = [...data].sort((a, b) => getNumericValue(a[series]) - getNumericValue(b[series]))
     return passedConfig.rankByValue === 'asc' ? sorted : sorted.reverse()
   }
   return data

--- a/packages/chart/src/helpers/tests/handleRankByValue.test.ts
+++ b/packages/chart/src/helpers/tests/handleRankByValue.test.ts
@@ -4,6 +4,7 @@ import { ChartConfig } from '../../types/ChartConfig'
 describe('handleRankByValue', () => {
   it('should sort the data in ascending order when rankByValue is "asc"', () => {
     const data = [{ value: 3 }, { value: 1 }, { value: 2 }]
+    const originalData = [...data]
     const config: ChartConfig = {
       rankByValue: 'asc',
       series: [{ dataKey: 'value' }]
@@ -11,10 +12,13 @@ describe('handleRankByValue', () => {
 
     const result = handleRankByValue(data, config)
     expect(result).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }])
+    expect(result).not.toBe(data)
+    expect(data).toEqual(originalData)
   })
 
   it('should sort the data in descending order when rankByValue is "desc"', () => {
     const data = [{ value: 3 }, { value: 1 }, { value: 2 }]
+    const originalData = [...data]
     const config: ChartConfig = {
       rankByValue: 'desc',
       series: [{ dataKey: 'value' }]
@@ -22,6 +26,8 @@ describe('handleRankByValue', () => {
 
     const result = handleRankByValue(data, config)
     expect(result).toEqual([{ value: 3 }, { value: 2 }, { value: 1 }])
+    expect(result).not.toBe(data)
+    expect(data).toEqual(originalData)
   })
 
   it('should handle numeric strings correctly', () => {
@@ -33,5 +39,17 @@ describe('handleRankByValue', () => {
 
     const result = handleRankByValue(data, config)
     expect(result).toEqual([{ value: '1' }, { value: '2' }, { value: '3' }])
+  })
+
+  it('should return the original data reference when rankByValue is not set', () => {
+    const data = [{ value: 3 }, { value: 1 }, { value: 2 }]
+    const config: ChartConfig = {
+      rankByValue: undefined,
+      series: [{ dataKey: 'value' }]
+    }
+
+    const result = handleRankByValue(data, config)
+    expect(result).toBe(data)
+    expect(result).toEqual([{ value: 3 }, { value: 1 }, { value: 2 }])
   })
 })


### PR DESCRIPTION
This pull request addresses an important bug where the `handleRankByValue` function was mutating the input data array, which could lead to unexpected side effects in charts that share the same data. The changes ensure that data sorting for ranking does not mutate the original array, and comprehensive regression tests and a Storybook story are added to verify this behavior.

**Bug fix: Prevent mutation of input data in ranking**

* Updated `handleRankByValue` to create a shallow copy of the data before sorting, ensuring the original array is not mutated.

**Testing and regression coverage**

* Added/updated unit tests in `handleRankByValue.test.ts` to check that the original data is not mutated and that a new array is returned when sorting, as well as to verify reference equality when ranking is not applied. [[1]](diffhunk://#diff-ac788905461ff186fc22806b3678eb6773c7621d5e1585ca5c8b57408d033f63R7-R30) [[2]](diffhunk://#diff-ac788905461ff186fc22806b3678eb6773c7621d5e1585ca5c8b57408d033f63R43-R54)
* Added a comprehensive Storybook regression story (`Chart.RankByValueMutation.stories.tsx`) that visually and programmatically verifies that the shared data order is preserved when rendering multiple charts with and without ranking, and when exclusions are applied.

**Related code update**

* Fixed `CdcChartComponent.tsx` to use the correct data source for exclusions, ensuring consistency with the new non-mutating behavior.