### PR TITLE
Fix: duplicated boxplot calculations between plots and tables

### DIFF
--- a/.agents/skills/cove-algorithm-improvement/SKILL.md
+++ b/.agents/skills/cove-algorithm-improvement/SKILL.md
@@ -90,6 +90,10 @@ Keep speculative ideas separate from confirmed findings. If no serious algorithm
 
 When asked to implement:
 
+- For UI-visible, editor-visible, runtime-visible, or dashboard-visible behavior, first create or update a narrowly scoped Storybook story that demonstrates the algorithm area needing the fix. Prefer an affected package's existing `_stories` patterns and shared testing helpers from `@cdc/core/helpers/testing` when a play assertion is useful.
+- Make the story a reviewable reproduction or characterization of the current behavior, not the production fix. Keep the data fixture small and named around the edge case being demonstrated.
+- After creating the Storybook story, pause before editing production algorithm code. Tell the developer the story path, what behavior it demonstrates, and the targeted Storybook command from `AGENTS.md` to run. Ask whether to continue with the fix, then wait for explicit confirmation.
+- If a Storybook story is not a sensible way to demonstrate the algorithm issue, explain why before proceeding with the closest reviewable characterization artifact, such as a focused unit test or fixture.
 - Start with characterization tests when current behavior is ambiguous or compatibility-sensitive.
 - Prefer pure helper extraction only when it makes edge cases easier to test or removes real duplication.
 - Preserve input objects and package defaults unless mutation is an intentional, documented contract.

--- a/packages/chart/src/_stories/Chart.BoxPlotStatsParity.stories.tsx
+++ b/packages/chart/src/_stories/Chart.BoxPlotStatsParity.stories.tsx
@@ -1,0 +1,207 @@
+import { useMemo } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, waitFor } from 'storybook/test'
+
+import { assertVisualizationRendered } from '@cdc/core/helpers/testing'
+import Chart from '../CdcChartComponent'
+import { createPlots } from '../components/BoxPlot/helpers'
+import { getBoxPlotConfig } from '../helpers/getBoxPlotConfig'
+import type { ChartConfig } from '../types/ChartConfig'
+
+const expectedOutlier = '1000'
+const expectedMetadataValues = '10,20,30,40,1000'
+
+const boxPlotRows = [
+  { Group: 'Group A', Score: '10' },
+  { Group: 'Group A', Score: '20' },
+  { Group: 'Group A', Score: '30' },
+  { Group: 'Group A', Score: '40' },
+  { Group: 'Group A', Score: '1,000' }
+]
+
+const boxPlotLabels = {
+  maximum: 'Maximum',
+  q3: 'Upper Quartile',
+  median: 'Median',
+  q1: 'Lower Quartile',
+  minimum: 'Minimum',
+  count: 'Count',
+  mean: 'Mean',
+  sd: 'Standard Deviation',
+  iqr: 'Interquartile Range',
+  outliers: 'Outliers',
+  values: 'Values',
+  lowerBounds: 'Lower Bounds',
+  upperBounds: 'Upper Bounds'
+}
+
+const getConfig = (): ChartConfig =>
+  ({
+    version: '4.26.8',
+    type: 'chart',
+    visualizationType: 'Box Plot',
+    title: 'Box Plot Stats Parity Regression',
+    orientation: 'vertical',
+    animate: false,
+    data: boxPlotRows,
+    table: {
+      show: true,
+      expanded: true,
+      download: false,
+      label: 'Data Table',
+      indexLabel: ''
+    },
+    xAxis: {
+      dataKey: 'Group',
+      type: 'categorical',
+      label: 'Group'
+    },
+    yAxis: {
+      dataKey: 'Score',
+      label: 'Score',
+      hideAxis: false,
+      hideTicks: false,
+      gridLines: true,
+      numTicks: 5
+    },
+    series: [
+      {
+        dataKey: 'Score',
+        name: 'Score'
+      }
+    ],
+    boxplot: {
+      plots: [],
+      categories: [],
+      borders: 'true',
+      plotOutlierValues: true,
+      plotNonOutlierValues: true,
+      labels: boxPlotLabels
+    },
+    legend: {
+      hide: true
+    },
+    dataFormat: {
+      roundTo: 0,
+      commas: false
+    }
+  } as ChartConfig)
+
+function BoxPlotStatsParityRegression() {
+  const config = useMemo(() => getConfig(), [])
+  const [metadataPlots] = getBoxPlotConfig(config, config.data)
+  const rendererPlots = createPlots(config.data, config)
+  const metadataPlot = metadataPlots[0]
+  const rendererPlot = rendererPlots[0]
+
+  const metadataValues = metadataPlot?.values?.join(',') || ''
+  const metadataOutliers = metadataPlot?.columnOutliers?.join(',') || '(none)'
+  const rendererAcceptedValues =
+    [...(rendererPlot?.columnNonOutliers?.Score || []), ...(rendererPlot?.columnOutliers?.Score || [])].join(',') ||
+    '(none)'
+  const rendererOutliers = rendererPlot?.columnOutliers?.Score?.join(',') || '(none)'
+  const hasStatsParity = metadataValues === rendererAcceptedValues && metadataOutliers === rendererOutliers
+
+  return (
+    <div
+      style={{
+        background: '#eef2f7',
+        display: 'grid',
+        gap: 16,
+        padding: 16
+      }}
+    >
+      <section
+        style={{
+          background: '#fff',
+          border: '1px solid #d9dfe7',
+          borderRadius: 6,
+          padding: 16
+        }}
+      >
+        <Chart config={config} isEditor={false} interactionLabel='boxplot-stats-parity-regression' />
+      </section>
+
+      <section
+        aria-label='Box plot stats parity diagnostic'
+        style={{
+          background: '#f7f8fa',
+          border: '1px solid #d9dfe7',
+          borderRadius: 6,
+          display: 'grid',
+          gap: 8,
+          padding: 12
+        }}
+      >
+        <div>
+          <strong>Input score values:</strong> <span>10,20,30,40,1,000</span>
+        </div>
+        <div>
+          <strong>Metadata values:</strong> <span data-testid='boxplot-metadata-values'>{metadataValues}</span>
+        </div>
+        <div>
+          <strong>Metadata outliers:</strong> <span data-testid='boxplot-metadata-outliers'>{metadataOutliers}</span>
+        </div>
+        <div>
+          <strong>Renderer accepted values:</strong>{' '}
+          <span data-testid='boxplot-renderer-values'>{rendererAcceptedValues}</span>
+        </div>
+        <div>
+          <strong>Renderer outliers:</strong> <span data-testid='boxplot-renderer-outliers'>{rendererOutliers}</span>
+        </div>
+        <div data-testid='boxplot-stats-parity-status'>
+          <strong>Status:</strong> {hasStatsParity ? 'Stats parity preserved' : 'Issue reproduced'}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+const getBoxPlotTableValue = (canvasElement: HTMLElement, rowLabel: string) => {
+  const row = Array.from(canvasElement.querySelectorAll('tr')).find(tableRow => {
+    const firstCell = tableRow.querySelector('th, td')
+    return firstCell?.textContent?.trim() === rowLabel
+  })
+
+  return Array.from(row?.querySelectorAll('th, td') || [])
+    .slice(1)
+    .map(cell => cell.textContent?.trim())
+    .join('')
+}
+
+const meta: Meta<typeof BoxPlotStatsParityRegression> = {
+  title: 'Components/Templates/Chart/Box Plot Stats Parity Regression',
+  component: BoxPlotStatsParityRegression,
+  parameters: {
+    layout: 'fullscreen'
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof BoxPlotStatsParityRegression>
+
+export const Formatted_Numeric_Values_Keep_Stats_Parity: Story = {
+  play: async ({ canvasElement }) => {
+    await assertVisualizationRendered(canvasElement)
+
+    await waitFor(() => {
+      expect(canvasElement.querySelector('[data-testid="boxplot-metadata-values"]')?.textContent).toBe(
+        expectedMetadataValues
+      )
+      expect(canvasElement.querySelector('[data-testid="boxplot-metadata-outliers"]')?.textContent).toBe(
+        expectedOutlier
+      )
+      expect(canvasElement.querySelector('[data-testid="boxplot-renderer-values"]')?.textContent).toBe(
+        expectedMetadataValues
+      )
+      expect(canvasElement.querySelector('[data-testid="boxplot-renderer-outliers"]')?.textContent).toBe(
+        expectedOutlier
+      )
+      expect(canvasElement.querySelector('[data-testid="boxplot-stats-parity-status"]')?.textContent).toContain(
+        'Stats parity preserved'
+      )
+      expect(getBoxPlotTableValue(canvasElement, 'Values')).toBe(expectedMetadataValues)
+      expect(getBoxPlotTableValue(canvasElement, 'Outliers')).toBe(expectedOutlier)
+    })
+  }
+}

--- a/packages/chart/src/components/BoxPlot/helpers/index.ts
+++ b/packages/chart/src/components/BoxPlot/helpers/index.ts
@@ -1,6 +1,5 @@
-import sortBy from 'lodash/sortBy'
 import uniq from 'lodash/uniq'
-import * as d3 from 'd3-array'
+import { calculateBoxPlotStats } from '../../../helpers/boxPlotStats'
 
 interface Plot {
   columnCategory: string
@@ -30,47 +29,6 @@ export const handleTooltip = (boxplot, columnCategory, key, q1, q3, median, iqr,
   `
 }
 
-const calculateBoxPlotStats = (values: number[]) => {
-  if (!values || values.length === 0) return {}
-
-  // Sort the values
-  const sortedValues = sortBy(values.map(v => Number(v)))
-
-  // Quartiles
-  const firstQuartile = d3.quantile(sortedValues, 0.25) ?? 0
-  const thirdQuartile = d3.quantile(sortedValues, 0.75) ?? 0
-
-  // Interquartile Range (IQR)
-  const iqr = thirdQuartile - firstQuartile
-
-  // Outlier Bounds
-  const lowerBound = firstQuartile - 1.5 * iqr
-  const upperBound = thirdQuartile + 1.5 * iqr
-  // const lowerFence = q1 - 1.5 * iqr
-  // const upperFence = q3 + 1.5 * iqr
-
-  // Non-Outlier Values
-  const nonOutliers = sortedValues.filter(value => value >= lowerBound && value <= upperBound)
-  // **Outliers** =
-  const outliers = sortedValues.filter(v => v < lowerBound || v > upperBound)
-  const whiskerMax =
-    sortedValues
-      .slice()
-      .reverse()
-      .find(v => v <= upperBound) ?? thirdQuartile
-  const whiskerMin = nonOutliers.length > 0 ? nonOutliers[0] : firstQuartile
-  // Calculate Box Plot Stats
-  return {
-    min: whiskerMin,
-    max: whiskerMax,
-    median: d3.median(sortedValues),
-    firstQuartile,
-    thirdQuartile,
-    iqr,
-    outliers
-  }
-}
-
 const getValuesBySeriesKey = (group: string, config, data) => {
   const allSeriesKeys = config.series.map(item => item?.dataKey)
   const result = {}
@@ -80,24 +38,6 @@ const getValuesBySeriesKey = (group: string, config, data) => {
   })
 
   return result
-}
-
-// Helper to calculate outliers based on IQR
-const calculateOutliers = (values: number[], firstQuartile: number, thirdQuartile: number) => {
-  const iqr = thirdQuartile - firstQuartile
-  const lowerBound = firstQuartile - 1.5 * iqr
-  const upperBound = thirdQuartile + 1.5 * iqr
-  return values.filter(value => value < lowerBound || value > upperBound)
-}
-
-// Helper to calculate non-outliers based on IQR
-const calculateNonOutliers = (values: number[], firstQuartile: number, thirdQuartile: number): number[] => {
-  const iqr = thirdQuartile - firstQuartile
-  const lowerBound = firstQuartile - 1.5 * iqr
-  const upperBound = thirdQuartile + 1.5 * iqr
-
-  // Return values within the bounds
-  return values.filter(value => value >= lowerBound && value <= upperBound)
 }
 
 // Main function to create plots with additional outlier data
@@ -120,29 +60,18 @@ export const createPlots = (data, config) => {
 
       // Calculate outliers and non-outliers for each series key
       Object.keys(keyValues).forEach(key => {
-        const raw = keyValues[key] ?? []
-
-        // 2) normalize → trim, drop empties/non-numbers, coerce to Number
-        const cleaned: number[] = raw
-          .map(v => (typeof v === 'string' ? v.trim() : v)) // trim strings
-          .filter(v => v != null && v !== '' && !isNaN(+v)) // drop null/''/non-nums
-          .map(v => +v)
-
-        if (cleaned.length === 0) {
-          return
-        }
+        const stats = calculateBoxPlotStats(keyValues[key] ?? [])
+        if (!stats) return
 
         // Calculate box plot statistics
-        const { firstQuartile, thirdQuartile, min, max, median, iqr, outliers } = calculateBoxPlotStats(cleaned)
-        // Calculate outliers and non-outliers
-        columnOutliers[key] = calculateOutliers(cleaned, firstQuartile, thirdQuartile).map(Number)
-        columnNonOutliers[key] = calculateNonOutliers(cleaned, firstQuartile, thirdQuartile).map(Number)
-        columnMedian[key] = median
-        columnMin[key] = Number(min)
-        columnMax[key] = Number(max)
-        columnQ1[key] = firstQuartile
-        columnQ3[key] = thirdQuartile
-        columnIqr[key] = iqr
+        columnOutliers[key] = stats.outliers
+        columnNonOutliers[key] = stats.nonOutliers
+        columnMedian[key] = stats.median ?? null
+        columnMin[key] = stats.whiskerMin
+        columnMax[key] = stats.whiskerMax
+        columnQ1[key] = stats.q1
+        columnQ3[key] = stats.q3
+        columnIqr[key] = stats.iqr
       })
 
       // Add the plot object to the plots array

--- a/packages/chart/src/helpers/boxPlotStats.ts
+++ b/packages/chart/src/helpers/boxPlotStats.ts
@@ -1,0 +1,53 @@
+import * as d3 from 'd3-array'
+import { sortByNumber, toSortableNumber } from '@cdc/core/helpers/sorting'
+
+export type BoxPlotStats = {
+  deviation: number | undefined
+  iqr: number
+  lowerBound: number
+  mean: number | undefined
+  median: number | undefined
+  nonOutliers: number[]
+  outliers: number[]
+  q1: number
+  q3: number
+  upperBound: number
+  values: number[]
+  whiskerMax: number
+  whiskerMin: number
+}
+
+export const getSortedBoxPlotValues = (values: unknown[] = []): number[] => {
+  return sortByNumber(
+    values.filter(value => value !== null && value !== undefined && value !== '').map(toSortableNumber)
+  ).filter(Number.isFinite)
+}
+
+export const calculateBoxPlotStats = (values: unknown[] = []): BoxPlotStats | null => {
+  const sortedValues = getSortedBoxPlotValues(values)
+  if (!sortedValues.length) return null
+
+  const q1 = d3.quantile(sortedValues, 0.25) ?? 0
+  const q3 = d3.quantile(sortedValues, 0.75) ?? 0
+  const iqr = q3 - q1
+  const lowerBound = q1 - 1.5 * iqr
+  const upperBound = q3 + 1.5 * iqr
+  const nonOutliers = sortedValues.filter(value => value >= lowerBound && value <= upperBound)
+  const outliers = sortedValues.filter(value => value < lowerBound || value > upperBound)
+
+  return {
+    deviation: d3.deviation(sortedValues),
+    iqr,
+    lowerBound,
+    mean: d3.mean(sortedValues),
+    median: d3.median(sortedValues),
+    nonOutliers,
+    outliers,
+    q1,
+    q3,
+    upperBound,
+    values: sortedValues,
+    whiskerMax: nonOutliers[nonOutliers.length - 1] ?? q3,
+    whiskerMin: nonOutliers[0] ?? q1
+  }
+}

--- a/packages/chart/src/helpers/getBoxPlotConfig.ts
+++ b/packages/chart/src/helpers/getBoxPlotConfig.ts
@@ -1,12 +1,10 @@
 import capitalize from 'lodash/capitalize'
-import filter from 'lodash/filter'
 import flatMap from 'lodash/flatMap'
 import map from 'lodash/map'
-import min from 'lodash/min'
 import round from 'lodash/round'
 import uniq from 'lodash/uniq'
+import { calculateBoxPlotStats } from './boxPlotStats'
 import { ChartConfig } from '../types/ChartConfig'
-import * as d3 from 'd3-array'
 
 export const getBoxPlotConfig = (newConfig: ChartConfig, data: object[]) => {
   const combinedData = data
@@ -20,35 +18,27 @@ export const getBoxPlotConfig = (newConfig: ChartConfig, data: object[]) => {
         if (!g) throw new Error('No groups resolved in box plots')
 
         const filteredData = combinedData.filter(item => item[newConfig.xAxis.dataKey] === g)
-        const count = filteredData.length
-        const sortedData = map(filteredData, item => Number(item[seriesKey])).sort()
+        const stats = calculateBoxPlotStats(map(filteredData, item => item[seriesKey]))
 
-        if (!sortedData) throw new Error('boxplots dont have data yet')
+        if (!stats) throw new Error('boxplots dont have data yet')
         if (!plots) throw new Error('boxplots dont have plots yet')
 
-        const q1 = d3.quantile(sortedData, 0.25)
-        const q3 = d3.quantile(sortedData, 0.75)
-
-        const iqr = q3 - q1
-        const lowerBounds = q1 - 1.5 * iqr
-        const upperBounds = q3 + 1.5 * iqr
-        const nonOutliers = sortedData.filter(value => value >= lowerBounds && value <= upperBounds)
         plots.push({
           columnCategory: g,
-          columnMax: d3.max(nonOutliers),
-          columnThirdQuartile: round(q3, newConfig.dataFormat.roundTo),
-          columnMedian: Number(d3.median(sortedData)).toFixed(newConfig.dataFormat.roundTo),
-          columnFirstQuartile: round(q1, newConfig.dataFormat.roundTo),
-          columnMin: min(nonOutliers),
-          columnCount: count,
-          columnSd: Number(d3.deviation(sortedData)).toFixed(newConfig.dataFormat.roundTo),
-          columnMean: Number(d3.mean(sortedData)).toFixed(newConfig.dataFormat.roundTo),
-          columnIqr: round(iqr, newConfig.dataFormat.roundTo),
-          values: sortedData,
-          columnLowerBounds: lowerBounds,
-          columnUpperBounds: upperBounds,
-          columnOutliers: filter(sortedData, value => value < lowerBounds || value > upperBounds),
-          columnNonOutliers: filter(sortedData, value => value >= lowerBounds && value <= upperBounds)
+          columnMax: stats.whiskerMax,
+          columnThirdQuartile: round(stats.q3, newConfig.dataFormat.roundTo),
+          columnMedian: Number(stats.median).toFixed(newConfig.dataFormat.roundTo),
+          columnFirstQuartile: round(stats.q1, newConfig.dataFormat.roundTo),
+          columnMin: stats.whiskerMin,
+          columnCount: stats.values.length,
+          columnSd: Number(stats.deviation).toFixed(newConfig.dataFormat.roundTo),
+          columnMean: Number(stats.mean).toFixed(newConfig.dataFormat.roundTo),
+          columnIqr: round(stats.iqr, newConfig.dataFormat.roundTo),
+          values: stats.values,
+          columnLowerBounds: stats.lowerBound,
+          columnUpperBounds: stats.upperBound,
+          columnOutliers: stats.outliers,
+          columnNonOutliers: stats.nonOutliers
         })
       } catch (e) {
         console.error('COVE: ', e.message) // eslint-disable-line

--- a/packages/chart/src/helpers/tests/boxPlotStats.test.ts
+++ b/packages/chart/src/helpers/tests/boxPlotStats.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateBoxPlotStats, getSortedBoxPlotValues } from '../boxPlotStats'
+
+describe('boxPlotStats', () => {
+  it('normalizes numeric strings once for all box plot stats consumers', () => {
+    expect(getSortedBoxPlotValues(['1,000', '20', '', null, undefined, 'n/a', '3'])).toEqual([3, 20, 1000])
+  })
+
+  it('calculates quartiles, fences, whiskers, and outliers from sorted numeric values', () => {
+    const stats = calculateBoxPlotStats(['10', '20', '30', '40', '1,000'])
+
+    expect(stats).toMatchObject({
+      values: [10, 20, 30, 40, 1000],
+      q1: 20,
+      q3: 40,
+      median: 30,
+      iqr: 20,
+      lowerBound: -10,
+      upperBound: 70,
+      nonOutliers: [10, 20, 30, 40],
+      outliers: [1000],
+      whiskerMin: 10,
+      whiskerMax: 40
+    })
+  })
+
+  it('returns null when no finite values can be calculated', () => {
+    expect(calculateBoxPlotStats(['', null, undefined, 'n/a'])).toBeNull()
+  })
+})


### PR DESCRIPTION
This pull request introduces a standardized and robust approach for calculating box plot statistics in the chart package. It centralizes and unifies the logic for computing quartiles, outliers, whiskers, and related values, ensuring consistent results across both the data processing and rendering layers. The update also adds a regression Storybook story and comprehensive tests to prevent future parity issues between metadata and visualization.

**Box Plot Statistics Refactor and Standardization**

*Refactoring and Core Logic Changes:*
- Introduced a new `calculateBoxPlotStats` helper in `boxPlotStats.ts`, which normalizes numeric values, calculates quartiles, IQR, whiskers, outliers, and other stats, and is now used throughout the codebase for box plot calculations. This ensures all consumers use the same logic and normalization pipeline. [[1]](diffhunk://#diff-80b429f6b35ef4d1988fd583b70bc3e781618fb062c9eefb827115d1029438fbR1-R53) [[2]](diffhunk://#diff-335e288cfd8157a36314344837db321edb4bcd584a281e3af1d4fffc5c7578b8L1-R2) [[3]](diffhunk://#diff-cbb6961a9dbb27bd756eeaa5f652c3afdcf168019a1a2fb62e4eecb402b2a74aL2-L9)
- Updated both `getBoxPlotConfig` and the BoxPlot renderer (`createPlots`) to use the new stats helper, removing duplicate and inconsistent stats calculations. [[1]](diffhunk://#diff-cbb6961a9dbb27bd756eeaa5f652c3afdcf168019a1a2fb62e4eecb402b2a74aL23-R41) [[2]](diffhunk://#diff-335e288cfd8157a36314344837db321edb4bcd584a281e3af1d4fffc5c7578b8L33-L73) [[3]](diffhunk://#diff-335e288cfd8157a36314344837db321edb4bcd584a281e3af1d4fffc5c7578b8L123-R74)

*Testing and Verification:*
- Added a dedicated test suite for box plot statistics (`boxPlotStats.test.ts`) to verify normalization, stats calculation, and edge cases.
- Added a regression Storybook story (`Chart.BoxPlotStatsParity.stories.tsx`) that asserts parity between metadata and rendered box plot stats, preventing future regressions.

*Documentation and Developer Workflow:*
- Updated the algorithm improvement skill guide to require Storybook stories as reviewable reproductions for UI-visible algorithm changes, ensuring issues are demonstrated before fixes are implemented.